### PR TITLE
linux-yocto-onl: update to 5.15.77

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.76"
+LINUX_VERSION ?= "5.15.77"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "4f5365f77018349d64386b202b37e8b737236556"
+SRCREV_machine ?= "793d8378b74ac283a4dd7cef1b304553c8a42260"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "a120c990509eccdaa613b264a4f6c187277548df"
+SRCREV_meta ?= "28a9034e474be110394424334cfb2bb3cdb99a61"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel to 5.15.77 and kmeta to HEAD.

Changelog for kernel:

* https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.77

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>