### PR TITLE
accon-as4630-54pe: add PoE support

### DIFF
--- a/conf/machine/accton-as4630-54pe.conf
+++ b/conf/machine/accton-as4630-54pe.conf
@@ -40,6 +40,7 @@ GLIBC_ADDONS = "nptl"
 MACHINE_EXTRA_RDEPENDS += " \
     accton-as4630-54pe-cpld-mod \
     accton-as4630-54pe-leds-mod \
+    accton-as4630-54pe-poe-mcu-mod \
     accton-as4630-54pe-psu-mod \
     optoe-mod \
     ym2651y-mod \

--- a/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
+++ b/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
@@ -47,3 +47,6 @@ done
 
 # add EEPROM
 create_i2c_dev 24c02 0x57 1
+
+# add PoE MCU
+create_i2c_dev as4630_54pe_poe_mcu 0x20 16

--- a/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
@@ -1,0 +1,27 @@
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
+
+inherit module
+
+SRC_URI = " \
+	  file://Makefile \
+	  file://accton_as4630_54pe_poe_mcu.c \
+	  file://COPYING \
+	  file://poectl \
+          "
+
+S = "${WORKDIR}"
+
+KERNEL_MODULE_AUTOLOAD += "accton_as4630_54pe_poe_mcu"
+
+EXTRA_OEMAKE += " KBUILD_MODPOST_WARN=1"
+
+FILES_${PN} += "${sbindir}/poectl"
+
+do_install_append() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/poectl ${D}${sbindir}
+}
+
+# The inherit of module.bbclass will automatically name module packages with
+# "kernel-module-" prefix as required by the oe-core build environment.

--- a/recipes-kernel/accton-as4630-poe-mcu/files/COPYING
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/COPYING
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/recipes-kernel/accton-as4630-poe-mcu/files/Makefile
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/Makefile
@@ -1,0 +1,19 @@
+#KERNELS := onl-kernel-3.16-lts-x86-64-all:amd64
+#KMODULES := $(wildcard *.c)
+#VENDOR := delta
+#BASENAME := x86-64-delta-ag9032v1
+#ARCH := x86_64
+#include $(ONL)/make/kmodule.mk
+
+obj-m := accton_as4630_54pe_poe_mcu.o
+
+SRC := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC)
+
+modules_install:
+	$(MAKE) -C $(KERNEL_SRC) M=$(SRC) modules_install
+
+clean:
+	rm -f *.o *~ core .depend .*.cmd *.ko *.mod.c

