### PR TITLE
drop fixed management port configs

### DIFF
--- a/recipes-core/platform-as4610/files/90-enp.link
+++ b/recipes-core/platform-as4610/files/90-enp.link
@@ -1,4 +1,0 @@
-[Match]
-Path=*platform-18022000.ethernet*
-[Link]
-Name=enp0

--- a/recipes-core/platform-as4610/platform-as4610_0.1.bb
+++ b/recipes-core/platform-as4610/platform-as4610_0.1.bb
@@ -11,14 +11,12 @@ inherit systemd
 SRC_URI += " \
     file://platform-as4610-init.service \
     file://platform-as4610-init.sh \
-    file://90-enp.link \
     file://fw_env.config \
 "
 
 FILES:${PN} = " \
     ${systemd_system_unitdir}/platform-as4610-init.service \
     ${bindir}/platform-as4610-init.sh \
-    ${systemd_unitdir}/network/90-enp.link \
     ${sysconfdir}/fw_env.config \
 "
 
@@ -28,9 +26,6 @@ do_install() {
         install -m 0644 ${WORKDIR}/platform-as4610-init.service ${D}${systemd_system_unitdir}
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/platform-as4610-init.sh ${D}${bindir}
-        # systemd-networkd
-        install -d ${D}${systemd_unitdir}/network/
-        install -m 0644 ${WORKDIR}/*.link ${D}${systemd_unitdir}/network/
         # uboot env
         install -d ${D}${sysconfdir}
         install -m 0644 ${WORKDIR}/fw_env.config ${D}/${sysconfdir}/

--- a/recipes-core/platform-as4630-54pe/files/90-enp.link
+++ b/recipes-core/platform-as4630-54pe/files/90-enp.link
@@ -1,4 +1,0 @@
-[Match]
-Path=pci-0000:08:00.0
-[Link]
-Name=enp0

--- a/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
+++ b/recipes-core/platform-as4630-54pe/platform-as4630-54pe_0.1.bb
@@ -9,14 +9,12 @@ inherit systemd
 SRC_URI += " \
     file://platform-as4630-54pe-init.service \
     file://platform-as4630-54pe-init.sh \
-    file://90-enp.link \
 "
 
 # TODO ADD FILES
 FILES:${PN} = " \
     ${systemd_system_unitdir}/platform-as4630-54pe-init.service \
     ${bindir}/platform-as4630-54pe-init.sh \
-    ${systemd_unitdir}/network/90-enp.link \
 "
 
 
@@ -25,10 +23,6 @@ do_install() {
         install -m 0644 ${WORKDIR}/platform-as4630-54pe-init.service ${D}${systemd_system_unitdir}
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/platform-as4630-54pe-init.sh ${D}${bindir}
-
-        # systemd-networkd
-        install -d ${D}${systemd_unitdir}/network/
-        install -m 0644 ${WORKDIR}/*.link ${D}${systemd_unitdir}/network/
 }
 
 SYSTEMD_SERVICE:${PN}:append = "platform-as4630-54pe-init.service"


### PR DESCRIPTION
Let the installer take care of setting up the management port config instead of shipping a hardcoded version of the `90-enp.link` in the image. This way we can support multiple switches needing different management configs in one image.

Depends on https://github.com/bisdn/meta-switch/pull/125

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>