### PR TITLE
accton-as4630-54pe: add support for edgecore eps201(as4630-54te)

### DIFF
--- a/conf/machine/accton-as4630-54pe.conf
+++ b/conf/machine/accton-as4630-54pe.conf
@@ -40,6 +40,9 @@ MACHINE_EXTRA_RDEPENDS += " \
     kernel-module-x86-64-accton-as4630-54pe-cpld \
     kernel-module-x86-64-accton-as4630-54pe-leds \
     kernel-module-x86-64-accton-as4630-54pe-psu \
+    kernel-module-x86-64-accton-as4630-54te-cpld \
+    kernel-module-x86-64-accton-as4630-54te-leds \
+    kernel-module-x86-64-accton-as4630-54te-psu \
     kernel-module-ym2651y \
 "
 MACHINE_EXTRA_RDEPENDS += "platform-${ONIE_MACHINE_TYPE}"

--- a/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
+++ b/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
@@ -47,8 +47,11 @@ modprobe x86-64-accton-as4630-${variant}-leds
 
 # init mux (PCA9548)
 create_i2c_dev pca9548 0x77 1
+echo '-2' > /sys/bus/i2c/devices/1-0077/idle_state
 create_i2c_dev pca9548 0x71 2
+echo '-2' > /sys/bus/i2c/devices/2-0071/idle_state
 create_i2c_dev pca9548 0x70 3
+echo '-2' > /sys/bus/i2c/devices/3-0070/idle_state
 
 # allow SFP LEDs to be controlled by MAC
 OTHER=$(i2cget -y -f 0x3 0x60 0x86)

--- a/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
+++ b/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
@@ -23,10 +23,27 @@ add_port() {
 	echo "port${2}" > "/sys/bus/i2c/devices/${3}-0050/port_name"
 }
 
+onl_platform="$(cat /etc/onl/platform)"
+
+case "$onl_platform" in
+	*as4630-54pe*)
+		variant="54pe"
+		psu_dev="ype1200am"
+		;;
+	*as4630-54te*)
+		variant="54te"
+		psu_dev="ym1921"
+		;;
+	*)
+		echo "Unsupported model: $onl_platform"
+		exit 1
+		;;
+esac
+
 # load modules
-modprobe x86-64-accton-as4630-54pe-cpld
-modprobe x86-64-accton-as4630-54pe-psu
-modprobe x86-64-accton-as4630-54pe-leds
+modprobe x86-64-accton-as4630-${variant}-cpld
+modprobe x86-64-accton-as4630-${variant}-psu
+modprobe x86-64-accton-as4630-${variant}-leds
 
 # init mux (PCA9548)
 create_i2c_dev pca9548 0x77 1
@@ -41,7 +58,7 @@ if [ "$(($OTHER & 0x80))" == "0" ]; then
 fi
 
 # add CPLD
-create_i2c_dev as4630_54pe_cpld 0x60 3
+create_i2c_dev as4630_${variant}_cpld 0x60 3
 
 # init LM77
 create_i2c_dev lm77 0x48 14
@@ -49,12 +66,12 @@ create_i2c_dev lm75 0x4a 25
 create_i2c_dev lm75 0x4b 24
 
 # init PSU-1
-create_i2c_dev as4630_54pe_psu1 0x50 10
-create_i2c_dev ype1200am 0x58 10
+create_i2c_dev as4630_${variant}_psu1 0x50 10
+create_i2c_dev ${psu_dev} 0x58 10
 
 # init PSU-2
-create_i2c_dev as4630_54pe_psu2 0x51 11
-create_i2c_dev ype1200am 0x59 11
+create_i2c_dev as4630_${variant}_psu2 0x51 11
+create_i2c_dev ${psu_dev} 0x59 11
 
 for port in {49..52}; do
 	add_port 'optoe2' $port $((port-31))
@@ -67,5 +84,7 @@ done
 # add EEPROM
 create_i2c_dev 24c02 0x57 1
 
-# add PoE MCU
-create_i2c_dev as4630_54pe_poe_mcu 0x20 16
+if [ "$variant" = "54pe" ]; then
+	# add PoE MCU
+	create_i2c_dev as4630_54pe_poe_mcu 0x20 16
+fi

