### PR TITLE
yocto-linux-onl: armel-iproc: do not disable VXLAN

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/bsp/armel-iproc/armel-iproc.cfg
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/bsp/armel-iproc/armel-iproc.cfg
@@ -1347,7 +1347,6 @@ CONFIG_BONDING=y
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
 # CONFIG_NET_TEAM is not set
-# CONFIG_VXLAN is not set
 # CONFIG_MACSEC is not set
 # CONFIG_NETCONSOLE is not set
 # CONFIG_NETPOLL is not set


### PR DESCRIPTION
Do not disable VXLAN in the config, so that kernel meta snippets can
enable it.

While not supported by Helix 4, this aligns the configs across platforms
a bit.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>