### PR TITLE
onl: delta-ag7648: properly fix deadlock on probe

### DIFF
--- a/recipes-extended/onl/files/delta-ag7648/0012-delta-ag7648-make-sure-i2c-i801-is-loaded-before-cre.patch
+++ b/recipes-extended/onl/files/delta-ag7648/0012-delta-ag7648-make-sure-i2c-i801-is-loaded-before-cre.patch
@@ -1,43 +1,37 @@
-From f20cf829e7b2bfbf803aa975ccd2f8231b7a2068 Mon Sep 17 00:00:00 2001
+From c6e73fdc63fabcbfd222ad3204f966e8db7fd06d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 30 Nov 2022 10:21:21 +0100
 Subject: [PATCH] delta-ag7648: make sure i2c-i801 is loaded before creating
  devices
 
-The order in which the modules must be loaded are super fragile:
-i2c-i801 must be loaded before instantiating the devices.
+Make sure i2c-i801 is loaded before we create devices so that the
+pca954x mux will use busses 2-9 and not claim the one of i2c-i801.
 
-Neither i2c-ismt nor any of the cpld drivers may be loaded before
-creating the devices, else only a subset of devices may be created, or
-the module may hang in init.
-
-We cannot request modules to be unloaded or not loaded, but we can
-at least make sure that i2c-i801 is loaded and ready.
+Since the mux is attached to i2c-ismt, we do not need request it, as
+it will always get a bus assigned before we can even register the
+mux device.
 
 Upstream-Status: Unsuitable [platform is EOL]
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
- .../builds/x86-64-delta-ag7648-i2c-mux-setting.c    | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
+ .../builds/x86-64-delta-ag7648-i2c-mux-setting.c       | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
-index 206094fbc5a1..012209db24dc 100644
+index 206094fbc5a1..cedfa4e3da62 100644
 --- a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
 +++ b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
-@@ -517,6 +517,19 @@ static int __init delta_switch_init(void)
+@@ -517,6 +517,16 @@ static int __init delta_switch_init(void)
  
  	pr_debug("DMI Matched %s\n", dmi_id->ident);
  
 +	/*
-+	 * The order in which these modules must be loaded are super fragile:
-+	 * i2c-i801 must be loaded before instantiating the devices.
-+	 * 
-+	 * Neither i2c-ismt nor any of the cpld drivers may be loaded before
-+	 * creating the devices, else only a subset of devices may be created,
-+	 * or the module may hang in init.
++	 * Make sure i2c-i801 is loaded before we create devices so that the
++	 * pca954x mux will use busses 2-9 and not claim the one of i2c-i801.
 +	 *
-+	 * We cannot request modules to be unloaded or not loaded, but we can
-+	 * at least make sure that i2c-i801 is loaded and ready.
++	 * Since the mux is attached to i2c-ismt, we do not need request it, as
++	 * it will always get a bus assigned before we can even register the
++	 * mux device.
 +	 */
 +	request_module("i2c-i801");
 +

