### PR TITLE
onl: support all platforms

### DIFF
--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -162,8 +162,6 @@ do_install() {
       ln -r -s ${D}${libdir}/libonlp-${baseplatform}.so.1 ${D}${libdir}/libonlp-${baseplatform}.so
   done
 
-  ln -r -s ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1 ${D}${libdir}/libonlp-platform.so.1
-
   # install libonlp shared library
   install -m 0755 packages/base/any/onlp/builds/onlp/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp.so ${D}${libdir}
   mv ${D}${libdir}/libonlp.so ${D}${libdir}/libonlp.so.1
@@ -173,6 +171,11 @@ do_install() {
   install -m 0755 packages/base/any/onlp/builds/onlp-platform-defaults/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-platform-defaults.so ${D}${libdir}
   mv ${D}${libdir}/libonlp-platform-defaults.so ${D}${libdir}/libonlp-platform-defaults.so.1
   ln -r -s ${D}${libdir}/libonlp-platform-defaults.so.1 ${D}${libdir}/libonlp-platform-defaults.so
+
+  # install libonlp-platform shared library
+  install -m 0755 packages/base/any/onlp/builds/onlp-platform/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-platform.so ${D}${libdir}
+  mv ${D}${libdir}/libonlp-platform.so ${D}${libdir}/libonlp-platform.so.1
+  ln -r -s ${D}${libdir}/libonlp-platform.so.1 ${D}${libdir}/libonlp-platform.so
 
   # service file
   install -d ${D}${systemd_unitdir}/system

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -153,18 +153,18 @@ do_install() {
   install -m 0644 sm/bigcode/modules/cjson/module/inc/cjson/*.h ${D}${includedir}/cjson/
   install -m 0644 sm/infra/modules/AIM/module/inc/AIM/*.h ${D}${includedir}/AIM/
 
-  # install libonlp-platform shared library (includes AIM.a  AIM_posix.a  BigList.a  cjson.a  cjson_util.a  IOF.a  onlplib.a  x86_64_delta_ag7648.a)
+  # install libonlp-<platform> shared library
   install -m 0755 ${ONLP_DIR}/builds/lib/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-${ONL_PLATFORM}.so ${D}${libdir}
   mv ${D}${libdir}/libonlp-${ONL_PLATFORM}.so ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1
   ln -r -s ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1 ${D}${libdir}/libonlp-${ONL_PLATFORM}.so
   ln -r -s ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1 ${D}${libdir}/libonlp-platform.so.1
 
-  # install libonlp shared library (includes TODO)
+  # install libonlp shared library
   install -m 0755 packages/base/any/onlp/builds/onlp/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp.so ${D}${libdir}
   mv ${D}${libdir}/libonlp.so ${D}${libdir}/libonlp.so.1
   ln -r -s ${D}${libdir}/libonlp.so.1 ${D}${libdir}/libonlp.so
 
-  # install libonlp shared library (includes TODO)
+  # install libonlp-platform-defaults shared library
   install -m 0755 packages/base/any/onlp/builds/onlp-platform-defaults/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-platform-defaults.so ${D}${libdir}
   mv ${D}${libdir}/libonlp-platform-defaults.so ${D}${libdir}/libonlp-platform-defaults.so.1
   ln -r -s ${D}${libdir}/libonlp-platform-defaults.so.1 ${D}${libdir}/libonlp-platform-defaults.so

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -174,10 +174,6 @@ do_install() {
   mv ${D}${libdir}/libonlp-platform-defaults.so ${D}${libdir}/libonlp-platform-defaults.so.1
   ln -r -s ${D}${libdir}/libonlp-platform-defaults.so.1 ${D}${libdir}/libonlp-platform-defaults.so
 
-  # platform file
-  install -d ${D}${sysconfdir}/onl
-  echo "${ONL_PLATFORM}-r${ONIE_MACHINE_REV}" > ${D}${sysconfdir}/onl/platform
-
   # service file
   install -d ${D}${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/onlpd.service ${D}${systemd_unitdir}/system

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -118,11 +118,12 @@ do_compile() {
   V=1 VERBOSE=1 oe_runmake -C packages/base/any/onlp/builds alltargets
   V=1 VERBOSE=1 oe_runmake -C packages/base/any/onlp/builds/onlpd alltargets
 
-  # get the path to the platform
-  ONLP_PLATFORM="${ONL_PLATFORM}-r${ONIE_MACHINE_REV}"
-  ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${ONLP_PLATFORM}:${ONL_BUILD_ARCH})
+  for platform in ${ONL_PLATFORM_SUPPORT}; do
+      # get the path to the platform
+      ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${platform}:${ONL_BUILD_ARCH})
 
-  V=1 VERBOSE=1 oe_runmake -C ${ONLP_DIR}/builds/lib alltargets
+      V=1 VERBOSE=1 oe_runmake -C ${ONLP_DIR}/builds/lib alltargets
+  done
 }
 
 do_install() {
@@ -137,9 +138,6 @@ do_install() {
     ${D}${includedir}/onlplib \
     ${D}${libdir}
 
-  # get the path to the platform
-  ONLP_PLATFORM="${ONL_PLATFORM}-r${ONIE_MACHINE_REV}"
-  ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${ONLP_PLATFORM}:${ONL_BUILD_ARCH})
 
   # install onlpdump
   install -m 0755 packages/base/any/onlp/builds/onlpd/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/onlpd ${D}${bindir}
@@ -153,10 +151,17 @@ do_install() {
   install -m 0644 sm/bigcode/modules/cjson/module/inc/cjson/*.h ${D}${includedir}/cjson/
   install -m 0644 sm/infra/modules/AIM/module/inc/AIM/*.h ${D}${includedir}/AIM/
 
-  # install libonlp-<platform> shared library
-  install -m 0755 ${ONLP_DIR}/builds/lib/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-${ONL_PLATFORM}.so ${D}${libdir}
-  mv ${D}${libdir}/libonlp-${ONL_PLATFORM}.so ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1
-  ln -r -s ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1 ${D}${libdir}/libonlp-${ONL_PLATFORM}.so
+  for platform in ${ONL_PLATFORM_SUPPORT}; do
+      # get the path to the platform
+      ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${platform}:${ONL_BUILD_ARCH})
+
+      # install libonlp-<baseplatform> shared library
+      baseplatform=${platform%-r*}
+      install -m 0755 ${ONLP_DIR}/builds/lib/BUILD/${ONL_DEBIAN_SUITE}/${TOOLCHAIN}/bin/libonlp-${baseplatform}.so ${D}${libdir}
+      mv ${D}${libdir}/libonlp-${baseplatform}.so ${D}${libdir}/libonlp-${baseplatform}.so.1
+      ln -r -s ${D}${libdir}/libonlp-${baseplatform}.so.1 ${D}${libdir}/libonlp-${baseplatform}.so
+  done
+
   ln -r -s ${D}${libdir}/libonlp-${ONL_PLATFORM}.so.1 ${D}${libdir}/libonlp-platform.so.1
 
   # install libonlp shared library

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -48,3 +48,17 @@ SRC_URI += " \
            file://delta-ag7648/0001-agema-ag7648-fix-buffer-overflow-while-reading-therm.patch \
            file://delta-ag7648/0002-agema-ag7648-don-t-create-random-rx_los-bitmap-value.patch \
 "
+
+ONL_PLATFORM_SUPPORT:arm = " \
+    arm-accton-as4610-30-r0 \
+    arm-accton-as4610-54-r0 \
+"
+
+ONL_PLATFORM_SUPPORT:x86-64 = " \
+    x86-64-accton-as4630-54pe-r0 \
+    x86-64-accton-as5835-54x-r0 \
+    x86-64-accton-as7726-32x-r0 \
+    x86-64-cel-questone-2a-r0 \
+    x86-64-delta-ag5648-r0 \
+    x86-64-delta-ag7648-r0 \
+"


### PR DESCRIPTION
Rework the onl package into a generic package:

1. build and ship all libonlp-<platform>.so for all supported machines
2. drop the /etc/onl/platform symlink, and let the installer take care of it
3. replace the libonlp-platform.so symlink with the dummy libonlp-platform.so library from onl

Building all platforms at once means we also get build checks for all platforms when building an image, and not just the selected platform. This is also needed for as4610 so we can properly setup the libonlp symlink based on the running machine.

Having a proper libonlp-platform.so instead of a symlink makes it easier for other packages to link against it, as it won't be an alias for the current machine's libonlp-* anymore, which might have additional dependencies. 

The installer will take care of replacing the dummy lib with the proper one for the platform. 

Total build time increase is marginal, even when building all supported platforms.

Depends on https://github.com/bisdn/bisdn-onie-additions/pull/8