### PR TITLE
drop warrior support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "open-network-linux"
 BBFILE_PATTERN_open-network-linux = "^${LAYERDIR}/"
 BBFILE_PRIORITY_open-network-linux = "6"
 
-LAYERSERIES_COMPAT_open-network-linux = "warrior dunfell"
+LAYERSERIES_COMPAT_open-network-linux = "dunfell"

--- a/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,4 +1,0 @@
-# platform-as4610 provides the config, so do not ship one
-do_install_append_accton-as4610() {
-	rm ${D}${sysconfdir}/fw_env.config
-}


### PR DESCRIPTION
Warrior is old, and now untested for quite a while, so let's drop
compatibility with it.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>