### PR TITLE
platform-questone-2a: load switchboard cpld module

### DIFF
--- a/recipes-core/platform-questone-2a/files/platform-questone-2a-init.sh
+++ b/recipes-core/platform-questone-2a/files/platform-questone-2a-init.sh
@@ -18,3 +18,6 @@ function wait_for_file() {
 # PCA9547 modulize
 wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev 24lc64t 0x56 1
+
+# load baseboard cpld module
+modprobe questone2a_baseboard_cpld


### PR DESCRIPTION
Make sure the switchboard_cpld module is loaded, else onlpdump will
throw errors.

the switchboard_cpld was autoloaded when it was built seperately, but
yocto did not provide this anymore when we moved the module build into
ONL.

Fix this by loading the moedule explicitly when initializing the
platform, like we do for all other platforms.

Fixed the following errors shown by onlpdump:

sh: line 1: /sys/devices/platform/sys_cpld/getreg: No such file or directory
cat: can't open '/sys/devices/platform/sys_cpld/getreg': No such file or directory
 PSU 1
   Description: PSU-Left
   State: Missing
 PSU 2
   Description: PSU-Right
   State: Missing
 LED 1
sh: line 1: /sys/devices/platform/sys_cpld/getreg: No such file or directory
cat: can't open '/sys/devices/platform/sys_cpld/getreg': No such file or directory
   Description: System LED
   State: Present
   Mode: OFF

Fixes: 75e0c3589806 ("cel-questone-2a: build platform modules via ONL")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>