--- a/recipes-kernel/accton-as4630-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -1,0 +1,516 @@
+/*
+ * AS4630 PoE MCU driver
+ *
+ * Copyright (C) 2021 BISDN GmbH
+ * Jonas Gorski <jonas.gorski@bisdn.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/i2c.h>
+#include <linux/fs.h>
+#include <linux/of.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/debugfs.h>
+
+#include <asm/unaligned.h>
+
+/* TODO: replace these with regmap or something more sane */
+extern int as4630_54pe_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int as4630_54pe_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+
+#define AS4630_CPLD_ADDRESS		0x60
+
+#define AS4630_CPLD_POE_CONTROL_REG	0x18
+#define  POE_CONTROL_EN			BIT(0)
+#define  POE_RESET_MCU			BIT(1)
+#define  POE_POWER_BANK_MASK		0x1c
+#define   POE_POWER_1PSU		0x0
+#define   POE_POWER_2PSU		0x2
+
+#define COUNTER_AUTO			-1
+
+#define MCU_OP_PSE_EN			0x00
+#define MCU_OP_PSE_MAP			0x02
+#define MCU_OP_PSE_MAP_RESET		0x03
+#define MCU_OP_PSE_RESET		0x09
+#define MCU_OP_PSE_SETUP_PORT		0x0e
+#define MCU_OP_PSE_PORT_DETECT_TYPE	0x10
+#define MCU_OP_PSE_PORT_DISCONNECT	0x13
+#define MCU_OP_PSE_PORT_POWERUP_MODE	0x1c
+#define MCU_OP_PSE_PORT_POWERUP_MANAGE	0x17
+#define MCU_OP_PSE_SET_GUARDBAND	0x18
+#define MCU_OP_PSE_STATUS		0x20
+#define MCU_OP_PSE_PORT_STATUS		0x21
+#define MCU_OP_PSE_PORT_EXT_CONFIG	0x26
+#define MCU_OP_PSE_PORT_MEASUREMENT	0x30
+
+/* Disable PoE by default for now, 4-Pair ports do not work reliably */
+#define PSE_EN_DEFAULT			0
+
+#define PSE_4P_PWR_UP_MODE		0
+#define PSE_4P_DETECT_MODE		0
+#define PSE_4P_PWR_UP_MODE_CL4		1
+
+/* UART message format */
+struct pse_msg {
+	u8 opcode;
+	u8 counter;
+	u8 data[9];
+	u8 csum;
+} __packed;
+
+struct as4630_poe_pse;
+
+#define MCU_CHAN_INVALID	0xffu
+
+struct as4630_poe_port {
+	struct as4630_poe_pse *parent;
+
+	u8 port_num;
+	u8 device;
+	u8 pri_chan;
+	u8 alt_chan;
+
+	bool pse_en;
+
+	bool fourp_en;
+	u8 fourp_powerup;
+	u8 fourp_detection;
+	u8 fourp_mode;
+};
+
+struct as4630_poe_pse {
+	struct i2c_client *client;
+	struct dentry *debugfs;
+
+	struct mutex mutex;
+
+	u8 tx_counter;
+
+	int num_ports;
+
+	struct as4630_poe_port *ports;
+};
+
+static int as4630_poe_pse_csum(const void *data)
+{
+	const u8 *tmp = data;
+	int i;
+	u8 csum = 0;
+
+	for (i = 0; i < sizeof(struct pse_msg) - 1; i++)
+		csum += *tmp++;
+
+	return csum;
+}
+
+static int as4630_poe_pse_send(struct as4630_poe_pse *pse, struct pse_msg *cmd,
+			       struct pse_msg *resp, int counter)
+{
+	struct i2c_client *client = pse->client;
+	int csum, ret = 0;
+	struct pse_msg tmp;
+
+	if (counter >= 0) {
+		cmd->counter = counter;
+	} else {
+		cmd->counter = pse->tx_counter++;
+		if (pse->tx_counter == 0xfe)
+			pse->tx_counter = 0x01;
+	}
+
+	cmd->csum = as4630_poe_pse_csum(cmd);
+
+	dev_dbg(&client->dev, "sending message: op=%02x cnt=%02x data=%*ph\n",
+		cmd->opcode, cmd->counter, sizeof(cmd->data), cmd->data);
+
+	ret = i2c_smbus_write_i2c_block_data(client, cmd->opcode,
+					     sizeof(*cmd) - 1, &cmd->counter);
+	if (ret < 0) {
+		dev_info(&client->dev, "failed writing message: %i\n", ret);
+		goto out;
+	}
+
+	msleep(40);
+
+	ret = i2c_smbus_read_i2c_block_data(client, 0, sizeof(tmp),
+					    (u8* )&tmp);
+	if (ret < 0) {
+		/* MCU_OP_PSE_RESET may not yield a response */
+		if (cmd->opcode != MCU_OP_PSE_RESET) {
+			dev_err(&pse->client->dev, "time out while waiting for response\n");
+			ret = -ETIMEDOUT;
+		}
+		goto out;
+	}
+
+	dev_dbg(&client->dev, "received message: op=%02x cnt=%02x data=%*ph [csum=%02x %s]\n",
+		tmp.opcode, tmp.counter, sizeof(tmp.data), tmp.data, tmp.csum,
+		tmp.csum == as4630_poe_pse_csum(&tmp) ? "ok" : "ng");
+
+	if (tmp.csum != as4630_poe_pse_csum(&tmp))
+		ret = -EIO;
+
+	if (resp)
+		memcpy(resp, &tmp, sizeof(tmp));
+out:
+	return ret < 0 ? ret : 0;
+}
+
+static int as4630_poe_pse_enable(struct as4630_poe_pse *pse,
+				 struct as4630_poe_port *port, bool enable)
+{
+	struct pse_msg cmd;
+	int ret;
+
+	memset(cmd.data, 0xff, sizeof(cmd.data));
+
+	cmd.opcode = MCU_OP_PSE_EN;
+	cmd.data[0] = port->port_num;
+	cmd.data[1] = enable;
+
+	mutex_lock(&pse->mutex);
+	ret = as4630_poe_pse_send(pse, &cmd, NULL, COUNTER_AUTO);
+	mutex_unlock(&pse->mutex);
+
+	if (!ret)
+		port->pse_en = enable;
+	return ret;
+}
+
+static int as4630_poe_pse_init_ports(struct as4630_poe_pse *pse,
+				     int p1, int p2, int p3, int p4)
+{
+	struct pse_msg cmd;
+
+	cmd.opcode = MCU_OP_PSE_EN;
+	cmd.data[0] = p1;
+	cmd.data[1] = PSE_EN_DEFAULT;
+	cmd.data[2] = p2;
+	cmd.data[3] = PSE_EN_DEFAULT;
+	cmd.data[4] = p3;
+	cmd.data[5] = PSE_EN_DEFAULT;
+	cmd.data[6] = p4;
+	cmd.data[7] = PSE_EN_DEFAULT;
+	cmd.data[8] = 0xff;
+
+	return as4630_poe_pse_send(pse, &cmd, NULL, COUNTER_AUTO);
+}
+
+static int as4630_poe_pse_init(struct as4630_poe_pse *pse)
+{
+	int i, ret = 0, reg;
+
+	reg = as4630_54pe_cpld_read(AS4630_CPLD_ADDRESS,
+				    AS4630_CPLD_POE_CONTROL_REG);
+	if (reg < 0)
+		return reg;
+
+	mutex_lock(&pse->mutex);
+
+	for (i = 0; i < pse->num_ports; i += 4) {
+		struct as4630_poe_port *p1, *p2, *p3, *p4;
+
+		p1 = &pse->ports[i];
+		p2 = &pse->ports[i + 1];
+		p3 = &pse->ports[i + 2];
+		p4 = &pse->ports[i + 3];
+
+		p1->parent = pse;
+		p2->parent = pse;
+		p3->parent = pse;
+		p4->parent = pse;
+
+		p1->port_num = i;
+		p2->port_num = i + 1;
+		p3->port_num = i + 2;
+		p4->port_num = i + 3;
+
+		p1->pse_en = PSE_EN_DEFAULT;
+		p2->pse_en = PSE_EN_DEFAULT;
+		p3->pse_en = PSE_EN_DEFAULT;
+		p4->pse_en = PSE_EN_DEFAULT;
+
+		ret = as4630_poe_pse_init_ports(pse, p1->port_num, p2->port_num,
+						p3->port_num, p4->port_num);
+		if (ret)
+			goto out;
+	}
+out:
+	mutex_unlock(&pse->mutex);
+
+	/* enable power to ports */
+	if (!ret)
+		as4630_54pe_cpld_write(AS4630_CPLD_ADDRESS,
+				       AS4630_CPLD_POE_CONTROL_REG,
+				       reg | POE_CONTROL_EN);
+	return ret;
+}
+
+static ssize_t read_file_port_enable(struct file *file, char __user *user_buf,
+				     size_t count, loff_t *ppos)
+{
+	struct as4630_poe_port *port = file->private_data;
+	unsigned int len;
+	char buf[32];
+
+	len = sprintf(buf, "%d\n", port->pse_en);
+
+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
+}
+
+static ssize_t write_file_port_enable(struct file *file, const char __user *user_buf,
+				      size_t count, loff_t *ppos)
+{
+	struct as4630_poe_port *port = file->private_data;
+	unsigned long enable;
+	unsigned int len;
+	char buf[32];
+
+	len = min(count, sizeof(buf) - 1);
+	if (copy_from_user(buf, user_buf, len))
+		return -EFAULT;
+
+	buf[len] = '\0';
+	if (kstrtoul(buf, 0, &enable))
+		return -EINVAL;
+
+	if (enable != 0 && enable != 1)
+		return -EINVAL;
+
+	if (port->pse_en != enable)
+		as4630_poe_pse_enable(port->parent, port, enable);
+
+	return count;
+}
+
+static const struct file_operations pse_en_ops = {
+	.read = read_file_port_enable,
+	.write = write_file_port_enable,
+	.open = simple_open,
+	.owner = THIS_MODULE,
+	.llseek = default_llseek,
+};
+
+static ssize_t read_file_port_status(struct file *file, char __user *user_buf,
+				     size_t count, loff_t *ppos)
+{
+	struct as4630_poe_port *port = file->private_data;
+	struct as4630_poe_pse *pse = port->parent;
+	struct pse_msg cmd, resp;
+	unsigned int len;
+	char buf[32];
+	int ret;
+
+	mutex_lock(&pse->mutex);
+	memset(cmd.data, 0xff, sizeof(cmd.data));
+	cmd.opcode = MCU_OP_PSE_PORT_STATUS;
+	cmd.data[0] = port->port_num;
+
+	ret = as4630_poe_pse_send(pse, &cmd, &resp, COUNTER_AUTO);
+	mutex_unlock(&pse->mutex);
+	if (ret)
+		return ret;
+
+	len = sprintf(buf, "%*ph\n", sizeof(resp.data), resp.data);
+
+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
+}
+
+static const struct file_operations pse_port_status_ops = {
+	.read = read_file_port_status,
+	.open = simple_open,
+	.owner = THIS_MODULE,
+	.llseek = default_llseek,
+};
+
+static ssize_t read_file_port_measurement(struct file *file, char __user *user_buf,
+				          size_t count, loff_t *ppos)
+{
+	struct as4630_poe_port *port = file->private_data;
+	struct as4630_poe_pse *pse = port->parent;
+	struct pse_msg cmd, resp;
+	char buf[64];
+	unsigned int len;
+	int ret, voltage, curr, temp, power;
+
+	mutex_lock(&pse->mutex);
+	memset(cmd.data, 0xff, sizeof(cmd.data));
+	cmd.opcode = MCU_OP_PSE_PORT_MEASUREMENT;
+	cmd.data[0] = port->port_num;
+
+	ret = as4630_poe_pse_send(pse, &cmd, &resp, COUNTER_AUTO);
+	mutex_unlock(&pse->mutex);
+	if (ret)
+		return ret;
+
+	voltage = DIV_ROUND_CLOSEST(get_unaligned_be16(&resp.data[1]) * 6445, 1000);
+	curr = get_unaligned_be16(&resp.data[3]);
+	temp = ((get_unaligned_be16(&resp.data[5]) - 120) * -125) + 12500;
+	power = get_unaligned_be16(&resp.data[7]);
+
+	len = sprintf(buf, "%i.%02iV\n%i.%03iA\n%i.%02iC\n%i.%01iW\n",
+		      voltage / 100, voltage % 100,
+		      curr / 1000, curr % 1000,
+		      temp / 100, temp % 100,
+		      power / 10, power % 10);
+
+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
+}
+
+static const struct file_operations pse_measurement_ops = {
+	.read = read_file_port_measurement,
+	.open = simple_open,
+	.owner = THIS_MODULE,
+	.llseek = default_llseek,
+};
+
+static ssize_t read_file_status(struct file *file, char __user *user_buf,
+				size_t count, loff_t *ppos)
+{
+	struct as4630_poe_pse *pse = file->private_data;
+	struct pse_msg cmd, resp;
+	unsigned int len;
+	char buf[32];
+	int ret;
+
+	mutex_lock(&pse->mutex);
+	memset(cmd.data, 0xff, sizeof(cmd.data));
+	cmd.opcode = MCU_OP_PSE_STATUS;
+
+	ret = as4630_poe_pse_send(pse, &cmd, &resp, COUNTER_AUTO);
+	mutex_unlock(&pse->mutex);
+	if (ret)
+		return ret;
+
+	len = sprintf(buf, "%*ph\n", sizeof(resp.data), resp.data);
+
+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
+}
+
+static const struct file_operations pse_status_ops = {
+	.read = read_file_status,
+	.open = simple_open,
+	.owner = THIS_MODULE,
+	.llseek = default_llseek,
+};
+
+static void as4630_poe_pse_debugfs_create(struct as4630_poe_pse *pse)
+{
+	int i;
+
+	pse->debugfs = debugfs_create_dir(dev_name(&pse->client->dev), NULL);
+	debugfs_create_file("status", 0200, pse->debugfs, pse, &pse_status_ops);
+
+	for (i = 0; i < pse->num_ports; i++) {
+		struct dentry *portdir;
+		char dirname[16];
+
+		sprintf(dirname, "port%d", i);
+
+		portdir = debugfs_create_dir(dirname, pse->debugfs);
+
+		if (!portdir)
+			return;
+
+		debugfs_create_file("enable", 0600, portdir, &pse->ports[i], &pse_en_ops);
+		debugfs_create_file("status", 0200, portdir, &pse->ports[i], &pse_port_status_ops);
+		debugfs_create_file("measurement", 0200, portdir, &pse->ports[i], &pse_measurement_ops);
+	}
+}
+
+static int as4630_poe_pse_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
+{
+	int num_ports = 0, ret, reg, psu_rating;
+	struct as4630_poe_pse *pse;
+	struct pse_msg cmd, resp;
+
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK))
+		return -EIO;
+
+	pse = devm_kzalloc(&client->dev, sizeof(*pse), GFP_KERNEL);
+	if (!pse)
+		return -ENOMEM;
+
+	i2c_set_clientdata(client, pse);
+	mutex_init(&pse->mutex);
+
+	pse->client = client;
+	pse->tx_counter = 1;
+
+	memset(cmd.data, 0xff, sizeof(cmd.data));
+	cmd.opcode = MCU_OP_PSE_STATUS;
+	ret = as4630_poe_pse_send(pse, &cmd, &resp, 0);
+	if (ret)
+		return ret;
+
+	pse->num_ports = resp.data[1];
+	dev_info(&client->dev, "Found %i port PoE PSE\n", pse->num_ports);
+
+	pse->ports = devm_kcalloc(&client->dev, sizeof(pse->ports[0]), pse->num_ports, GFP_KERNEL);
+	if (!pse->ports)
+		return -ENOMEM;
+
+	as4630_poe_pse_init(pse);
+
+	as4630_poe_pse_debugfs_create(pse);
+
+	return 0;
+}
+
+static int as4630_poe_pse_remove(struct i2c_client *client)
+{
+	struct as4630_poe_pse *pse = i2c_get_clientdata(client);
+	int reg;
+
+	debugfs_remove_recursive(pse->debugfs);
+
+	/* disable power to ports */
+	reg = as4630_54pe_cpld_read(AS4630_CPLD_ADDRESS,
+				    AS4630_CPLD_POE_CONTROL_REG);
+	if (reg >= 0)
+		as4630_54pe_cpld_write(AS4630_CPLD_ADDRESS,
+				       AS4630_CPLD_POE_CONTROL_REG,
+				       reg & ~POE_CONTROL_EN);
+	else
+		dev_warn(&client->dev, "failed to access CPLD: %i\n", reg);
+
+	return 0;
+}
+
+static const struct i2c_device_id as4630_54pe_poe_pse_id[] = {
+    { "as4630_54pe_poe_mcu" },
+    { },
+};
+MODULE_DEVICE_TABLE(i2c, as4630_54pe_poe_pse_id);
+
+static struct i2c_driver as4630_poe_pse_driver = {
+	.probe = as4630_poe_pse_probe,
+	.remove = as4630_poe_pse_remove,
+	.id_table = as4630_54pe_poe_pse_id,
+	.driver = {
+		.name = "as4630_54pe_poe_mcu",
+		.owner = THIS_MODULE,
+	},
+};
+module_i2c_driver(as4630_poe_pse_driver);
+
+MODULE_AUTHOR("Jonas Gorski <jonas.gorski@bisdn.de>");
+MODULE_DESCRIPTION("AS4630 PoE PSE MCU driver");
+MODULE_LICENSE("GPL");

