### PR TITLE
agema-ag7648: fix support of optical QSFP modules

### DIFF
--- a/recipes-core/platform-ag7648/files/platform-ag7648-init.sh
+++ b/recipes-core/platform-ag7648/files/platform-ag7648-init.sh
@@ -15,6 +15,8 @@ function enable_tx() {
 }
 
 function enable_qsfp() {
+	# disable LP Mode
+	i2cset -y 2 0x32 0x0b 0xc0
 	# clear ResetL
 	i2cset -y 2 0x32 0x0d 0x3f
 }

--- a/recipes-core/platform-ag7648/files/platform-ag7648-init.sh
+++ b/recipes-core/platform-ag7648/files/platform-ag7648-init.sh
@@ -14,6 +14,11 @@ function enable_tx() {
 	i2cset -y 2 0x33 0x0d 0x00
 }
 
+function enable_qsfp() {
+	# clear ResetL
+	i2cset -y 2 0x32 0x0d 0x3f
+}
+
 function wait_for_file() {
 	FILE=$1
 	i=0
@@ -53,4 +58,4 @@ if [ "$BOOT_STATE" != "success" ]; then
 fi
 
 wait_for_file /sys/bus/i2c/devices/0-0069 && set_clocksouce
-wait_for_file /sys/bus/i2c/devices/i2c-2 && enable_tx
+wait_for_file /sys/bus/i2c/devices/i2c-2 && enable_tx && enable_qsfp

--- a/recipes-extended/onl/files/delta-ag7648/0011-delta-ag7648-do-not-reset-QSFP-modules-when-IRQ-is-a.patch
+++ b/recipes-extended/onl/files/delta-ag7648/0011-delta-ag7648-do-not-reset-QSFP-modules-when-IRQ-is-a.patch
@@ -1,0 +1,116 @@
+Upstream-Status: Unsubmitted
+
+From 40cdd20bf474905924c141ff3d87553a9dbf0239 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 11 Oct 2022 16:42:23 +0200
+Subject: [PATCH] delta-ag7648: do not reset QSFP modules when IRQ is asserted
+
+The IntL signal may also be asserted when the module finished initializing:
+
+SFF-8679 says:
+
+> 5.3.2 ResetL
+>
+> ... During the execution of a reset (t_init) the host shall disregard
+> all status bits until the module indicates a completion of reset
+> interrupt by asserting "low" on the IntL/RxLOSL signal (see SFF-8636
+> for details). However, on power up (including hot insertion) the module
+> should post this completion of reset interrupt without the host pulling
+> ResetL low.
+
+If a module does this, then this puts the driver in an endless loop of:
+
+1. module resets/initializes, asserts interrupt
+2. driver sees interrupt asserted, resets module
+3. goto 1
+
+To fix that, don't try to be clever in the mux driver, and let userspace
+handle any issues.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../builds/x86-64-delta-ag7648-cpld-mux-2.c   | 61 -------------------
+ 1 file changed, 61 deletions(-)
+
+diff --git a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-cpld-mux-2.c b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-cpld-mux-2.c
+index d42daee20770..339c0071fb5d 100755
+--- a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-cpld-mux-2.c
++++ b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-cpld-mux-2.c
+@@ -71,7 +71,6 @@ static int i2c_mux_cpld_set(const struct cpldmux *mux, unsigned int chan_id)
+ 	int try
+ 		, change = 0;
+ 	s32 res = -EIO;
+-	int intr, reset_ctrl;
+ 	int i;
+ 
+ 	data.byte = chan_id;
+@@ -94,66 +93,6 @@ static int i2c_mux_cpld_set(const struct cpldmux *mux, unsigned int chan_id)
+ 				I2C_SMBUS_BYTE_DATA, &data);
+ 			if (res == -EAGAIN)
+ 				continue;
+-			//read the interrupt status
+-			res = ctrl_adap->algo->smbus_xfer(
+-				ctrl_adap, mux->data.cpld_addr, flags,
+-				I2C_SMBUS_READ, CPLD_QSFP_INTR_STATUS_REG,
+-				I2C_SMBUS_BYTE_DATA, &data);
+-			if (res == -EAGAIN)
+-				continue;
+-
+-			intr = data.byte;
+-
+-			//read the reset control
+-			res = ctrl_adap->algo->smbus_xfer(
+-				ctrl_adap, mux->data.cpld_addr, flags,
+-				I2C_SMBUS_READ, CPLD_QSFP_RESET_CTRL_REG,
+-				I2C_SMBUS_BYTE_DATA, &data);
+-			if (res == -EAGAIN)
+-				continue;
+-
+-			reset_ctrl = data.byte;
+-
+-			/* there is an interrupt for QSFP port, including failure/plugin/un-plugin
+-            *  try to reset it.
+-            *
+-            */
+-			for (i = 0; i < mux->data.n_values; i++) {
+-				if ((reset_ctrl & (1 << i)) == 0) {
+-					change = 1;
+-				}
+-				if ((intr & (1 << i)) == 0) {
+-					res = ctrl_adap->algo->smbus_xfer(
+-						ctrl_adap, mux->data.cpld_addr,
+-						flags, I2C_SMBUS_READ,
+-						CPLD_QSFP_RESET_CTRL_REG,
+-						I2C_SMBUS_BYTE_DATA, &data);
+-					if (res == -EAGAIN)
+-						continue;
+-					data.byte &= ~(1 << i);
+-
+-					res = ctrl_adap->algo->smbus_xfer(
+-						ctrl_adap, mux->data.cpld_addr,
+-						flags, I2C_SMBUS_WRITE,
+-						CPLD_QSFP_RESET_CTRL_REG,
+-						I2C_SMBUS_BYTE_DATA, &data);
+-					if (res == -EAGAIN)
+-						continue;
+-					change = 1;
+-				}
+-			}
+-			if (change) {
+-				msleep(10);
+-				data.byte = CPLD_DESELECT_CHANNEL;
+-				res = ctrl_adap->algo->smbus_xfer(
+-					ctrl_adap, mux->data.cpld_addr, flags,
+-					I2C_SMBUS_WRITE,
+-					CPLD_QSFP_RESET_CTRL_REG,
+-					I2C_SMBUS_BYTE_DATA, &data);
+-				if (res == -EAGAIN)
+-					continue;
+-				msleep(200);
+-			}
+ 
+ 			// read first
+ 			//res = ctrl_adap->algo->smbus_xfer(ctrl_adap, mux->data.cpld_addr, flags,
+-- 
+2.37.3
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -70,6 +70,7 @@ SRC_URI += " \
            file://delta-ag7648/0008-ag7648-i2c-mux-setting-mod-fix-race-in-CPLD-device-r.patch \
            file://delta-ag7648/0009-ag7648-i2c-mux-setting-mod-force-mux-bus-numbers.patch \
            file://delta-ag7648/0010-x86-64-delta-ag7648-i2c-mux-setting-mod-update-to-ne.patch \
+           file://delta-ag7648/0011-delta-ag7648-do-not-reset-QSFP-modules-when-IRQ-is-a.patch \
 "
 
 FILES:${PN} = " \


### PR DESCRIPTION
Fix two issues with handling of (mainly) optical QSFP modules:

1. Do not assume an asserted IntL signal means that the module has an error, it may also just mean it finished initializing, so do not reset modules in response to an asserted IntL.
2. Do not limit modules to the lowest power class by disabling LP Mode.

Especially 1. caused slow onlpdump output when an optical module is inserted, as every read from any QSFP eeprom triggered a reset loop until the the timeout is reached or so. This also had the side effect of breaking any active link in optical modules.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>