### PR TITLE
platform-as4610: drop the fw_env.config file

### DIFF
--- a/recipes-core/platform-as4610/files/fw_env.config
+++ b/recipes-core/platform-as4610/files/fw_env.config
@@ -1,2 +1,0 @@
-# MTD device name       Device offset   Env. size       Flash sector size
-/dev/mtd2               0x00000000      0x00002000         0x00010000

--- a/recipes-core/platform-as4610/platform-as4610_0.1.bb
+++ b/recipes-core/platform-as4610/platform-as4610_0.1.bb
@@ -4,6 +4,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MPL-2.0;md5=81
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+# This will actually be provided by the installer, but we need to pretend to
+# provide it so Yocto will be happy.
 RPROVIDES:${PN} += " u-boot-default-env"
 
 inherit systemd
@@ -11,13 +13,11 @@ inherit systemd
 SRC_URI += " \
     file://platform-as4610-init.service \
     file://platform-as4610-init.sh \
-    file://fw_env.config \
 "
 
 FILES:${PN} = " \
     ${systemd_system_unitdir}/platform-as4610-init.service \
     ${bindir}/platform-as4610-init.sh \
-    ${sysconfdir}/fw_env.config \
 "
 
 
@@ -26,9 +26,6 @@ do_install() {
         install -m 0644 ${WORKDIR}/platform-as4610-init.service ${D}${systemd_system_unitdir}
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/platform-as4610-init.sh ${D}${bindir}
-        # uboot env
-        install -d ${D}${sysconfdir}
-        install -m 0644 ${WORKDIR}/fw_env.config ${D}/${sysconfdir}/
 }
 
 SYSTEMD_SERVICE:${PN}:append = "platform-as4610-init.service"


### PR DESCRIPTION
Since the installer will now create the fw_env.config file, we do not
need to provide one in the image.

Keep the u-boot-default-env provide, since the libubootenv-bin package
providing fw_{print,set}env has it as a dependency.

Depends on https://github.com/bisdn/meta-switch/pull/128

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>