### PR TITLE
platform-as4630-54pe: make sure optoe device is present

### DIFF
--- a/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
+++ b/recipes-core/platform-as4630-54pe/files/platform-as4630-54pe-init.sh
@@ -6,8 +6,20 @@ create_i2c_dev() {
   echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
+function wait_for_file() {
+	FILE=$1
+	i=0
+	while [ $i -lt 10 ]; do
+		test -e $FILE && return 0
+		i=$(( i + 1 ))
+		sleep 1
+	done
+	return 1
+}
+
 add_port() {
 	create_i2c_dev ${1} 0x50 ${3}
+	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"
 	echo "port${2}" > "/sys/bus/i2c/devices/${3}-0050/port_name"
 }
 


### PR DESCRIPTION
When the optoe module is loaded on demand, the first optoe device
creation may be slow enough that the port_name file does not exist yet
when we try to set it.

Fix this by wating for it to exist before we try to write to it.

Fixes the following error on boot:

```
Aug 25 08:42:19 accton-as4630-54pe systemd[1]: Starting Setup platform as4630-54pe...
Aug 25 08:42:20 accton-as4630-54pe platform-as4630-54pe-init.sh[2013]: /usr/bin/platform-as4630-54pe-init.sh: line 11: /sys/bus/i2c/devices/18-0050/port_name: Permission denied
Aug 25 08:42:20 accton-as4630-54pe systemd[1]: platform-as4630-54pe-init.service: Main process exited, code=exited, status=1/FAILURE
Aug 25 08:42:20 accton-as4630-54pe systemd[1]: platform-as4630-54pe-init.service: Failed with result 'exit-code'.
```

Fixes: 70ef7c292ad3 ("onl: build common kernel modules within onl")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>