### PR TITLE
linux-yocto-onl/5.15: update to 5.15.44

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -4,10 +4,10 @@ require linux-yocto-onl.inc
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.35"
+LINUX_VERSION ?= "5.15.44"
 #https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "81d8d30c35edf29c5c70186ccb14dac4a5ca38a8"
-SRCREV_meta ?= "178b786485dfb3edb05af51f0ba9195ffa07e358"
+SRCREV_machine ?= "4e67be407725b1d8b829ed2075987037abec98ec"
+SRCREV_meta ?= "529199264800b52ae173fc91241c8e64615850e3"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update to include the latest fixes from upstream. Update meta to HEAD,
lacking a v5.15.44 commit yet.

Most interesting change from 5.15.44:

    ping: fix address binding wrt vrf

    commit e1a7ac6f3ba6e157adcd0ca94d92a401f1943f56 upstream.

    When ping_group_range is updated, 'ping' uses the DGRAM ICMP socket,
    instead of an IP raw socket. In this case, 'ping' is unable to bind its
    socket to a local address owned by a vrflite.

    Before the patch:
    $ sysctl -w net.ipv4.ping_group_range='0  2147483647'
    $ ip link add blue type vrf table 10
    $ ip link add foo type dummy
    $ ip link set foo master blue
    $ ip link set foo up
    $ ip addr add 192.168.1.1/24 dev foo
    $ ip addr add 2001::1/64 dev foo
    $ ip vrf exec blue ping -c1 -I 192.168.1.1 192.168.1.2
    ping: bind: Cannot assign requested address
    $ ip vrf exec blue ping6 -c1 -I 2001::1 2001::2
    ping6: bind icmp socket: Cannot assign requested address

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>