--- a/recipes-extended/onl/files/delta-ag7648/0013-delta-ag7648-prevent-potential-deadlock-on-probe.patch
+++ b/recipes-extended/onl/files/delta-ag7648/0013-delta-ag7648-prevent-potential-deadlock-on-probe.patch
@@ -1,0 +1,121 @@
+From 8af85840361e6d7b69eaf29feef6a90962557ec8 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 2 Dec 2022 11:26:07 +0100
+Subject: [PATCH] delta-ag7648: prevent potential deadlock on probe
+
+When the i2c-ismt and pca954x modules are already loaded, there
+will be a deadlock due to recursive locking:
+
+ i2c_for_each_dev()
+   mutex_lock(&core_lock) <-- first lock
+   bus_for_each_dev()
+     delta_switch_scan_peripherals()
+       delta_switch_instantiate_i2c_device()
+         i2c_new_scanned_device()
+             ...
+             i2c_device_probe()
+               pca954x_probe()
+                 i2c_mux_add_adapter()
+                   i2c_add_adapter()
+                     mutex_lock(&core_lock) <-- deadlock
+
+To avoid this, do not try to add any devices while under the core lock,
+and just collect the matched adapters, and only after returning from the
+bus scan, do the device registration.
+
+Upstream-Status: Unsuitable [platform is EOL]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../x86-64-delta-ag7648-i2c-mux-setting.c     | 54 ++++++++++++++++++-
+ 1 file changed, 52 insertions(+), 2 deletions(-)
+
+diff --git a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
+index cedfa4e3da62..3a0dfb591aad 100644
+--- a/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
++++ b/packages/platforms/delta/x86-64/ag7648/modules/builds/x86-64-delta-ag7648-i2c-mux-setting.c
+@@ -67,6 +67,7 @@ struct i2c_peripheral {
+ 	struct platform_device *(*init_cb)(void);
+ 	struct platform_device *pd;
+ 	struct i2c_client *client;
++	struct i2c_adapter *adapter;
+ };
+ 
+ struct delta_switch {
+@@ -441,8 +442,41 @@ MODULE_DEVICE_TABLE(dmi, delta_switch_dmi_table);
+ 
+ static int __init delta_switch_scan_peripherals(struct device *dev, void *data)
+ {
++	struct i2c_peripheral *i2c_dev;
++	struct i2c_adapter *adapter;
++	const char *adapter_name;
++	int i;
++
+ 	if (dev->type == &i2c_adapter_type) {
+-		delta_switch_check_adapter(to_i2c_adapter(dev));
++		adapter = to_i2c_adapter(dev);
++		for (i = 0; i < dta_switch->num_i2c_peripherals; i++) {
++			i2c_dev = &dta_switch->i2c_peripherals[i];
++
++			/* Skip devices already created */
++			if (i2c_dev->client || i2c_dev->pd)
++				continue;
++
++			/*
++			 * The only adapters that can exist at this point are
++			 * the SMBUS adapters.
++			 */
++			if (i2c_dev->type != I2C_ADAPTER_SMBUS_I801
++			    && i2c_dev->type != I2C_ADAPTER_SMBUS_ISMT)
++				continue;
++
++			adapter_name = delta_switch_get_adapter_name(i2c_dev, adapter);
++			if (!adapter_name)
++				continue;
++
++			if (strncmp(adapter->name, adapter_name, strlen(adapter_name)))
++				continue;
++			/*
++			 * Registering the device directly here would might
++			 * cause a deadlock, so store the adapter here for
++			 * now.
++			 */
++			i2c_dev->adapter = adapter;
++		}
+ 	}
+ 
+ 	return 0;
+@@ -507,7 +541,7 @@ delta_switch_prepare(const struct delta_switch *src)
+ static int __init delta_switch_init(void)
+ {
+ 	const struct dmi_system_id *dmi_id;
+-	int error;
++	int error, i;
+ 
+ 	dmi_id = dmi_first_match(delta_switch_dmi_table);
+ 	if (!dmi_id) {
+@@ -551,6 +585,22 @@ static int __init delta_switch_init(void)
+ 	 */
+ 	i2c_for_each_dev(NULL, delta_switch_scan_peripherals);
+ 
++	for (i = 0; i < dta_switch->num_i2c_peripherals; i++) {
++		struct i2c_peripheral *i2c_dev;
++
++		i2c_dev = &dta_switch->i2c_peripherals[i];
++
++		/* Skip devices already created */
++		if (i2c_dev->client)
++			continue;
++
++		if (!i2c_dev->adapter)
++			continue;
++
++		i2c_dev->client = delta_switch_instantiate_i2c_device(
++			i2c_dev->adapter, &i2c_dev->board_info, i2c_dev->alt_addr);
++	}
++
+ 	return 0;
+ 
+ err_destroy_dta_switch:
+-- 
+2.38.1
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -74,6 +74,7 @@ SRC_URI += " \
            file://delta-ag7648/0010-x86-64-delta-ag7648-i2c-mux-setting-mod-update-to-ne.patch \
            file://delta-ag7648/0011-delta-ag7648-do-not-reset-QSFP-modules-when-IRQ-is-a.patch \
            file://delta-ag7648/0012-delta-ag7648-make-sure-i2c-i801-is-loaded-before-cre.patch \
+           file://delta-ag7648/0013-delta-ag7648-prevent-potential-deadlock-on-probe.patch \
 "
 
 FILES:${PN} = " \
@@ -87,7 +88,3 @@ ONL_PLATFORMS_IGNORE = ""
 
 # delta_ag5648v1 is an alias for delta_ag5648
 ONL_PLATFORMS_IGNORE += "x86_64-delta_ag5648v1-r0"
-
-# for some unknown reason this module causes a deadlock when loaded too
-# late, so force it being loaded earlier by loading it explicitly
-KERNEL_MODULE_AUTOLOAD = "x86-64-delta-ag7648-i2c-mux-setting"


### PR DESCRIPTION
When the i2c-ismt and pca954x modules are already loaded, there will be a deadlock due to recursive locking:

```
 i2c_for_each_dev()
   mutex_lock(&core_lock) <-- first lock
   bus_for_each_dev()
     delta_switch_scan_peripherals()
       delta_switch_instantiate_i2c_device()
         i2c_new_scanned_device()
             ...
             i2c_device_probe()
               pca954x_probe()
                 i2c_mux_add_adapter()
                   i2c_add_adapter()
                     mutex_lock(&core_lock) <-- deadlock
```

To avoid this, do not try to add any devices while under the core lock, and just collect the matched adapters, and only after returning from the bus scan, do the device registration.

We still need to make sure that at least i2c-i801 is loaded, as
userspace depends on stable i2c bus numbering, which we can only ensure
when i2c-i801 is probed and has a bus assigned, so the pca941x mux won't
be able to claim it.

Since the comment about the CPLD drivers not being loaded is bogus,
rewrite the commit message and comment of the earlier patch to the
actual cause.

This also allows us to drop the autoload for the module, as there is no need for it being loaded early.

Fixes: 54356ec88f76 ("delta-ag7648: make sure i2c-i801 is loaded before creating devices")
Fixes: 33d0f74483ec ("onl: delta-ag7648: work around deadlock in module load")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>