### PR TITLE
linux-yocto-onl/5.10: update to 5.10.70

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.10.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.10.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.10.60"
+LINUX_VERSION ?= "5.10.70"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
-SRCREV_machine ?= "2c5bd949b1df3f9fb109107b3d766e2ebabd7238"
-SRCREV_meta ?= "e44a7f9801f8fc6b670bf121038d912257a83d7e"
+SRCREV_machine ?= "f93026b28e2afe5060a493b0bbcee19d12961b7e"
+SRCREV_meta ?= "917c420111475e33a26f46a9a2855b973ffffadb"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=kernel-meta \


### PR DESCRIPTION
Update Linux 5.10 to it's newest release, 5.10.70.

In absence of a 5.10.70 bump yet in meta, bump to HEAD, which has a kver
bump to 5.10.69.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>