--- a/recipes-extended/onl/files/accton-as4630-54te/0001-accton-as4630-54te-silence-unused-result-warning.patch
+++ b/recipes-extended/onl/files/accton-as4630-54te/0001-accton-as4630-54te-silence-unused-result-warning.patch
@@ -1,0 +1,34 @@
+Upstream-Status: unsubmitted
+
+From 58e424e6e1223ef05078c02b834d53e43b378197 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 15 Aug 2022 14:41:52 +0200
+Subject: [PATCH] accton-as4630-54te: silence unused result warning
+
+Fixes the following build warning:
+| ../x86_64_accton_as4630_54pe/module/src/sysi.c: In function 'onlp_sysi_platform_manage_fans':
+| ../x86_64_accton_as4630_54pe/module/src/sysi.c:238:9: error: ignoring return value of 'system' declared with attribute 'warn_unused_result' [-Werror=unused-result]
+|   238 |         system(SHUTDOWN_DUT_CMD);
+|       |         ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
+index 941c9501099e..8f9e3bdac50d 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sysi.c
+@@ -235,7 +235,7 @@ int onlp_sysi_platform_manage_fans(void)
+         /*critical case*/
+         AIM_SYSLOG_CRIT("Temperature critical", "Temperature critical", "Alarm for temperature critical is detected, reset DUT");
+         sleep(2);
+-        system(SHUTDOWN_DUT_CMD);
++        (void)!!system(SHUTDOWN_DUT_CMD);
+     }
+ 
+     if (current_state != ori_state) {
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4630-54te/0002-Edgecore-as4630_54te-Update-thermal-threshold.patch
+++ b/recipes-extended/onl/files/accton-as4630-54te/0002-Edgecore-as4630_54te-Update-thermal-threshold.patch
@@ -1,0 +1,81 @@
+Upstream-Status: Submitted [https://github.com/opencomputeproject/OpenNetworkLinux/pull/906]
+
+From eb1347ff172b658d523670ee0afb0bd7b81282a4 Mon Sep 17 00:00:00 2001
+From: Brandon Chuang <brandon_chuang@edge-core.com>
+Date: Fri, 12 Aug 2022 15:48:59 +0800
+Subject: [PATCH] [Edgecore][as4630_54te] Update thermal threshold
+
+Update the thermal threshold values provided by hardware team.
+The unit of temperature is degree Celsius.
+
+CPU
+  Warring 70
+  Error 75
+  Shuntdown 80
+
+LM75-4B
+  Warring 65
+  Error 70
+  Shuntdown 75
+
+LM75-4A
+  Warring 65
+  Error 70
+  Shuntdown 75
+
+LM75-48
+  Warring 65
+  Error 70
+  Shuntdown 75
+
+PSU
+  Warring 45
+  Error 50
+  Shuntdown 55
+
+Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>
+---
+ .../x86_64_accton_as4630_54pe/module/src/thermali.c  | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/thermali.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/thermali.c
+index 71f30fb0f6fa..528974f407eb 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/thermali.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/thermali.c
+@@ -71,27 +71,27 @@ static onlp_thermal_info_t linfo[] = {
+     { }, /* Not used */
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE), "CPU Core", 0, {0} },
+             ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 70000, 75000, 80000 }
+         },
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-4B", 0, {0} },
+             ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 65000, 70000, 75000 }
+         },
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD), "LM75-2-4A", 0, {0} },
+             ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 65000, 70000, 75000 }
+         },
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD), "LM77-3-48", 0, {0} },
+            ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 65000, 70000, 75000 }
+         },
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU1), "PSU-1 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU1_ID)},
+             ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 45000, 50000, 55000 }
+         },
+     { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU2), "PSU-2 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU2_ID)},
+             ONLP_THERMAL_STATUS_PRESENT,
+-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
++            ONLP_THERMAL_CAPS_ALL, 0, { 45000, 50000, 55000 }
+         }
+ };
+ 
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4630-54te/0003-Edgecore-as4630_54te-Support-YM-1151F-power-supply.patch
+++ b/recipes-extended/onl/files/accton-as4630-54te/0003-Edgecore-as4630_54te-Support-YM-1151F-power-supply.patch
@@ -1,0 +1,128 @@
+Upstream-Status: Submitted [https://github.com/opencomputeproject/OpenNetworkLinux/pull/907]
+
+From 35148f6ef6ff552a29982f08bc42fad29322804e Mon Sep 17 00:00:00 2001
+From: Brandon Chuang <brandon_chuang@edge-core.com>
+Date: Fri, 12 Aug 2022 16:14:17 +0800
+Subject: [PATCH] [Edgecore][as4630_54te] Support YM-1151F power supply
+
+Modify driver and onlp to support YM-1151F
+The airflow direction is front to back
+
+The output of onlpdump is as follows:
+   psu @ 1 = {
+       Description: PSU-1
+       Model:  YM-1151F-A01R
+       SN:     SA03A1442209007283
+       Status: 0x00000001 [ PRESENT ]
+       Caps:   0x00000151 [ AC,VOUT,IOUT,POUT ]
+       Vin:    0
+       Vout:   12015
+       Iin:    0
+       Iout:   2113
+       Pin:    0
+       Pout:   25000
+       fan @ 4 = {
+           Description: PSU 1 - Fan 1
+           Status: 0x00000009 [ PRESENT,F2B ]
+           Caps:   0x00000038 [ SET_PERCENTAGE,GET_RPM,GET_PERCENTAGE ]
+           RPM:    9600
+           Per:    37
+           Model:  NULL
+           SN:     NULL
+       }
+       thermal @ 5 = {
+           Description: PSU-1 Thermal Sensor 1
+           Status: 0x00000001 [ PRESENT ]
+           Caps:   0x0000000f [ GET_TEMPERATURE,GET_WARNING_THRESHOLD,GET_ERROR_THRESHOLD,GET_SHUTDOWN_THRESHOLD ]
+           Temperature: 36000
+           thresholds = {
+               Warning: 45000
+               Error: 50000
+               Shutdown: 55000
+           }
+       }
+   }
+
+Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>
+---
+ .../modules/builds/x86-64-accton-as4630-54te-psu.c           | 5 +++--
+ .../onlp/builds/x86_64_accton_as4630_54pe/module/src/fani.c  | 3 ++-
+ .../x86_64_accton_as4630_54pe/module/src/platform_lib.c      | 4 +++-
+ .../x86_64_accton_as4630_54pe/module/src/platform_lib.h      | 3 ++-
+ .../onlp/builds/x86_64_accton_as4630_54pe/module/src/psui.c  | 1 +
+ 5 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/x86-64-accton-as4630-54te-psu.c b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/x86-64-accton-as4630-54te-psu.c
+index 461b137d1866..f39985560a46 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/modules/builds/x86-64-accton-as4630-54te-psu.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/modules/builds/x86-64-accton-as4630-54te-psu.c
+@@ -313,8 +313,9 @@ as4630_54te_psu_data *as4630_54te_psu_update_device(struct device *dev)
+ 				data->model_name[ARRAY_SIZE(data->model_name)-1] = '\0';
+ 			}
+ 
+-			if (strncmp(data->model_name, "YM-1151D-A03R", MAX_MODEL_NAME) == 0)
+-				serial_offset = 0x2E; /* YM-1151D-A03R */
++			if (strncmp(data->model_name, "YM-1151D-A03R", MAX_MODEL_NAME) == 0 ||
++				strncmp(data->model_name, "YM-1151F-A01R", MAX_MODEL_NAME) == 0)
++				serial_offset = 0x2E; /* YM-1151D-A03R or YM-1151F-A01R */
+ 			else
+ 				serial_offset = 0x35; /* YM-1151D-A02R */
+ 
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/fani.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/fani.c
+index 843e06d9e348..c7e55f359f68 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/fani.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/fani.c
+@@ -149,7 +149,8 @@ _onlp_get_fan_direction_on_psu(void)
+             continue;
+         }
+ 
+-        if (PSU_TYPE_YM1151D_F2B == psu_type) {
++        if (PSU_TYPE_YM1151D_F2B == psu_type ||
++            PSU_TYPE_YM1151F_F2B == psu_type) {
+             return ONLP_FAN_STATUS_F2B;
+         }
+         else {
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
+index a0f05c1ef35a..21a824625096 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.c
+@@ -24,7 +24,9 @@ psu_type_t get_psu_type(int id, char *data_buf, int data_len)
+     }
+ 
+     /* Check AC model name */
+-    if (strncmp(str, "YM-1151D-A03R", strlen("YM-1151D-A03R")) == 0)
++    if (strncmp(str, "YM-1151F-A01R", strlen("YM-1151F-A01R")) == 0)
++        ptype = PSU_TYPE_YM1151F_F2B;
++    else if (strncmp(str, "YM-1151D-A03R", strlen("YM-1151D-A03R")) == 0)
+         ptype = PSU_TYPE_YM1151D_F2B;
+     else
+         ptype = PSU_TYPE_YM1151D_B2F;
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
+index b572ae3fb93b..8efc34449110 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/platform_lib.h
+@@ -59,7 +59,8 @@ int psu_pmbus_info_get(int id, char *node, int *value);
+ typedef enum psu_type {
+     PSU_TYPE_UNKNOWN,
+     PSU_TYPE_YM1151D_F2B,
+-    PSU_TYPE_YM1151D_B2F
++    PSU_TYPE_YM1151D_B2F,
++    PSU_TYPE_YM1151F_F2B
+ } psu_type_t;
+ 
+ psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/psui.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/psui.c
+index 280acd7dde0d..5bf35ff66da4 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/psui.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/psui.c
+@@ -146,6 +146,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
+     psu_type = get_psu_type(index, info->model, sizeof(info->model));
+ 
+     switch (psu_type) {
++        case PSU_TYPE_YM1151F_F2B:
+         case PSU_TYPE_YM1151D_F2B:
+         case PSU_TYPE_YM1151D_B2F:
+             ret = psu_ym2651y_info_get(info);
+-- 
+2.37.2
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -41,6 +41,7 @@ SRC_URI += " \
            file://accton-as4630-54pe/0003-Fix-fan-direction-api.patch \
            file://accton-as4630-54pe/0004-accton-as4630-54pe-silence-error.patch \
            file://accton-as4630-54pe/0005-accton-as4630-54pe-Avoid-undefined-behaviour.patch \
+           file://accton-as4630-54te/0001-accton-as4630-54te-silence-unused-result-warning.patch \
            file://accton-as5835-54x/0001-AS5835-54x-Support-psu_fan_dir-sysfs-for-YM-1401A-PS.patch \
            file://accton-as5835-54x/0002-as5835-rename-psu_serial_numer-psu_serial_number.patch \
            file://accton-as7726-32x/0001-as7726-32x-silence-ignored-return-value-warnings.patch \
@@ -75,6 +76,7 @@ ONL_PLATFORM_SUPPORT:arm = " \
 
 ONL_PLATFORM_SUPPORT:x86-64 = " \
     x86-64-accton-as4630-54pe-r0 \
+    x86-64-accton-as4630-54te-r0 \
     x86-64-accton-as5835-54x-r0 \
     x86-64-accton-as7726-32x-r0 \
     x86-64-cel-questone-2a-r0 \

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -43,6 +43,7 @@ SRC_URI += " \
            file://accton-as4630-54pe/0005-accton-as4630-54pe-Avoid-undefined-behaviour.patch \
            file://accton-as4630-54te/0001-accton-as4630-54te-silence-unused-result-warning.patch \
            file://accton-as4630-54te/0002-Edgecore-as4630_54te-Update-thermal-threshold.patch \
+           file://accton-as4630-54te/0003-Edgecore-as4630_54te-Support-YM-1151F-power-supply.patch \
            file://accton-as5835-54x/0001-AS5835-54x-Support-psu_fan_dir-sysfs-for-YM-1401A-PS.patch \
            file://accton-as5835-54x/0002-as5835-rename-psu_serial_numer-psu_serial_number.patch \
            file://accton-as7726-32x/0001-as7726-32x-silence-ignored-return-value-warnings.patch \

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -42,6 +42,7 @@ SRC_URI += " \
            file://accton-as4630-54pe/0004-accton-as4630-54pe-silence-error.patch \
            file://accton-as4630-54pe/0005-accton-as4630-54pe-Avoid-undefined-behaviour.patch \
            file://accton-as4630-54te/0001-accton-as4630-54te-silence-unused-result-warning.patch \
+           file://accton-as4630-54te/0002-Edgecore-as4630_54te-Update-thermal-threshold.patch \
            file://accton-as5835-54x/0001-AS5835-54x-Support-psu_fan_dir-sysfs-for-YM-1401A-PS.patch \
            file://accton-as5835-54x/0002-as5835-rename-psu_serial_numer-psu_serial_number.patch \
            file://accton-as7726-32x/0001-as7726-32x-silence-ignored-return-value-warnings.patch \


### PR DESCRIPTION
Add support for Edgecore EPS201 (Accton AS4630-54TE) to the accton-as4630-54pe machine.

The AS4630-54TE and AS4630-54PE are very similar, with the main difference being PoE support and the used PSUs.

So enhance the existing AS4630-54PE image with AS4630-54TE support by enabling the support in ONL, and update the platform init script to load the appropriate modules based on the platform.

Also import to (currently open) PRs from ONL itself to [set proper thermal thresholds](https://github.com/opencomputeproject/OpenNetworkLinux/pull/906), and [support the PSU that is found in our device correctly](https://github.com/opencomputeproject/OpenNetworkLinux/pull/907).

We do not need to [disable iommu](https://github.com/opencomputeproject/OpenNetworkLinux/pull/897) as we already do that.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>