### PR TITLE
linux-yocto-onl: allow setting mac address on tap interface creation

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/0001-tun-allow-setting-hwaddr-on-tap-interface-creation.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/0001-tun-allow-setting-hwaddr-on-tap-interface-creation.patch
@@ -1,0 +1,43 @@
+Upstream-Status: undecided if suitable [rather hackish, but also simple]
+
+From 4644f254c1e41263ffb8e9f6a1559daed42fdeb9 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 19 Jul 2022 14:44:05 +0200
+Subject: [PATCH] tun: allow setting hwaddr on tap interface creation
+
+Sometimes using a fixed mac address on tap interfaces is desired, but
+setting it after creation may race with e.g. a network manager trying to
+set its own mac address (*cough* systemd-networkd) or configuring /
+enabling the interface.
+
+So allow passing a mac address in the ifreq by (ab)using the fact that
+the sa_family field of the sockaddr matches the ifr_flags, so we can
+just use the sa_data field of ifr_hwaddr for passing it.
+
+To avoid assigning unexpected mac addresses, do a validity check before
+trying to use it.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ drivers/net/tun.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/tun.c b/drivers/net/tun.c
+index fed85447701a..a3a9edd72798 100644
+--- a/drivers/net/tun.c
++++ b/drivers/net/tun.c
+@@ -1369,7 +1369,10 @@ static void tun_net_initialize(struct net_device *dev)
+ 		dev->priv_flags &= ~IFF_TX_SKB_SHARING;
+ 		dev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
+ 
+-		eth_hw_addr_random(dev);
++		if (is_valid_ether_addr(tun->ifr->ifr_hwaddr.sa_data))
++			eth_hw_addr_set(dev, tun->ifr->ifr_hwaddr.sa_data);
++		else
++			eth_hw_addr_random(dev);
+ 
+ 		break;
+ 	}
+-- 
+2.37.1
+

--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/bisdn-linux.scc
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/bisdn-linux.scc
@@ -2,6 +2,7 @@
 
 patch 0001-net-rtnetlink-send-BONDING_INFO-events-down-to-users.patch
 patch 0001-net-ipv6-apply-IFLA_INET6_ADDR_GEN_MODE-immediately.patch
+patch 0001-tun-allow-setting-hwaddr-on-tap-interface-creation.patch
 
 # https://git.yoctoproject.org/yocto-kernel-cache/tree/
 include features/bpf/bpf.scc


### PR DESCRIPTION
To allow baseboxd to create tap interfaces with the OpenFlow provided
MAC address, we need to allow creating tap interfaces with a fixed MAC
address, so allow passing a MAC address via the ifr_addr field.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>