### PR TITLE
linux-yocto-onl: enable VRF support here

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/bisdn-linux.scc
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-5.15.y/bisdn-kmeta/cfg/bisdn-linux.scc
@@ -8,6 +8,7 @@ patch 0001-tun-allow-setting-hwaddr-on-tap-interface-creation.patch
 include features/bpf/bpf.scc
 include features/cgroups/cgroups.scc
 include features/tun/tun.scc
+include features/vrf/vrf.scc
 include cfg/fs/ext4.scc
 include cfg/net/bridge.scc
 include cgl/cfg/net/ip_vs.scc


### PR DESCRIPTION
Enable VRF support via our bisdn-linux.scc instead of relying on a bbappend in meta-switch.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>