### PR TITLE
onl: do not provide /etc/onl/platform anymore

### DIFF
--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -169,10 +169,6 @@ do_install() {
   mv ${D}${libdir}/libonlp-platform-defaults.so ${D}${libdir}/libonlp-platform-defaults.so.1
   ln -r -s ${D}${libdir}/libonlp-platform-defaults.so.1 ${D}${libdir}/libonlp-platform-defaults.so
 
-  # platform file
-  install -d ${D}${sysconfdir}/onl
-  echo "${ONL_PLATFORM}-r${ONIE_MACHINE_REV}" > ${D}${sysconfdir}/onl/platform
-
   # service file
   install -d ${D}${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/onlpd.service ${D}${systemd_unitdir}/system


### PR DESCRIPTION
Now that this will be populated by the installer, we do not need to shop
a prepopulated file anymore.

Depends on https://github.com/bisdn/bisdn-onie-additions/pull/8

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>