### PR TITLE
accton-as4610: fix on-demand loading of modules

### DIFF
--- a/recipes-extended/onl/files/accton-as4610/0004-accton_as4610_cpld-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/accton-as4610/0004-accton_as4610_cpld-add-of-device-match-table.patch
@@ -1,0 +1,51 @@
+Upstream-Status: Unsubmitted
+
+From b7f587d0718b12d0c68886bfce2b55b4496ab976 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 12:09:49 +0200
+Subject: [PATCH 1/5] accton_as4610_cpld: add of device match table
+
+For on-demand loading to work the kernel needs to know which compatibles
+are handled by the driver, so add an appropriate table.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../armxx/arm-accton-as4610/modules/accton_as4610_cpld.c  | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+index 2ee2d1631095..767bdd11ecd5 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+@@ -33,6 +33,7 @@
+ #include <linux/stat.h>
+ #include <linux/hwmon-sysfs.h>
+ #include <linux/delay.h>
++#include <linux/of.h>
+ 
+ #define I2C_RW_RETRY_COUNT				10
+ #define I2C_RW_RETRY_INTERVAL			60 /* ms */
+@@ -73,6 +74,12 @@ static const struct i2c_device_id as4610_54_cpld_id[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, as4610_54_cpld_id);
+ 
++static const struct of_device_id as4610_54_cpld_of_id[] = {
++    { .compatible = "accton,as4610_54_cpld", .data = as4610_54_cpld },
++    { }
++};
++MODULE_DEVICE_TABLE(of, as4610_54_cpld_of_id);
++
+ #define TRANSCEIVER_PRESENT_ATTR_ID(index)   	MODULE_PRESENT_##index
+ #define TRANSCEIVER_TXDISABLE_ATTR_ID(index)   	MODULE_TXDISABLE_##index
+ #define TRANSCEIVER_RXLOS_ATTR_ID(index)   		MODULE_RXLOS_##index
+@@ -601,6 +608,7 @@ static struct i2c_driver as4610_54_cpld_driver = {
+ 	.driver		= {
+ 		.name	= "as4610_54_cpld",
+ 		.owner	= THIS_MODULE,
++		.of_match_table = as4610_54_cpld_of_id,
+ 	},
+ 	.probe		= as4610_54_cpld_probe,
+ 	.remove		= as4610_54_cpld_remove,
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4610/0005-accton_as4610_psu-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/accton-as4610/0005-accton_as4610_psu-add-of-device-match-table.patch
@@ -1,0 +1,49 @@
+Upstream-Status: Unsubmitted
+
+From ccf52b835ec13e478a7b9e78967dd6126270c4ec Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 12:10:23 +0200
+Subject: [PATCH 2/5] accton_as4610_psu: add of device match table
+
+For on-demand loading to work the kernel needs to know which compatibles
+are handled by the driver, so add an appropriate table.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../armxx/arm-accton-as4610/modules/accton_as4610_psu.c  | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_psu.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_psu.c
+index 9a579e79aec9..c29b9350ee7f 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_psu.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_psu.c
+@@ -33,6 +33,7 @@
+ #include <linux/slab.h>
+ #include <linux/delay.h>
+ #include <linux/dmi.h>
++#include <linux/of.h>
+ 
+ #define MAX_MODEL_NAME 11
+ #define MAX_SERIAL_NUMBER 18
+@@ -204,10 +205,18 @@ static const struct i2c_device_id as4610_psu_id[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, as4610_psu_id);
+ 
++static const struct of_device_id as4610_psu_of_id[] = {
++	{ .compatible = "accton,as4610_psu1", .data = as4610_psu1 },
++	{ .compatible = "accton,as4610_psu2", .data = as4610_psu2 },
++	{}
++};
++MODULE_DEVICE_TABLE(of, as4610_psu_of_id);
++
+ static struct i2c_driver as4610_psu_driver = {
+ 	.class		  = I2C_CLASS_HWMON,
+ 	.driver = {
+ 		.name	  = "as4610_psu",
++		.of_match_table = as4610_psu_of_id,
+ 	},
+ 	.probe		  = as4610_psu_probe,
+ 	.remove		  = as4610_psu_remove,
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4610/0006-accton-as4610-let-CPLD-handle-the-FAN-device.patch
+++ b/recipes-extended/onl/files/accton-as4610/0006-accton-as4610-let-CPLD-handle-the-FAN-device.patch
@@ -1,0 +1,212 @@
+Upstream-Status: Unsubmitted
+
+From 7bd9ca8fc5bf7eaeb3cc7e1b5b79518b35be32fd Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 12:22:19 +0200
+Subject: [PATCH 3/5] accton-as4610: let CPLD handle the FAN device
+
+The FAN device directly depends on the CPLD device, so let it be created
+by the CPLD driver. This allows us to convert the FAN driver to a simple
+platform driver.
+
+Ideally this would be handled as a MFD device, but this would require
+more substantial changes.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../modules/accton_as4610_cpld.c              | 27 ++++++
+ .../modules/accton_as4610_fan.c               | 86 ++++---------------
+ 2 files changed, 42 insertions(+), 71 deletions(-)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+index 767bdd11ecd5..967d087fa34b 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+@@ -34,6 +34,7 @@
+ #include <linux/hwmon-sysfs.h>
+ #include <linux/delay.h>
+ #include <linux/of.h>
++#include <linux/platform_device.h>
+ 
+ #define I2C_RW_RETRY_COUNT				10
+ #define I2C_RW_RETRY_INTERVAL			60 /* ms */
+@@ -65,6 +66,7 @@ enum as4610_product_id_e {
+ struct as4610_54_cpld_data {
+     enum cpld_type   type;
+     struct device   *hwmon_dev;
++    struct platform_device *fan_pdev;
+     struct mutex     update_lock;
+ };
+ 
+@@ -450,6 +452,8 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
+     return sprintf(buf, "%d", val);
+ }
+ 
++int as4610_product_id(void);
++
+ /* I2C init/probing/exit functions */
+ static int as4610_54_cpld_probe(struct i2c_client *client,
+ 			 const struct i2c_device_id *id)
+@@ -479,8 +483,28 @@ static int as4610_54_cpld_probe(struct i2c_client *client,
+     }
+ 
+     as4610_54_cpld_add_client(client);
++
++    switch (as4610_product_id()) {
++    case PID_AS4610_30P:
++    case PID_AS4610_54P:
++    case PID_AS4610_54T_B:
++	    data->fan_pdev = platform_device_register_simple("as4610_fan", -1, NULL, 0);
++	    if (IS_ERR(data->fan_pdev)) {
++		    ret = PTR_ERR(data->fan_pdev);
++		    goto exit_unregister;
++	    }
++	    break;
++    default:
++	    /* no fan */
++	    break;
++    }
++
+     return 0;
+ 
++exit_unregister:
++    as4610_54_cpld_remove_client(client);
++    /* Remove sysfs hooks */
++    sysfs_remove_group(&client->dev.kobj, &as4610_54_cpld_group);
+ exit_free:
+     kfree(data);
+ exit:
+@@ -491,6 +515,9 @@ static int as4610_54_cpld_remove(struct i2c_client *client)
+ {
+     struct as4610_54_cpld_data *data = i2c_get_clientdata(client);
+ 
++    if (data->fan_pdev)
++	    platform_device_unregister(data->fan_pdev);
++
+     as4610_54_cpld_remove_client(client);
+ 
+     /* Remove sysfs hooks */
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
+index 9b134e56922d..2e14798a9721 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
+@@ -255,11 +255,19 @@ static int as4610_fan_probe(struct platform_device *pdev)
+ {
+ 	int status = -1;
+ 
++	fan_data = kzalloc(sizeof(struct as4610_fan_data), GFP_KERNEL);
++	if (!fan_data) {
++		status = -ENOMEM;
++		goto exit;
++	}
++
++	mutex_init(&fan_data->update_lock);
++	fan_data->valid = 0;
++
+ 	/* Register sysfs hooks */
+ 	status = sysfs_create_group(&pdev->dev.kobj, &as4610_fan_group);
+ 	if (status) {
+-		goto exit;
+-
++		goto exit_free;
+ 	}
+ 
+ 	fan_data->hwmon_dev = hwmon_device_register_with_info(&pdev->dev, "as4610_fan",
+@@ -275,6 +283,8 @@ static int as4610_fan_probe(struct platform_device *pdev)
+ 
+ exit_remove:
+ 	sysfs_remove_group(&pdev->dev.kobj, &as4610_fan_group);
++exit_free:
++	kfree(fan_data);
+ exit:
+ 	return status;
+ }
+@@ -284,6 +294,8 @@ static int as4610_fan_remove(struct platform_device *pdev)
+ 	hwmon_device_unregister(fan_data->hwmon_dev);
+ 	sysfs_remove_group(&pdev->dev.kobj, &as4610_fan_group);
+ 
++	kfree(fan_data);
++
+ 	return 0;
+ }
+ 
+@@ -302,75 +314,7 @@ static struct platform_driver as4610_fan_driver = {
+ 	},
+ };
+ 
+-static int as4610_number_of_system_fan(void)
+-{
+-	int nFan = 0;
+-	int pid = as4610_product_id();
+-
+-	switch (pid) {
+-	case PID_AS4610_30P:
+-	case PID_AS4610_54P:
+-		nFan = 1;
+-		break;
+-	case PID_AS4610_54T_B:
+-		nFan = 2;
+-		break;
+-	default:
+-		nFan = 0;
+-		break;
+-	}
+-
+-	return nFan;
+-}
+-
+-static int __init as4610_fan_init(void)
+-{
+-	int ret;
+-
+-	if (as4610_number_of_system_fan() == 0) {
+-		return 0;
+-	}
+-
+-	ret = platform_driver_register(&as4610_fan_driver);
+-	if (ret < 0) {
+-		goto exit;
+-	}
+-
+-	fan_data = kzalloc(sizeof(struct as4610_fan_data), GFP_KERNEL);
+-	if (!fan_data) {
+-		ret = -ENOMEM;
+-		platform_driver_unregister(&as4610_fan_driver);
+-		goto exit;
+-	}
+-
+-	mutex_init(&fan_data->update_lock);
+-	fan_data->valid = 0;
+-
+-	fan_data->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+-	if (IS_ERR(fan_data->pdev)) {
+-		ret = PTR_ERR(fan_data->pdev);
+-		platform_driver_unregister(&as4610_fan_driver);
+-		kfree(fan_data);
+-		goto exit;
+-	}
+-
+-exit:
+-	return ret;
+-}
+-
+-static void __exit as4610_fan_exit(void)
+-{
+-	if (!fan_data) {
+-		return;
+-	}
+-
+-	platform_device_unregister(fan_data->pdev);
+-	platform_driver_unregister(&as4610_fan_driver);
+-	kfree(fan_data);
+-}
+-
+-late_initcall(as4610_fan_init);
+-module_exit(as4610_fan_exit);
++module_platform_driver(as4610_fan_driver);
+ 
+ MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+ MODULE_DESCRIPTION("as4610_fan driver");
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4610/0007-accton-as4610-fix-FAN-driver-id-table.patch
+++ b/recipes-extended/onl/files/accton-as4610/0007-accton-as4610-fix-FAN-driver-id-table.patch
@@ -1,0 +1,41 @@
+Upstream-Status: Unsubmitted
+
+From 80a2852c20fe5c8d4d8c134028201bd8a7a54f3b Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 14:16:09 +0200
+Subject: [PATCH 4/5] accton-as4610: fix FAN driver id table
+
+This is a platform driver, not an I2C driver, so fix and add the id
+table to the driver.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../armxx/arm-accton-as4610/modules/accton_as4610_fan.c      | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
+index 2e14798a9721..ff75c0f9d464 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
+@@ -299,15 +299,16 @@ static int as4610_fan_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
+-static const struct i2c_device_id as4610_fan_id[] = {
++static const struct platform_device_id as4610_fan_id[] = {
+ 	{ "as4610_fan", 0 },
+ 	{}
+ };
+-MODULE_DEVICE_TABLE(i2c, as4610_fan_id);
++MODULE_DEVICE_TABLE(platform, as4610_fan_id);
+ 
+ static struct platform_driver as4610_fan_driver = {
+ 	.probe		= as4610_fan_probe,
+ 	.remove		= as4610_fan_remove,
++	.id_table	= as4610_fan_id,
+ 	.driver		= {
+ 		.name	= DRVNAME,
+ 		.owner	= THIS_MODULE,
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/accton-as4610/0008-accton-as4610-let-CPLD-handle-the-LED-device.patch
+++ b/recipes-extended/onl/files/accton-as4610/0008-accton-as4610-let-CPLD-handle-the-LED-device.patch
@@ -1,0 +1,203 @@
+Upstream-Status: Unsubmitted
+
+From f2f6b43f603a9214bedeb9ea305c32c38cc693cb Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 14:26:51 +0200
+Subject: [PATCH 5/5] accton-as4610: let CPLD handle the LED device
+
+The LED device directly depends on the CPLD device, so let it be created
+by the CPLD driver. This allows us to convert the LED driver to a simple
+platform driver.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../modules/accton_as4610_cpld.c              | 20 ++++-
+ .../modules/accton_as4610_leds.c              | 77 ++++++-------------
+ 2 files changed, 43 insertions(+), 54 deletions(-)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+index 967d087fa34b..ee950c3042c7 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+@@ -67,6 +67,7 @@ struct as4610_54_cpld_data {
+     enum cpld_type   type;
+     struct device   *hwmon_dev;
+     struct platform_device *fan_pdev;
++    struct platform_device *led_pdev;
+     struct mutex     update_lock;
+ };
+ 
+@@ -461,6 +462,7 @@ static int as4610_54_cpld_probe(struct i2c_client *client,
+ 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
+ 	struct as4610_54_cpld_data *data;
+ 	int ret = -ENODEV;
++	int pid;
+ 
+ 	if (!i2c_check_functionality(adap, I2C_FUNC_SMBUS_BYTE))
+ 		goto exit;
+@@ -484,7 +486,9 @@ static int as4610_54_cpld_probe(struct i2c_client *client,
+ 
+     as4610_54_cpld_add_client(client);
+ 
+-    switch (as4610_product_id()) {
++    pid = as4610_product_id();
++
++    switch (pid) {
+     case PID_AS4610_30P:
+     case PID_AS4610_54P:
+     case PID_AS4610_54T_B:
+@@ -499,8 +503,19 @@ static int as4610_54_cpld_probe(struct i2c_client *client,
+ 	    break;
+     }
+ 
++    if (pid != PID_UNKNOWN) {
++	data->led_pdev = platform_device_register_simple("as4610_led", -1, NULL, 0);
++	    if (IS_ERR(data->led_pdev)) {
++		    ret = PTR_ERR(data->led_pdev);
++		    goto exit_unregister_fan;
++	    }
++    }
++
+     return 0;
+ 
++exit_unregister_fan:
++    platform_device_unregister(data->fan_pdev);
++
+ exit_unregister:
+     as4610_54_cpld_remove_client(client);
+     /* Remove sysfs hooks */
+@@ -515,6 +530,9 @@ static int as4610_54_cpld_remove(struct i2c_client *client)
+ {
+     struct as4610_54_cpld_data *data = i2c_get_clientdata(client);
+ 
++    if (data->led_pdev)
++	    platform_device_unregister(data->led_pdev);
++
+     if (data->fan_pdev)
+ 	    platform_device_unregister(data->fan_pdev);
+ 
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_leds.c b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_leds.c
+index 5771b0a55c1a..cb3859c1fabc 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_leds.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_leds.c
+@@ -22,6 +22,7 @@
+ /*#define DEBUG*/
+ 
+ #include <linux/module.h>
++#include <linux/mod_devicetable.h>
+ #include <linux/kernel.h>
+ #include <linux/init.h>
+ #include <linux/platform_device.h>
+@@ -575,6 +576,19 @@ static int as4610_led_probe(struct platform_device *pdev)
+ {
+ 	int ret = 0, i;
+ 
++	int pid = as4610_product_id();
++	if (pid == PID_UNKNOWN) {
++		return -ENODEV;
++	}
++
++	ledctl = kzalloc(sizeof(struct as4610_led_data), GFP_KERNEL);
++	if (!ledctl) {
++		return -ENOMEM;
++	}
++
++	ledctl->led_map = as4610_ledmaps[pid];
++	mutex_init(&ledctl->update_lock);
++
+ 	for (i = 0; i < NUM_OF_LED; i++) {
+ 		if (!(ledctl->led_map & BIT(i))) {
+ 			continue;
+@@ -597,6 +611,7 @@ error:
+ 
+ 		led_classdev_unregister(&as4610_leds[i]);
+ 	}
++	kfree(ledctl);
+ 
+ 	return ret;
+ }
+@@ -612,72 +627,28 @@ static int as4610_led_remove(struct platform_device *pdev)
+ 
+ 		led_classdev_unregister(&as4610_leds[i]);
+ 	}
++	kfree(ledctl);
+ 
+ 	return 0;
+ }
+ 
++static const struct platform_device_id as4610_led_id[] = {
++	{ "as4610_led", 0 },
++	{}
++};
++MODULE_DEVICE_TABLE(platform, as4610_led_id);
++
+ static struct platform_driver as4610_led_driver = {
+ 	.probe		= as4610_led_probe,
+ 	.remove		= as4610_led_remove,
++	.id_table	= as4610_led_id,
+ 	.driver		= {
+ 	.name	= DRVNAME,
+ 	.owner	= THIS_MODULE,
+ 	},
+ };
+ 
+-static int __init as4610_led_init(void)
+-{
+-	int ret, pid;
+-
+-	if (as4610_product_id() == PID_UNKNOWN) {
+-		return -ENODEV;
+-	}
+-
+-	ret = platform_driver_register(&as4610_led_driver);
+-	if (ret < 0) {
+-		goto exit;
+-	}
+-
+-	ledctl = kzalloc(sizeof(struct as4610_led_data), GFP_KERNEL);
+-	if (!ledctl) {
+-		ret = -ENOMEM;
+-		platform_driver_unregister(&as4610_led_driver);
+-		goto exit;
+-	}
+-
+-	pid = as4610_product_id();
+-	if (pid == PID_UNKNOWN) {
+-		return -ENODEV;
+-	}
+-
+-	ledctl->led_map = as4610_ledmaps[pid];
+-	mutex_init(&ledctl->update_lock);
+-
+-	ledctl->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+-	if (IS_ERR(ledctl->pdev)) {
+-		ret = PTR_ERR(ledctl->pdev);
+-		platform_driver_unregister(&as4610_led_driver);
+-		kfree(ledctl);
+-		goto exit;
+-	}
+-
+-exit:
+-	return ret;
+-}
+-
+-static void __exit as4610_led_exit(void)
+-{
+-	if (!ledctl) {
+-		return;
+-	}
+-
+-	platform_device_unregister(ledctl->pdev);
+-	platform_driver_unregister(&as4610_led_driver);
+-	kfree(ledctl);
+-}
+-
+-late_initcall(as4610_led_init);
+-module_exit(as4610_led_exit);
++module_platform_driver(as4610_led_driver);
+ 
+ MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+ MODULE_DESCRIPTION("as4610_led driver");
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/onl/0013-optoe-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0013-optoe-add-of-device-match-table.patch
@@ -1,0 +1,57 @@
+Upstream-Status: Unsubmitted [also these aren't proper compatible names]
+
+From 61ecfec197d29d2434a3a1f21fca19df1fba0968 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 11:43:30 +0200
+Subject: [PATCH 1/2] optoe: add of device match table
+
+For on-demand loading to work the kernel needs to know which compatibles
+are handled by the driver, so add an appropriate table.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ packages/base/any/kernels/modules/optoe.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/packages/base/any/kernels/modules/optoe.c b/packages/base/any/kernels/modules/optoe.c
+index 464a69326be1..dae5e5b5d5f9 100644
+--- a/packages/base/any/kernels/modules/optoe.c
++++ b/packages/base/any/kernels/modules/optoe.c
+@@ -125,6 +125,7 @@
+ #include <linux/sysfs.h>
+ #include <linux/jiffies.h>
+ #include <linux/i2c.h>
++#include <linux/of.h>
+ #include <linux/version.h>
+ 
+ #ifdef EEPROM_CLASS
+@@ -246,6 +247,18 @@ static const struct i2c_device_id optoe_ids[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, optoe_ids);
+ 
++#ifdef CONFIG_OF
++static const struct of_device_id optoe_of_ids[] = {
++	{ .compatible = "optoe1", .data = ONE_ADDR },
++	{ .compatible = "optoe2", .data = TWO_ADDR },
++	{ .compatible = "optoe3", .data = CMIS_ADDR },
++	{ .compatible = "sff8436", .data = ONE_ADDR },
++	{ .compatible = "24c04", .data = TWO_ADDR },
++	{ /* END OF LIST */ }
++};
++MODULE_DEVICE_TABLE(of, optoe_of_ids);
++#endif
++
+ /*-------------------------------------------------------------------------*/
+ /*
+  * This routine computes the addressing information to be used for
+@@ -1179,6 +1192,7 @@ static struct i2c_driver optoe_driver = {
+ 	.driver = {
+ 		.name = "optoe",
+ 		.owner = THIS_MODULE,
++		.of_match_table = of_match_ptr(optoe_of_ids),
+ 	},
+ 	.probe = optoe_probe,
+ 	.remove = optoe_remove,
+-- 
+2.37.2
+

--- a/recipes-extended/onl/files/onl/0014-ym2561y-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0014-ym2561y-add-of-device-match-table.patch
@@ -1,0 +1,54 @@
+Upstream-Status: Unsubmitted
+
+From e4d145132b2dc3922af537c2f8cf87661d04be6f Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 26 Aug 2022 11:49:20 +0200
+Subject: [PATCH 2/2] ym2561y: add of device match table
+
+For on-demand loading to work the kernel needs to know which compatibles
+are handled by the driver, so add an appropriate table.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ packages/base/any/kernels/modules/ym2651y.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/packages/base/any/kernels/modules/ym2651y.c b/packages/base/any/kernels/modules/ym2651y.c
+index 5964e28afc3e..ef89ef22db86 100755
+--- a/packages/base/any/kernels/modules/ym2651y.c
++++ b/packages/base/any/kernels/modules/ym2651y.c
+@@ -33,6 +33,7 @@
+ #include <linux/slab.h>
+ #include <linux/delay.h>
+ #include <linux/string.h>
++#include <linux/of.h>
+ #include <linux/version.h>
+ 
+ #define MAX_FAN_DUTY_CYCLE      100
+@@ -601,10 +602,23 @@ static const struct i2c_device_id ym2651y_id[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, ym2651y_id);
+ 
++#ifdef CONFIG_OF
++static const struct of_device_id ym2651y_of_id[] = {
++    { .compatible = "3y-power,ym2651", .data = YM2651 },
++    { .compatible = "3y.power,ym2401", .data = YM2401 },
++    { .compatible = "3y-power,ym2851", .data = YM2851 },
++    { .compatible = "3y-power,ym1921", .data = YM1921 },
++    { .compatible = "3y-power,ype1200am", .data = YPEB1200AM },
++    {}
++};
++MODULE_DEVICE_TABLE(of, ym2651y_of_id);
++#endif
++
+ static struct i2c_driver ym2651y_driver = {
+     .class      = I2C_CLASS_HWMON,
+     .driver = {
+         .name   = "ym2651",
++        .of_match_table = of_match_ptr(ym2651y_of_id),
+     },
+     .probe    = ym2651y_probe,
+     .remove   = ym2651y_remove,
+-- 
+2.37.2
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -26,6 +26,8 @@ SRC_URI += " \
            file://onl/0010-tools-replace-yaml.load-with-yaml.full_load.patch \
            file://onl/0011-optoe-allow-compilation-with-linux-5.5-and-newer.patch \
            file://onl/0012-kmodbuild.sh-don-t-treat-undefined-symbols-as-errors.patch \
+           file://onl/0013-optoe-add-of-device-match-table.patch \
+           file://onl/0014-ym2561y-add-of-device-match-table.patch \
            file://bigcode/0001-WIP-convert-to-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0002-dynamically-determine-location-of-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0003-avoid-multiple-global-definitions-for-not_empty.patch;patchdir=${SUBMODULE_BIGCODE} \
@@ -36,6 +38,11 @@ SRC_URI += " \
            file://accton-as4610/0001-accton-as4610-fix-buffer-overflow-while-accessing-le.patch \
            file://accton-as4610/0002-accton-as4610-fix-value-truncation-when-accessing-le.patch \
            file://accton-as4610/0003-accton-as4610-do-not-try-to-read-out-PSU-values-for-.patch \
+           file://accton-as4610/0004-accton_as4610_cpld-add-of-device-match-table.patch \
+           file://accton-as4610/0005-accton_as4610_psu-add-of-device-match-table.patch \
+           file://accton-as4610/0006-accton-as4610-let-CPLD-handle-the-FAN-device.patch \
+           file://accton-as4610/0007-accton-as4610-fix-FAN-driver-id-table.patch \
+           file://accton-as4610/0008-accton-as4610-let-CPLD-handle-the-LED-device.patch \
            file://accton-as4630-54pe/0001-as4630-54pe-Add-SFP-reset-sysfs-and-fix-Led-drv.patch \
            file://accton-as4630-54pe/0002-Add-rest-lpmode-code-to-sfpi_control-set-get-api.patch \
            file://accton-as4630-54pe/0003-Fix-fan-direction-api.patch \


### PR DESCRIPTION
Fix the on-demand loading of modules by providing proper id tables for
all relevant drivers, and let the CPLD driver instantiate the LED and
FAN devices if present instead of the modules themselves in their init
functions.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>