### PR TITLE
accton-as4630-54pe: Fix poectl i2c device path

### DIFF
--- a/recipes-kernel/accton-as4630-poe-mcu/files/poectl
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/poectl
@@ -20,7 +20,7 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-systempath=/sys/kernel/debug/i2c-16-0020
+systempath=/sys/kernel/debug/16-0020
 readonly systempath
 
 if ! [ -d "$systempath" ]; then


### PR DESCRIPTION
The i2c path for the poe driver for the accton as4630-54pe
is present under /sys/kernel/debug/16-0020.

Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>