### PR TITLE
linux-yocto-onl/5.10: update to 5.10.75

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.10.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.10.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.10.70"
+LINUX_VERSION ?= "5.10.75"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
-SRCREV_machine ?= "f93026b28e2afe5060a493b0bbcee19d12961b7e"
-SRCREV_meta ?= "917c420111475e33a26f46a9a2855b973ffffadb"
+SRCREV_machine ?= "3a9842b42e421f6496a78a42a123639cf6d7ed31"
+SRCREV_meta ?= "d946f3fc08705ad3c8051fdf2869e9f8696e9747"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=kernel-meta \


### PR DESCRIPTION
Update Linux 5.10 to it's newest release, 5.10.75.

In absence of a 5.10.75 bump yet in meta, bump to HEAD.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>