### PR TITLE
linux-yocto-onl: update to 5.15.64

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.56"
+LINUX_VERSION ?= "5.15.64"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "760adb59f6211e157dd587927ac26c42abc81550"
+SRCREV_machine ?= "1ded0ef2419e8f83a17d65594523ec3aeb2e3d0f"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "624cd634ceb095c2949b1cf8b69b0c96b098cb44"
+SRCREV_meta ?= "8fa8d5e477034473ed7532fe20006b5f2bc87aa0"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 5.15.64 and kernel meta to HEAD in absence
of a 5.15.64 commit.

Most interesting change is from 5.15.64:

    bonding: 802.3ad: fix no transmission of LACPDUs

    [ Upstream commit d745b5062ad2b5da90a5e728d7ca884fc07315fd ]

    This is caused by the global variable ad_ticks_per_sec being zero as
    demonstrated by the reproducer script discussed below. This causes
    all timer values in __ad_timer_to_ticks to be zero, resulting
    in the periodic timer to never fire.

(reproducer omitted)

Changelogs for the kernel:

* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.64
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.63
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.62
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.61
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.60
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.59
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.58
* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.57

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>