### PR TITLE
linux-yocto-onl/5.15: update to 5.15.6

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.3"
+LINUX_VERSION ?= "5.15.6"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "3b17187f5ca1f5d0c641fdc90a6a7e38afdf8fae"
-SRCREV_meta ?= "bee5d6a15909f05935f4a61f83a72cddfca7934a"
+SRCREV_machine ?= "a2547651bc896f95a3680a6a0a27401e7c7a1080"
+SRCREV_meta ?= "df57bc53f6ca3fb3b2d3a9e5331ceff533d6f508"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update to latest and gratest, with plenty of fixes.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>