### PR TITLE
update and fix SPDX licensing

### DIFF
--- a/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
+++ b/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = ""
-LICENSE = "EPLv1.0"
+LICENSE = "EPL-1.0"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/EPL-1.0;md5=57f8d5e2b3e98ac6e088986c12bf94e6"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/recipes-core/platform-as5835-54x/platform-as5835-54x_0.1.bb
+++ b/recipes-core/platform-as5835-54x/platform-as5835-54x_0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = ""
-LICENSE = "EPLv1.0"
+LICENSE = "EPL-1.0"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/EPL-1.0;md5=57f8d5e2b3e98ac6e088986c12bf94e6"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/recipes-core/platform-as7726-32x/platform-as7726-32x_0.1.bb
+++ b/recipes-core/platform-as7726-32x/platform-as7726-32x_0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = ""
-LICENSE = "EPLv1.0"
+LICENSE = "EPL-1.0"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/EPL-1.0;md5=57f8d5e2b3e98ac6e088986c12bf94e6"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"

--- a/recipes-core/platform-questone-2a/platform-questone-2a_0.1.bb
+++ b/recipes-core/platform-questone-2a/platform-questone-2a_0.1.bb
@@ -1,5 +1,5 @@
 SUMMARY = ""
-LICENSE = "CLOSED"
+LICENSE = "EPL-1.0"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "Open Network Linux Components for Yocto integration"
 HOMEPAGE = "https://www.opennetlinux.org/"
-LICENSE = "EPLv1.0"
+LICENSE = "EPL-1.0"
 LIC_FILES_CHKSUM = "\
   file://LICENSE;beginline=14;md5=7e6d108802170df125adb4f452c3c9dd \
   file://${SUBMODULE_INFRA}/LICENSE;md5=457079d296746aac524eb56eb6822ea8 \

--- a/recipes-kernel/accton-as4610-cpld/accton-as4610-cpld-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-cpld/accton-as4610-cpld-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4610-fan/accton-as4610-fan-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-fan/accton-as4610-fan-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4610-leds/accton-as4610-leds-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-leds/accton-as4610-leds-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4610-poe-mcu/accton-as4610-poe-mcu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-poe-mcu/accton-as4610-poe-mcu-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4610-psu/accton-as4610-psu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-psu/accton-as4610-psu-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4630-54pe-cpld-mod/accton-as4630-54pe-cpld-mod.bb
+++ b/recipes-kernel/accton-as4630-54pe-cpld-mod/accton-as4630-54pe-cpld-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports the accton cpld that hold the channel select mechanism for other i2c slave devices, such as SFP."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4630-54pe-leds-mod/accton-as4630-54pe-leds-mod.bb
+++ b/recipes-kernel/accton-as4630-54pe-leds-mod/accton-as4630-54pe-leds-mod.bb
@@ -1,6 +1,6 @@
 SUMMARY = "A LED driver for the accton_as4630_54pe_led"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4630-54pe-psu-mod/accton-as4630-54pe-psu-mod.bb
+++ b/recipes-kernel/accton-as4630-54pe-psu-mod/accton-as4630-54pe-psu-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "An hwmon driver for accton as4630_54pe Power Module"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as5835-54x-cpld-mod/accton-as5835-54x-cpld-mod.bb
+++ b/recipes-kernel/accton-as5835-54x-cpld-mod/accton-as5835-54x-cpld-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as5835-54x-fan-mod/accton-as5835-54x-fan-mod.bb
+++ b/recipes-kernel/accton-as5835-54x-fan-mod/accton-as5835-54x-fan-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "A hwmon driver for the Accton as5835 54x fan"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as5835-54x-leds-mod/accton-as5835-54x-leds-mod.bb
+++ b/recipes-kernel/accton-as5835-54x-leds-mod/accton-as5835-54x-leds-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports the accton cpld that hold the channel select mechanism for other i2c slave devices, such as SFP."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as5835-54x-psu-mod/accton-as5835-54x-psu-mod.bb
+++ b/recipes-kernel/accton-as5835-54x-psu-mod/accton-as5835-54x-psu-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "An hwmon driver for accton as5835_54x Power Module"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as7726-32x-cpld-mod/accton-as7726-32x-cpld-mod.bb
+++ b/recipes-kernel/accton-as7726-32x-cpld-mod/accton-as7726-32x-cpld-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as7726-32x-fan-mod/accton-as7726-32x-fan-mod.bb
+++ b/recipes-kernel/accton-as7726-32x-fan-mod/accton-as7726-32x-fan-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as7726-32x-leds-mod/accton-as7726-32x-leds-mod.bb
+++ b/recipes-kernel/accton-as7726-32x-leds-mod/accton-as7726-32x-leds-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/accton-as7726-32x-psu-mod/accton-as7726-32x-psu-mod.bb
+++ b/recipes-kernel/accton-as7726-32x-psu-mod/accton-as7726-32x-psu-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/agema-ag5648-i2c-cpld-mod/agema-ag5648-i2c-cpld-mod_1.0.bb
+++ b/recipes-kernel/agema-ag5648-i2c-cpld-mod/agema-ag5648-i2c-cpld-mod_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2" 
-LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e" 
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module
 

