### PR TITLE
accton-as4610: no need to remove grub anymore

### DIFF
--- a/conf/machine/accton-as4610.conf
+++ b/conf/machine/accton-as4610.conf
@@ -14,8 +14,6 @@ require conf/machine/include/qemu.inc
 require conf/machine/include/arm/armv7a/tune-cortexa9.inc
 require conf/machine/include/onl.inc
 
-BISDN_SWITCH_IMAGE_EXTRA_INSTALL:remove = "grub"
-
 MACHINE_FEATURES += "pcbios"
 MACHINE_FEATURES:remove = "alsa"
 


### PR DESCRIPTION
Now that we do not try to install grub for arm anymore, we also don't
need to remove it anymore.

Depends on https://github.com/bisdn/meta-switch/pull/113

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>