### PR TITLE
linux-yocto-onl: update to 5.15.56

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.44"
+LINUX_VERSION ?= "5.15.46"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "4e67be407725b1d8b829ed2075987037abec98ec"
+SRCREV_machine ?= "aed23654e8ed2cc776ae26a87ef773ff38b48d7f"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "529199264800b52ae173fc91241c8e64615850e3"
+SRCREV_meta ?= "6b9da9c15f1c04c1b22ef4b10d68303df2d4a470"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.46"
+LINUX_VERSION ?= "5.15.48"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "aed23654e8ed2cc776ae26a87ef773ff38b48d7f"
+SRCREV_machine ?= "e1dd58c995daf8b632344b61df9d3cbed26454dc"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "6b9da9c15f1c04c1b22ef4b10d68303df2d4a470"
+SRCREV_meta ?= "8828a8e63fc50647e3f714a8a87a95c6d3e5b391"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.52"
+LINUX_VERSION ?= "5.15.54"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "545aecd229613138d6db54fb2b5221faca10137f"
+SRCREV_machine ?= "843dae1756d9bddee21a96827784791fd97d484e"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "263a2fb6fb2ed6f632d8d62fb46be2c51553b662"
+SRCREV_meta ?= "0e3a81a5aefbea03388b1235fbcc3dec278425d0"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.48"
+LINUX_VERSION ?= "5.15.52"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "e1dd58c995daf8b632344b61df9d3cbed26454dc"
+SRCREV_machine ?= "545aecd229613138d6db54fb2b5221faca10137f"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "8828a8e63fc50647e3f714a8a87a95c6d3e5b391"
+SRCREV_meta ?= "263a2fb6fb2ed6f632d8d62fb46be2c51553b662"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.54"
+LINUX_VERSION ?= "5.15.56"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "843dae1756d9bddee21a96827784791fd97d484e"
+SRCREV_machine ?= "760adb59f6211e157dd587927ac26c42abc81550"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "0e3a81a5aefbea03388b1235fbcc3dec278425d0"
+SRCREV_meta ?= "624cd634ceb095c2949b1cf8b69b0c96b098cb44"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Our kernel is falling behind, so update to latest and gratest.

Kernel-meta updated to HEAD, lacking a v5.15.56 commit.

To allow easier bisection in case of issues, split up the kernel updates along the kver bumps in kernel-meta.

Boot tested on AS4610 and AG7648.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>