### PR TITLE
conf: fixup override usage

### DIFF
--- a/conf/machine/accton-as4610.conf
+++ b/conf/machine/accton-as4610.conf
@@ -17,7 +17,7 @@ require conf/machine/include/onl.inc
 BISDN_SWITCH_IMAGE_EXTRA_INSTALL_remove = "grub"
 
 MACHINE_FEATURES += "pcbios"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 0 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/accton-as4630-54pe.conf
+++ b/conf/machine/accton-as4630-54pe.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 1 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/accton-as5835-54x.conf
+++ b/conf/machine/accton-as5835-54x.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 1 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/accton-as7726-32x.conf
+++ b/conf/machine/accton-as7726-32x.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 1 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/agema-ag5648.conf
+++ b/conf/machine/agema-ag5648.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 1 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/agema-ag7648.conf
+++ b/conf/machine/agema-ag7648.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 0 115200"
 SERIAL_CONSOLE = "115200 ttyS0"

--- a/conf/machine/cel-questone-2a.conf
+++ b/conf/machine/cel-questone-2a.conf
@@ -16,7 +16,7 @@ require conf/machine/include/x86-base.inc
 require conf/machine/include/onl.inc
 
 MACHINE_FEATURES += "pcbios efi"
-MACHINE_FEATURES_remove += "alsa"
+MACHINE_FEATURES_remove = "alsa"
 
 SYSLINUX_OPTS = "serial 1 115200"
 SERIAL_CONSOLE = "115200 ttyS0"


### PR DESCRIPTION
Combining overrides with += is not officially supported, and will
trigger a warning in newer yocto releases [1]:

  WARNING: MACHINE_FEATURES:remove += is not a recommended operator combination, please replace it.

[1] https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html#append-prepend-in-combination-with-other-operators

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>