### PR TITLE
agema-ag5648: add support for delta_ag5648v1 variant

### DIFF
--- a/conf/machine/agema-ag5648.conf
+++ b/conf/machine/agema-ag5648.conf
@@ -24,6 +24,11 @@ BISDN_ONIE_MACHINE = "ag5648"
 ONIE_VENDOR = "delta"
 ONIE_MACHINE_TYPE = "ag5648"
 
+ONL_PLATFORM_SUPPORT = " \
+    x86_64-delta_ag5648-r0 \
+    x86_64-delta_ag5648v1-r0 \
+"
+
 # delta-ag5648's i2c-cpld is part of delta's common vendor modules
 ONL_MODULE_VENDORS = "delta"
 

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -80,6 +80,9 @@ def onl_arch_map(arch, tune):
 ONL_BUILD_ARCH = "${@onl_arch_map(d.getVar('TARGET_ARCH'), d.getVar('TUNE_FEATURES'))}"
 ONL_DEBIAN_SUITE = "buster"
 
+ONL_PLATFORMS_BUILD = "${ONL_PLATFORM_SUPPORT}"
+ONL_PLATFORMS_BUILD:remove = "${ONL_PLATFORMS_IGNORE}"
+
 ###
 # TODO CFLAGS?
 EXTRA_OEMAKE = "\
@@ -130,7 +133,7 @@ do_compile() {
   ${S}/tools/scripts/kmodbuild.sh "${STAGING_KERNEL_BUILDDIR}" "$mods" "onl/onl/common"
   cd -
 
-  for onie_platform in ${ONL_PLATFORM_SUPPORT}; do
+  for onie_platform in ${ONL_PLATFORMS_BUILD}; do
       # onl uses dashes instead of undescores for platforms
       platform="$(echo $onie_platform | tr '_' '-')"
 
@@ -182,7 +185,7 @@ do_install() {
   mkdir -p ${D}${nonarch_base_libdir}/modules
   cp -r onl-modules/lib/modules ${D}${nonarch_base_libdir}
 
-  for onie_platform in ${ONL_PLATFORM_SUPPORT}; do
+  for onie_platform in ${ONL_PLATFORMS_BUILD}; do
       # onl uses dashes instead of undescores for platforms
       platform="$(echo $onie_platform | tr '_' '-')"
       # get the path to the platform

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -81,6 +81,9 @@ FILES:${PN} = " \
 # ONIE platforms that should not be built
 ONL_PLATFORMS_IGNORE = ""
 
+# delta_ag5648v1 is an alias for delta_ag5648
+ONL_PLATFORMS_IGNORE += "x86_64-delta_ag5648v1-r0"
+
 # for some unknown reason this module causes a deadlock when loaded too
 # late, so force it being loaded earlier by loading it explicitly
 KERNEL_MODULE_AUTOLOAD = "x86-64-delta-ag7648-i2c-mux-setting"

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -78,6 +78,9 @@ FILES:${PN} = " \
   ${libdir}/libonlp*.so.1 \
 "
 
+# ONIE platforms that should not be built
+ONL_PLATFORMS_IGNORE = ""
+
 # for some unknown reason this module causes a deadlock when loaded too
 # late, so force it being loaded earlier by loading it explicitly
 KERNEL_MODULE_AUTOLOAD = "x86-64-delta-ag7648-i2c-mux-setting"


### PR DESCRIPTION
It looks like some (newer?) variants of Delta AG5648V1 report themselves as delta_ag5648v1 instead of the expected delta_ag5648 in [ONIE](https://github.com/opencomputeproject/onie/tree/master/machine/delta) as their machine name. This causes issues as there is no such machine in ONIE, nor in [ONL](https://github.com/opencomputeproject/OpenNetworkLinux/tree/master/packages/platforms/delta/x86-64).

Under the assumption that hardware-wise the AG5648V1 identifying as delta_ag5648 and the one identifying as delta_ag5648v1 are identical, add it to ONL_PLATFORM_SUPPORT and tell ONL to not try to build anything for it.

Depends on https://github.com/bisdn/meta-switch/pull/115 so that the installer supports it.