### PR TITLE
linux-yocto-onl/5.15: update to 5.15.14

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.6"
+LINUX_VERSION ?= "5.15.14"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "a2547651bc896f95a3680a6a0a27401e7c7a1080"
-SRCREV_meta ?= "df57bc53f6ca3fb3b2d3a9e5331ceff533d6f508"
+SRCREV_machine ?= "d114b082bef784345bfac1e1d5c17257005284f2"
+SRCREV_meta ?= "72e4eafb6b3c999aefc56e1c1b9dfa0c94ae2fbb"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel and meta to 5.15.14.

Most interesting/relevant changes come from 5.15.7:

    net: mpls: Fix notifications when deleting a device

    commit 7d4741eacdefa5f0475431645b56baf00784df1f upstream.

    There are various problems related to netlink notifications for mpls route
    changes in response to interfaces being deleted:
    * delete interface of only nexthop
            DELROUTE notification is missing RTA_OIF attribute
    * delete interface of non-last nexthop
            NEWROUTE notification is missing entirely
    * delete interface of last nexthop
            DELROUTE notification is missing nexthop

    All of these problems stem from the fact that existing routes are modified
    in-place before sending a notification. Restructure mpls_ifdown() to avoid
    changing the route in the DELROUTE cases and to create a copy in the
    NEWROUTE case.

and 5.15.12:

    bonding: fix ad_actor_system option setting to default

    [ Upstream commit 1c15b05baea71a5ff98235783e3e4ad227760876 ]

    When 802.3ad bond mode is configured the ad_actor_system option is set to
    "00:00:00:00:00:00". But when trying to set the all-zeroes MAC as actors'
    system address it was failing with EINVAL.

    An all-zeroes ethernet address is valid, only multicast addresses are not
    valid values.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>