### PR TITLE
armel-iproc: use upstream usb quirk implementation

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/10-02-arm-add-iproc-xgs.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/10-02-arm-add-iproc-xgs.patch
@@ -900,7 +900,7 @@ index 000000000000..35cd1896a318
 +};
 diff --git a/arch/arm/boot/dts/bcm-helix4.dtsi b/arch/arm/boot/dts/bcm-helix4.dtsi
 new file mode 100644
-index 000000000000..ee347c923744
+index 000000000000..66a4703ed4a7
 --- /dev/null
 +++ b/arch/arm/boot/dts/bcm-helix4.dtsi
 @@ -0,0 +1,483 @@
@@ -1167,7 +1167,7 @@ index 000000000000..ee347c923744
 +		};
 +
 +		ehci0: usb@1802a000 {
-+			compatible = "generic-ehci";
++			compatible = "brcm,xgs-iproc-ehci", "generic-ehci";
 +			reg = <0x1802a000 0x1000>;
 +			interrupts = <GIC_SPI 85 IRQ_TYPE_LEVEL_HIGH>;
 +			usb-phy = <&usbphy0>;

--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/10-17-usb-iproc-xgs-hack.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.10.y/bisdn-kmeta/bsp/armel-iproc/10-17-usb-iproc-xgs-hack.patch
@@ -31,7 +31,7 @@ index ab12c4bf0ef1..df4722b58415 100644
  	bool "Octeon on-chip OHCI support (DEPRECATED)"
  	depends on CAVIUM_OCTEON_SOC
 diff --git a/drivers/usb/host/ehci-platform.c b/drivers/usb/host/ehci-platform.c
-index a48dd3fac153..4f9db44b64a3 100644
+index a48dd3fac153..59b50b4af7d4 100644
 --- a/drivers/usb/host/ehci-platform.c
 +++ b/drivers/usb/host/ehci-platform.c
 @@ -45,6 +45,11 @@
@@ -71,7 +71,7 @@ index a48dd3fac153..4f9db44b64a3 100644
  	/*
  	 * Use reasonable defaults so platforms don't have to provide these
  	 * with DT probing on ARM.
-@@ -360,12 +379,20 @@ static int ehci_platform_probe(struct platform_device *dev)
+@@ -360,6 +379,9 @@ static int ehci_platform_probe(struct platform_device *dev)
  	hcd->rsrc_start = res_mem->start;
  	hcd->rsrc_len = resource_size(res_mem);
  
@@ -81,17 +81,6 @@ index a48dd3fac153..4f9db44b64a3 100644
  	err = usb_add_hcd(hcd, irq, IRQF_SHARED);
  	if (err)
  		goto err_power;
- 
- 	device_wakeup_enable(hcd->self.controller);
- 	device_enable_async_suspend(hcd->self.controller);
-+
-+#if CONFIG_USB_EHCI_XGS_IPROC
-+	ehci_writel(ehci, BCM_USB_FIFO_THRESHOLD,
-+			&ehci->regs->reserved4[6]);
-+#endif
- 	platform_set_drvdata(dev, hcd);
- 
- 	if (priv->quirk_poll)
 diff --git a/drivers/usb/host/ohci-platform.c b/drivers/usb/host/ohci-platform.c
 index 4a8456f12a73..6d33279e0271 100644
 --- a/drivers/usb/host/ohci-platform.c


### PR DESCRIPTION
Handling of this usb quirk was added to the kernel with https://github.com/torvalds/linux/commit/dfee57a8a6655f3b87fc34c3c07a8b05fd2aae29, so
activate it by adding the appropriate compatible string and drop the
broadcom variant.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>