### PR TITLE
accton-as4630-54pe-poe-mcu: do not autoload on boot

### DIFF
--- a/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4630-poe-mcu/accton-as4630-54pe-poe-mcu-mod_1.0.bb
@@ -12,8 +12,6 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-KERNEL_MODULE_AUTOLOAD += "accton_as4630_54pe_poe_mcu"
-
 EXTRA_OEMAKE += " KBUILD_MODPOST_WARN=1"
 
 FILES:${PN} += "${sbindir}/poectl"


### PR DESCRIPTION
There is no need to autoload the poe driver, as it will be loaded on demand when the I2C device is created by the platform init script.

Avoids loading the module on platforms that do not need it, e.g. accton-as4630-54te.

Fixes: 5dfbbf77bc20 ("accton-as4630-54pe-poe-pse: add driver for PoE")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>