### PR TITLE
platform-questone-2a: fix build by adding missing LIC_FILES_CHECKSUM

### DIFF
--- a/recipes-core/platform-questone-2a/platform-questone-2a_0.1.bb
+++ b/recipes-core/platform-questone-2a/platform-questone-2a_0.1.bb
@@ -1,5 +1,6 @@
 SUMMARY = ""
 LICENSE = "EPL-1.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/EPL-1.0;md5=57f8d5e2b3e98ac6e088986c12bf94e6"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 


### PR DESCRIPTION
Changing LICENSE to a non-closed one requires having a LIC_FILES_CHKSUM,
without it bitbake will fail the build.

So add a link to the common licenses one, like we have for all the other
platform packages.

Fixes: bbed8f8 ("platform-questone-2a: fix LICENSE")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>