--- a/recipes-kernel/accton-as4630-poe-mcu/files/poectl
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/poectl
@@ -1,0 +1,230 @@
+#!/bin/bash
+#
+# poectl for enable, disable, status and measurements of PoE ports
+# 
+# Usage:  poectl [OPTIONS] PORT | all
+# 
+# OPTIONS:
+#  -h   help
+#  -v   version
+#  -e   enable PoE
+#  -d   disable PoE
+#  -s   PoE status
+#  -mV  PoE voltage
+#  -mC  PoE current
+#  -mT  PoE temperature
+#  -mP  PoE power
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root" >&2
+   exit 1
+fi
+
+systempath=/sys/kernel/debug/i2c-16-0020
+readonly systempath
+
+if ! [ -d "$systempath" ]; then
+    echo "This platform does not support PoE" >&2
+    exit 1
+fi
+
+portmax=$((16#$(cat $systempath/status | cut -c4,5)))
+readonly portmax
+port=$2
+result=0
+version="1.0"
+
+#  Mapping basebox naming to system
+
+function mapping()
+{
+	case "$port" in
+		port1) sysport="port0";;
+		port2) sysport="port1";;
+		port3) sysport="port2";;
+		port4) sysport="port3";;
+		port5) sysport="port4";;
+		port6) sysport="port5";;
+		port7) sysport="port6";;
+		port8) sysport="port7";;
+		port9) sysport="port8";;
+		port10) sysport="port9";;
+		port11) sysport="port10";;
+		port12) sysport="port11";;
+		port13) sysport="port12";;
+		port14) sysport="port13";;
+		port15) sysport="port14";;
+		port16) sysport="port15";;
+		port17) sysport="port16";;
+		port18) sysport="port17";;
+		port19) sysport="port18";;
+		port20) sysport="port19";;
+		port21) sysport="port20";;
+		port22) sysport="port21";;
+		port23) sysport="port22";;
+		port24) sysport="port23";;
+		port25) sysport="port24";;
+		port26) sysport="port25";;
+		port27) sysport="port26";;
+		port28) sysport="port27";;
+		port29) sysport="port28";;
+		port30) sysport="port29";;
+		port31) sysport="port30";;
+		port32) sysport="port31";;
+		port33) sysport="port32";;
+		port34) sysport="port33";;
+		port35) sysport="port34";;
+		port36) sysport="port35";;
+		port37) sysport="port36";;
+		port38) sysport="port37";;
+		port39) sysport="port38";;
+		port40) sysport="port39";;
+		port41) sysport="port40";;
+		port42) sysport="port41";;
+		port43) sysport="port42";;
+		port44) sysport="port43";;
+		port45) sysport="port44";;
+		port46) sysport="port45";;
+		port47) sysport="port46";;
+		port48) sysport="port47";;
+		   all) sysport="all";;
+		     *) echo "Wrong port number!" >&2
+		        exit 1;; 
+	esac
+} 
+
+function enable()
+{
+	echo 1 > $systempath/$sysport"/enable"
+}
+
+function disable()
+{
+	echo 0 > $systempath/$sysport"/enable"
+}
+
+function status()
+{
+	echo -n "PoE status "$port": "
+	result=$(cat $systempath/$sysport/enable)
+	case "$result" in
+		0) echo "disabled";;
+		1) echo "enabled";;
+	esac  
+}
+
+function measureV()
+{
+        echo -n "PoE voltage status "$port": "
+        echo $(cat $systempath/$sysport/measurement|grep V)
+}
+function measureC()
+{
+        echo -n "PoE current status "$port": "
+        echo $(cat $systempath/$sysport/measurement|grep A)
+}
+
+function measureT()
+{
+        echo -n "PoE temperature status "$port": "
+        echo $(cat $systempath/$sysport/measurement|grep C)
+}
+
+function measureP()
+{
+        echo -n "PoE power status "$port": "
+        echo $(cat $systempath/$sysport/measurement|grep W)
+}
+
+function usage()
+{
+	    echo  "poectl for enabling, disabling, status and measurement reports of PoE ports"
+            echo  " "                                                                          
+            echo  "Usage:  poectl [OPTIONS] PORT | all"                                        
+            echo  " "                                                                          
+            echo  "OPTIONS:"                                                                   
+            echo  " -h   help"                                                                 
+            echo  " -v   version"                                                              
+            echo  " -e   enable PoE"                                                           
+            echo  " -d   disable PoE"                                                          
+            echo  " -s   PoE status"                                                           
+            echo  " -mV  PoE voltage"                                                          
+            echo  " -mC  PoE current"                                                          
+            echo  " -mT  PoE temperature"                                                      
+            echo  " -mP  PoE power" 
+} 
+
+# Main block
+
+if (("$#"==1)); then port=all 
+fi
+
+if (("$#"<1)); then usage;
+
+else
+
+	mapping
+
+	case "$1" in
+		-h) usage;; 
+		-v) echo "Version: "$version;;
+		-e) case "$port" in
+			all)	for ((i=1;i<($portmax+1);i++)); do
+					port="port"$i
+					mapping
+					enable
+				done;;
+			  *) 	enable;;
+		    esac;;
+		-d) case "$port" in
+       	         all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                                disable
+	                        done;;
+	                  *)    disable;;
+		    esac;;
+	        -s) case "$port" in
+	                all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                                status
+	                        done;;
+	                  *)    status;;
+	            esac;;
+	        -mV) case "$port" in
+	                all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                              	measureV  
+	                        done;;
+	                  *)    measureV;;
+	            esac;;
+	        -mC) case "$port" in
+	                all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                                measureC
+	                        done;;
+	                  *)    measureC;;
+	            esac;;
+	        -mT) case "$port" in
+	                all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                                measureT
+	                        done;;
+	                  *)    measureT;;
+	            esac;;
+	        -mP) case "$port" in
+	                all)    for ((i=1;i<($portmax+1);i++)); do
+	                                port="port"$i
+	                                mapping
+	                                measureP
+	                        done;;
+	                  *)    measureP;;
+	            esac;;
+		 *) echo "Wrong option syntax" >&2
+		    exit 1;;
+	esac
+fi


### PR DESCRIPTION
Add a driver for the PoE PSE MCU, adapted from the one for AS4610.

Main difference is that this one uses I2C to communicate, and does not need to program the MCU anymore, since it comes with a valid configuration.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>