### PR TITLE
linux-yocto-onl: import linux-yocto dependencies

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -29,3 +29,7 @@ SRC_URI += "\
 SRC_URI:append:arm = "\
     file://arch/arm/boot/dts;subdir=git \
 "
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+DEPENDS += "gmp-native libmpc-native"


### PR DESCRIPTION
The kernel build has some addtional dependencies, so import from the
upstream linux-yocto_5.15.bb [1].

Avoids the following build error when libelf-dev is not installed on the
build machine:

```
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/builtin-check.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from weak.c:10:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/weak.o] Error 1
| make[3]: *** Waiting for unfinished jobs....
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/help.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/arch.h:11,
|                  from check.c:12:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/check.o] Error 1
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/arch.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/check.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/special.h:10,
|                  from arch/x86/special.c:4:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[4]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/arch/x86/special.o] Error 1
| make[4]: *** Waiting for unfinished jobs....
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/pager.o
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/parse-options.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/arch.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/check.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/special.h:10,
|                  from special.c:16:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/special.o] Error 1
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/run-command.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from orc_dump.c:9:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/orc_dump.o] Error 1
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/sigchain.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/arch.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/check.h:11,
|                  from orc_gen.c:12:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/orc_gen.o] Error 1
|   CC      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/subcmd-config.o
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from builtin-check.c:20:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/builtin-check.o] Error 1
| In file included from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/objtool.h:13,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/arch.h:11,
|                  from /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/check.h:11,
|                  from arch/x86/decode.c:18:
| /home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/objtool/include/objtool/elf.h:10:10: fatal error: gelf.h: No such file or directory
|    10 | #include <gelf.h>
|       |          ^~~~~~~~
| compilation terminated.
| make[4]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:97: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/arch/x86/decode.o] Error 1
| make[3]: *** [/home/ubuntu/yocto/master/work-shared/accton-as4630-54pe/kernel-source/tools/build/Makefile.build:139: arch/x86] Error 2
| make[2]: *** [Makefile:56: /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/objtool-in.o] Error 2
| make[2]: *** Waiting for unfinished jobs....
|   LD      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/libsubcmd-in.o
|   AR      /home/ubuntu/yocto/master/work/accton_as4630_54pe-poky-linux/linux-yocto-onl/5.15.44+gitAUTOINC+5291992648_4e67be4077-r0/linux-accton_as4630_54pe-standard-build/tools/objtool/libsubcmd.a
| make[1]: *** [Makefile:69: objtool] Error 2
```

[1] https://git.yoctoproject.org/poky/tree/meta/recipes-kernel/linux/linux-yocto_5.15.bb?h=kirkstone#n43

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>