### PR TITLE
linux-yocto-onl/5.15: update to 5.15.22

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.14"
+LINUX_VERSION ?= "5.15.22"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "d114b082bef784345bfac1e1d5c17257005284f2"
-SRCREV_meta ?= "72e4eafb6b3c999aefc56e1c1b9dfa0c94ae2fbb"
+SRCREV_machine ?= "0bf5b7cc9848b5494b2ca4eb1ca6e05865e8cdf1"
+SRCREV_meta ?= "2d38a472b21ae343707c8bd64ac68a9eaca066a0"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update 5.15 to latest, and meta accordingly.

Most interesting fixes from 5.15.19:

    net: bridge: vlan: fix memory leak in __allowed_ingress

    [ Upstream commit fd20d9738395cf8e27d0a17eba34169699fccdff ]

    When using per-vlan state, if vlan snooping and stats are disabled,
    untagged or priority-tagged ingress frame will go to check pvid state.
    If the port state is forwarding and the pvid state is not
    learning/forwarding, untagged or priority-tagged frame will be dropped
    but skb memory is not freed.
    Should free skb when __allowed_ingress returns false.

    net: bridge: vlan: fix single net device option dumping

    [ Upstream commit dcb2c5c6ca9b9177f04abaf76e5a983d177c9414 ]

    When dumping vlan options for a single net device we send the same
    entries infinitely because user-space expects a 0 return at the end but
    we keep returning skb->len and restarting the dump on retry. Fix it by
    returning the value from br_vlan_dump_dev() if it completed or there was
    an error. The only case that must return skb->len is when the dump was
    incomplete and needs to continue (-EMSGSIZE).

Which affect us both.

Apart from that the ususal assortment of fixes in various subsystems and
drivers.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>