--- a/recipes-kernel/agema-ag5648-psu-mod/agema-ag5648-psu-mod_1.0.bb
+++ b/recipes-kernel/agema-ag5648-psu-mod/agema-ag5648-psu-mod_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "An hwmon driver for delta AG9032v1 PSU dps_800ab_16_d.c - Support for DPS-800AB-16 D Power Supply Module"
-LICENSE = "GPLv2" 
-LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e" 
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module
 

--- a/recipes-kernel/agema-ag5648-sfp-mod/agema-ag5648-sfp-mod_1.0.bb
+++ b/recipes-kernel/agema-ag5648-sfp-mod/agema-ag5648-sfp-mod_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "An hwmon driver for delta ag5648 qsfp"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/agema-ag7648-cpld-mux-1-mod/agema-ag7648-cpld-mux-1-mod.bb
+++ b/recipes-kernel/agema-ag7648-cpld-mux-1-mod/agema-ag7648-cpld-mux-1-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/agema-ag7648-cpld-mux-2-mod/agema-ag7648-cpld-mux-2-mod.bb
+++ b/recipes-kernel/agema-ag7648-cpld-mux-2-mod/agema-ag7648-cpld-mux-2-mod.bb
@@ -1,5 +1,5 @@
 SUMMARY = "This module supports cpld that read and write"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/agema-ag7648-i2c-mux-setting-mod/agema-ag7648-i2c-mux-setting-mod_1.0.bb
+++ b/recipes-kernel/agema-ag7648-i2c-mux-setting-mod/agema-ag7648-i2c-mux-setting-mod_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "A hwmon driver for the SMSC EMC2305 fan controller"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/agema-ag7648-i2c-mux-setting-mod/files/x86-64-delta-ag7648-i2c-mux-setting.c
+++ b/recipes-kernel/agema-ag7648-i2c-mux-setting-mod/files/x86-64-delta-ag7648-i2c-mux-setting.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Driver to instantiate Delta switch i2c/smbus devices.
 //
 // Copyright (C) 2018 BISDN GmbH

--- a/recipes-kernel/cel-questone-2a-baseboard-cpld-mod/cel-questone-2a-baseboard-cpld-mod_1.0.bb
+++ b/recipes-kernel/cel-questone-2a-baseboard-cpld-mod/cel-questone-2a-baseboard-cpld-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://questone2a_baseboard_cpld.c;beginline=6;endline=9;md5=7a0d0f37f38de4d6e61a03d518a9e16d"
 
 inherit module

--- a/recipes-kernel/cel-questone-2a-switchboard-mod/cel-questone-2a-switchboard-mod_1.0.bb
+++ b/recipes-kernel/cel-questone-2a-switchboard-mod/cel-questone-2a-switchboard-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://questone2a_switchboard.c;beginline=6;endline=11;md5=5c4ec744723e9bc290837205861cbe99"
 
 inherit module

--- a/recipes-kernel/cpr-4011-4mxx-mod/cpr-4011-4mxx-mod_1.0.bb
+++ b/recipes-kernel/cpr-4011-4mxx-mod/cpr-4011-4mxx-mod_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "A hwmon driver for the CPR-4011-4Mxx Redundant Power Module"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/emc2305-mod/emc2305-mod_1.0.bb
+++ b/recipes-kernel/emc2305-mod/emc2305-mod_1.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "A hwmon driver for the SMSC EMC2305 fan controller"
-LICENSE = "GPLv2" 
-LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e" 
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module
 

--- a/recipes-kernel/emerson700-mod/emerson700-mod_1.0.bb
+++ b/recipes-kernel/emerson700-mod/emerson700-mod_1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Emerson 700 PMBus driver"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/mc24lc64t-mod/mc24lc64t-mod_1.0.bb
+++ b/recipes-kernel/mc24lc64t-mod/mc24lc64t-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://mc24lc64t.c;beginline=6;endline=9;md5=7a0d0f37f38de4d6e61a03d518a9e16d"
 
 inherit module

--- a/recipes-kernel/optoe/optoe-mod_1.0.bb
+++ b/recipes-kernel/optoe/optoe-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module

--- a/recipes-kernel/ym2651y-mod/ym2651y-mod_1.0.bb
+++ b/recipes-kernel/ym2651y-mod/ym2651y-mod_1.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e"
 
 inherit module


### PR DESCRIPTION
Update all of our recipes to use the correct, current SPDX license identifiers, based on https://spdx.org/licenses/ (Version: 3.16 2022-02-06).

Mostly FOOvX => FOO-X and GPL-2.0 refined into 2.0-only or 2.0-or-later.

Since there were a lot of modules to fix up, I left them in one commit.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>