### PR TITLE
move management port config from /etc/systemd/network to /lib/systemd/network

### DIFF
--- a/recipes-core/platform-as4610/platform-as4610_0.1.bb
+++ b/recipes-core/platform-as4610/platform-as4610_0.1.bb
@@ -18,7 +18,7 @@ SRC_URI += " \
 FILES:${PN} = " \
     ${systemd_system_unitdir}/platform-as4610-init.service \
     ${bindir}/platform-as4610-init.sh \
-    ${sysconfdir}/systemd/network/90-enp.link \
+    ${systemd_unitdir}/network/90-enp.link \
     ${sysconfdir}/fw_env.config \
 "
 
@@ -29,9 +29,10 @@ do_install() {
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/platform-as4610-init.sh ${D}${bindir}
         # systemd-networkd
-        install -d ${D}${sysconfdir}/systemd/network/
-        install -m 0644 ${WORKDIR}/*.link ${D}${sysconfdir}/systemd/network/
+        install -d ${D}${systemd_unitdir}/network/
+        install -m 0644 ${WORKDIR}/*.link ${D}${systemd_unitdir}/network/
         # uboot env
+        install -d ${D}${sysconfdir}
         install -m 0644 ${WORKDIR}/fw_env.config ${D}/${sysconfdir}/
 }
 

--- a/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
+++ b/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
@@ -16,7 +16,7 @@ SRC_URI += " \
 FILES:${PN} = " \
     ${systemd_system_unitdir}/platform-as4630-54pe-init.service \
     ${bindir}/platform-as4630-54pe-init.sh \
-    ${sysconfdir}/systemd/network/90-enp.link \
+    ${systemd_unitdir}/network/90-enp.link \
 "
 
 
@@ -27,8 +27,8 @@ do_install() {
         install -m 0755 ${WORKDIR}/platform-as4630-54pe-init.sh ${D}${bindir}
 
         # systemd-networkd
-        install -d ${D}${sysconfdir}/systemd/network/
-        install -m 0644 ${WORKDIR}/*.link ${D}${sysconfdir}/systemd/network/
+        install -d ${D}${systemd_unitdir}/network/
+        install -m 0644 ${WORKDIR}/*.link ${D}${systemd_unitdir}/network/
 }
 
 SYSTEMD_SERVICE:${PN}:append = "platform-as4630-54pe-init.service"


### PR DESCRIPTION
The 90-enp.link isn't part of user configuration, and should therefore
be in /lib/systemd/network instead of /etc/systemd/network, so move it
there.

Only Accton AS4610 and Accton AS4630-54PE ship a 90-enp.link, other platforms are not affected.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>