### PR TITLE
linux-yocto-onl/5.10: update to 5.10.78

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/brcm-iproc-5.10.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/brcm-iproc-5.10.patch
@@ -19340,7 +19340,7 @@ index 35525a671400..8a3f481e23ba 100644
  
  	mutex_lock(&phydev->lock);
  
-@@ -1195,8 +1203,29 @@ void phy_state_machine(struct work_struct *work)
+@@ -1195,8 +1203,30 @@ void phy_state_machine(struct work_struct *work)
  	 * called from phy_disconnect() synchronously.
  	 */
  	mutex_lock(&phydev->lock);
@@ -19358,6 +19358,7 @@ index 35525a671400..8a3f481e23ba 100644
 +			schedule_cnt[phydev->mdio.addr] += 1;
 +			if (schedule_cnt[phydev->mdio.addr] > 5) {
 +				schedule_cnt[phydev->mdio.addr] = 0;
++				mutex_unlock(&phydev->lock);
 +				return;
 +			}
 +			phy_queue_state_machine(phydev, PHY_STATE_TIME);

--- a/recipes-kernel/linux/linux-yocto-onl_5.10.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.10.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.10.75"
+LINUX_VERSION ?= "5.10.78"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.10.y
-SRCREV_machine ?= "3a9842b42e421f6496a78a42a123639cf6d7ed31"
-SRCREV_meta ?= "d946f3fc08705ad3c8051fdf2869e9f8696e9747"
+SRCREV_machine ?= "5040520482a594e92d4f69141229a6dd26173511"
+SRCREV_meta ?= "a0238f7f4f2222d08bb18147bb5e24cc877b0546"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.10;destsuffix=kernel-meta \


### PR DESCRIPTION
Update to 5.10 to the newest release, 5.10.78, and update kernel-meta
accordingly.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>