### PR TITLE
linux-yocto-onl/5.10: update to 5.10.60

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.10.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.10.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.10.56"
+LINUX_VERSION ?= "5.10.60"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
-SRCREV_machine ?= "9746c25334cb364ab6651ee6dfd4cab3218d0c06"
-SRCREV_meta ?= "21354be869b17a8fedf281b16019a58abeb13449"
+SRCREV_machine ?= "2c5bd949b1df3f9fb109107b3d766e2ebabd7238"
+SRCREV_meta ?= "e44a7f9801f8fc6b670bf121038d912257a83d7e"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 5.10.60, bringing memory leak fixes, networking
fixes and various other smaller fixes.

In absence of kver bump to 5.10.60 update meta to latest HEAD.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>