### PR TITLE
kernel: update source comments in linux-yocto-onl_5.15.bb

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -5,8 +5,11 @@ require linux-yocto-onl.inc
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 LINUX_VERSION ?= "5.15.44"
-#https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
+# https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
 SRCREV_machine ?= "4e67be407725b1d8b829ed2075987037abec98ec"
+
+# Use commit for kver matching (or close to) LINUX_VERSION
+# https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
 SRCREV_meta ?= "529199264800b52ae173fc91241c8e64615850e3"
 
 SRC_URI += "\


### PR DESCRIPTION
Update comments to indicate what SRCREV_meta is referring to and how a
new value is selected.
