### PR TITLE
platform-onl-init: cleanup and refactor code

### DIFF
--- a/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function wait_for_file() {
 	FILE=$1

--- a/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 create_i2c_dev() {
 	local product_id="$(cat /sys/bus/i2c/drivers/as4610_54_cpld/0-0030/product_id)"
 	case "$product_id" in

--- a/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
@@ -1,32 +1,12 @@
 #!/bin/bash
 
-create_i2c_dev() {
-	local product_id="$(cat /sys/bus/i2c/drivers/as4610_54_cpld/0-0030/product_id)"
-	case "$product_id" in
-		"0" | "1")
-			echo port25 > /sys/bus/i2c/devices/2-0050/port_name
-			echo port26 > /sys/bus/i2c/devices/3-0050/port_name
-			echo port27 > /sys/bus/i2c/devices/4-0050/port_name
-			echo port28 > /sys/bus/i2c/devices/5-0050/port_name
-			echo port29 > /sys/bus/i2c/devices/6-0050/port_name
-			echo port30 > /sys/bus/i2c/devices/7-0050/port_name
-			;;
-		"2" | "3" | "5")
-			echo port49 > /sys/bus/i2c/devices/2-0050/port_name
-			echo port50 > /sys/bus/i2c/devices/3-0050/port_name
-			echo port51 > /sys/bus/i2c/devices/4-0050/port_name
-			echo port52 > /sys/bus/i2c/devices/5-0050/port_name
-			echo port53 > /sys/bus/i2c/devices/6-0050/port_name
-			echo port54 > /sys/bus/i2c/devices/7-0050/port_name
-			;;
-		*)
-			echo "platform-as4610-init: unknown product id $product_id"
-			return
-			;;
-	esac
+echo port25 > /sys/bus/i2c/devices/2-0050/port_name
+echo port26 > /sys/bus/i2c/devices/3-0050/port_name
+echo port27 > /sys/bus/i2c/devices/4-0050/port_name
+echo port28 > /sys/bus/i2c/devices/5-0050/port_name
+echo port29 > /sys/bus/i2c/devices/6-0050/port_name
+echo port30 > /sys/bus/i2c/devices/7-0050/port_name
 
-	# take out PHYs from reset
-	i2cset -y -f 0 0x30 0x19 0
-	i2cset -y -f 0 0x30 0x2a 0
-}
-create_i2c_dev
+# take out PHYs from reset
+i2cset -y -f 0 0x30 0x19 0
+i2cset -y -f 0 0x30 0x2a 0

--- a/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-30-r0-init.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1
@@ -14,26 +14,26 @@ function wait_for_file() {
 create_i2c_dev() {
 	local product_id="$(cat /sys/bus/i2c/drivers/as4610_54_cpld/0-0030/product_id)"
 	case "$product_id" in
-	"0"|"1")
-		echo port25 > /sys/bus/i2c/devices/2-0050/port_name
-		echo port26 > /sys/bus/i2c/devices/3-0050/port_name
-		echo port27 > /sys/bus/i2c/devices/4-0050/port_name
-		echo port28 > /sys/bus/i2c/devices/5-0050/port_name
-		echo port29 > /sys/bus/i2c/devices/6-0050/port_name
-		echo port30 > /sys/bus/i2c/devices/7-0050/port_name
-		;;
-	"2"|"3"|"5")
-		echo port49 > /sys/bus/i2c/devices/2-0050/port_name
-		echo port50 > /sys/bus/i2c/devices/3-0050/port_name
-		echo port51 > /sys/bus/i2c/devices/4-0050/port_name
-		echo port52 > /sys/bus/i2c/devices/5-0050/port_name
-		echo port53 > /sys/bus/i2c/devices/6-0050/port_name
-		echo port54 > /sys/bus/i2c/devices/7-0050/port_name
-		;;
-	*)
-		echo "platform-as4610-init: unknown product id $product_id"
-		return
-		;;
+		"0" | "1")
+			echo port25 > /sys/bus/i2c/devices/2-0050/port_name
+			echo port26 > /sys/bus/i2c/devices/3-0050/port_name
+			echo port27 > /sys/bus/i2c/devices/4-0050/port_name
+			echo port28 > /sys/bus/i2c/devices/5-0050/port_name
+			echo port29 > /sys/bus/i2c/devices/6-0050/port_name
+			echo port30 > /sys/bus/i2c/devices/7-0050/port_name
+			;;
+		"2" | "3" | "5")
+			echo port49 > /sys/bus/i2c/devices/2-0050/port_name
+			echo port50 > /sys/bus/i2c/devices/3-0050/port_name
+			echo port51 > /sys/bus/i2c/devices/4-0050/port_name
+			echo port52 > /sys/bus/i2c/devices/5-0050/port_name
+			echo port53 > /sys/bus/i2c/devices/6-0050/port_name
+			echo port54 > /sys/bus/i2c/devices/7-0050/port_name
+			;;
+		*)
+			echo "platform-as4610-init: unknown product id $product_id"
+			return
+			;;
 	esac
 
 	# take out PHYs from reset

--- a/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-54-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-arm-accton-as4610-54-r0-init.sh
@@ -1,1 +1,12 @@
-platform-arm-accton-as4610-30-r0-init.sh
+#!/bin/bash
+
+echo port49 > /sys/bus/i2c/devices/2-0050/port_name
+echo port50 > /sys/bus/i2c/devices/3-0050/port_name
+echo port51 > /sys/bus/i2c/devices/4-0050/port_name
+echo port52 > /sys/bus/i2c/devices/5-0050/port_name
+echo port53 > /sys/bus/i2c/devices/6-0050/port_name
+echo port54 > /sys/bus/i2c/devices/7-0050/port_name
+
+# take out PHYs from reset
+i2cset -y -f 0 0x30 0x19 0
+i2cset -y -f 0 0x30 0x2a 0

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 onl_platform="$(cat /etc/onl/platform)"
 

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -11,7 +11,12 @@ add_port() {
 }
 
 create_i2c_dev() {
-	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+	local i2c_dev_name=$1
+	local i2c_addr=$2
+	local i2c_bus_no=$3
+
+	wait_for_file "/sys/bus/i2c/devices/i2c-${i2c_bus_no}/new_device"
+	echo ${i2c_dev_name} ${i2c_addr} > /sys/bus/i2c/devices/i2c-${i2c_bus_no}/new_device
 }
 
 wait_for_file() {

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 wait_for_file() {
-	FILE=$1
-	i=0
+	local FILE=$1
+	local i=0
+
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
 		i=$((i + 1))

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+add_port() {
+	create_i2c_dev ${1} 0x50 ${3}
+	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"
+	echo "port${1}" > "/sys/bus/i2c/devices/${3}-0050/port_name"
+}
+
 create_i2c_dev() {
 	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+create_i2c_dev() {
+	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+}
+
 wait_for_file() {
 	local FILE=$1
 	local i=0

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 add_port() {
-	create_i2c_dev ${1} 0x50 ${3}
-	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"
-	echo "port${1}" > "/sys/bus/i2c/devices/${3}-0050/port_name"
+	local i2c_dev_name=$1
+	local portnum=$2
+	local i2c_bus_no=$3
+
+	create_i2c_dev ${i2c_dev_name} 0x50 ${i2c_bus_no}
+	wait_for_file "/sys/bus/i2c/devices/${i2c_bus_no}-0050/port_name"
+	echo "port${portnum}" > "/sys/bus/i2c/devices/${i2c_bus_no}-0050/port_name"
 }
 
 create_i2c_dev() {

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+wait_for_file() {
+	FILE=$1
+	i=0
+	while [ $i -lt 10 ]; do
+		test -e $FILE && return 0
+		i=$((i + 1))
+		sleep 1
+	done
+	return 1
+}
+
 onl_platform="$(cat /etc/onl/platform)"
 
 [ -e "/usr/bin/platform-${onl_platform}-init.sh" ] && . /usr/bin/platform-${onl_platform}-init.sh

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -2,31 +2,14 @@
 
 set -e
 
-onl_platform="$(cat /etc/onl/platform)"
-
-case "$onl_platform" in
-	*as4630-54pe*)
-		variant="54pe"
-		psu_dev="ype1200am"
-		;;
-	*as4630-54te*)
-		variant="54te"
-		psu_dev="ym1921"
-		;;
-	*)
-		echo "Unsupported model: $onl_platform"
-		exit 1
-		;;
-esac
-
 # make sure i2c-i801 is present
 wait_for_file /sys/bus/i2c/devices/i2c-0
 
 # load modules
 modprobe i2c-ismt
-modprobe x86-64-accton-as4630-${variant}-cpld
-modprobe x86-64-accton-as4630-${variant}-psu
-modprobe x86-64-accton-as4630-${variant}-leds
+modprobe x86-64-accton-as4630-54pe-cpld
+modprobe x86-64-accton-as4630-54pe-psu
+modprobe x86-64-accton-as4630-54pe-leds
 
 # init mux (PCA9548)
 create_i2c_dev pca9548 0x77 1
@@ -44,7 +27,7 @@ if [ "$(($OTHER & 0x80))" == "0" ]; then
 fi
 
 # add CPLD
-create_i2c_dev as4630_${variant}_cpld 0x60 3
+create_i2c_dev as4630_54pe_cpld 0x60 3
 
 # init LM77
 create_i2c_dev lm77 0x48 14
@@ -52,12 +35,12 @@ create_i2c_dev lm75 0x4a 25
 create_i2c_dev lm75 0x4b 24
 
 # init PSU-1
-create_i2c_dev as4630_${variant}_psu1 0x50 10
-create_i2c_dev ${psu_dev} 0x58 10
+create_i2c_dev as4630_54pe_psu1 0x50 10
+create_i2c_dev ype1200am 0x58 10
 
 # init PSU-2
-create_i2c_dev as4630_${variant}_psu2 0x51 11
-create_i2c_dev ${psu_dev} 0x59 11
+create_i2c_dev as4630_54pe_psu2 0x51 11
+create_i2c_dev ype1200am 0x59 11
 
 for port in {49..52}; do
 	add_port 'optoe2' $port $((port - 31))
@@ -70,7 +53,5 @@ done
 # add EEPROM
 create_i2c_dev 24c02 0x57 1
 
-if [ "$variant" = "54pe" ]; then
-	# add PoE MCU
-	create_i2c_dev as4630_54pe_poe_mcu 0x20 16
-fi
+# add PoE MCU
+create_i2c_dev as4630_54pe_poe_mcu 0x20 16

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -6,17 +6,6 @@ create_i2c_dev() {
 	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 add_port() {
 	create_i2c_dev ${1} 0x50 ${3}
 	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-create_i2c_dev() {
-	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
-}
-
 add_port() {
 	create_i2c_dev ${1} 0x50 ${3}
 	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -29,7 +29,6 @@ modprobe x86-64-accton-as4630-${variant}-psu
 modprobe x86-64-accton-as4630-${variant}-leds
 
 # init mux (PCA9548)
-wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev pca9548 0x77 1
 echo '-2' > /sys/bus/i2c/devices/1-0077/idle_state
 create_i2c_dev pca9548 0x71 2

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -3,15 +3,15 @@
 set -e
 
 create_i2c_dev() {
-  echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1
@@ -82,11 +82,11 @@ create_i2c_dev as4630_${variant}_psu2 0x51 11
 create_i2c_dev ${psu_dev} 0x59 11
 
 for port in {49..52}; do
-	add_port 'optoe2' $port $((port-31))
+	add_port 'optoe2' $port $((port - 31))
 done
 
 for port in {53..54}; do
-	add_port 'optoe1' $port $((port-31))
+	add_port 'optoe1' $port $((port - 31))
 done
 
 # add EEPROM

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-add_port() {
-	create_i2c_dev ${1} 0x50 ${3}
-	wait_for_file "/sys/bus/i2c/devices/${3}-0050/port_name"
-	echo "port${2}" > "/sys/bus/i2c/devices/${3}-0050/port_name"
-}
-
 onl_platform="$(cat /etc/onl/platform)"
 
 case "$onl_platform" in

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54te-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54te-r0-init.sh
@@ -1,1 +1,54 @@
-platform-x86-64-accton-as4630-54pe-r0-init.sh
+#!/bin/bash
+
+set -e
+
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
+
+# load modules
+modprobe i2c-ismt
+modprobe x86-64-accton-as4630-54te-cpld
+modprobe x86-64-accton-as4630-54te-psu
+modprobe x86-64-accton-as4630-54te-leds
+
+# init mux (PCA9548)
+create_i2c_dev pca9548 0x77 1
+echo '-2' > /sys/bus/i2c/devices/1-0077/idle_state
+create_i2c_dev pca9548 0x71 2
+echo '-2' > /sys/bus/i2c/devices/2-0071/idle_state
+create_i2c_dev pca9548 0x70 3
+echo '-2' > /sys/bus/i2c/devices/3-0070/idle_state
+
+# allow SFP LEDs to be controlled by MAC
+OTHER=$(i2cget -y -f 0x3 0x60 0x86)
+if [ "$(($OTHER & 0x80))" == "0" ]; then
+	OTHER=$(($OTHER | 0x80))
+	i2cset -y -f 0x3 0x60 0x86 $OTHER
+fi
+
+# add CPLD
+create_i2c_dev as4630_54te_cpld 0x60 3
+
+# init LM77
+create_i2c_dev lm77 0x48 14
+create_i2c_dev lm75 0x4a 25
+create_i2c_dev lm75 0x4b 24
+
+# init PSU-1
+create_i2c_dev as4630_54te_psu1 0x50 10
+create_i2c_dev ym1921 0x58 10
+
+# init PSU-2
+create_i2c_dev as4630_54te_psu2 0x51 11
+create_i2c_dev ym1921 0x59 11
+
+for port in {49..52}; do
+	add_port 'optoe2' $port $((port - 31))
+done
+
+for port in {53..54}; do
+	add_port 'optoe1' $port $((port - 31))
+done
+
+# add EEPROM
+create_i2c_dev 24c02 0x57 1

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
@@ -8,33 +8,33 @@
 
 set -o errexit -o nounset
 
-function wait_for_file() {
-  FILE=$1
-  i=0
-  while [ $i -lt 10 ]; do
-    test -e $FILE && return 0
-    i=$(( i + 1 ))
-    sleep 1
-  done
-  return 1
+wait_for_file() {
+	FILE=$1
+	i=0
+	while [ $i -lt 10 ]; do
+		test -e $FILE && return 0
+		i=$((i + 1))
+		sleep 1
+	done
+	return 1
 }
 
 create_i2c_dev() {
-  local i2c_dev_name=$1
-  local i2c_dev_addr=$2
-  local i2c_bus_no=$3
+	local i2c_dev_name=$1
+	local i2c_dev_addr=$2
+	local i2c_bus_no=$3
 
-  wait_for_file "/sys/bus/i2c/devices/i2c-$i2c_bus_no/new_device"
-  echo "$i2c_dev_name" "$i2c_dev_addr" > /sys/bus/i2c/devices/i2c-${i2c_bus_no}/new_device
+	wait_for_file "/sys/bus/i2c/devices/i2c-$i2c_bus_no/new_device"
+	echo "$i2c_dev_name" "$i2c_dev_addr" > /sys/bus/i2c/devices/i2c-${i2c_bus_no}/new_device
 
-  # For pca9548 multiplexer, set idle_state to -2 (MUX_IDLE_DISCONNECT)
-  # Not doing this can result, for instance, in SFP EEPROMs not being
-  # read correctly by onlp.
-  if [ "$i2c_dev_name" = "pca9548" ]; then
-    # Replace leading "0x" with "00"
-    i2c_dev_addr_4="00${i2c_dev_addr:2}"
-    echo '-2' > /sys/bus/i2c/devices/$i2c_bus_no-$i2c_dev_addr_4/idle_state
-  fi
+	# For pca9548 multiplexer, set idle_state to -2 (MUX_IDLE_DISCONNECT)
+	# Not doing this can result, for instance, in SFP EEPROMs not being
+	# read correctly by onlp.
+	if [ "$i2c_dev_name" = "pca9548" ]; then
+		# Replace leading "0x" with "00"
+		i2c_dev_addr_4="00${i2c_dev_addr:2}"
+		echo '-2' > /sys/bus/i2c/devices/$i2c_bus_no-$i2c_dev_addr_4/idle_state
+	fi
 }
 # make sure i2c-i801 is present
 wait_for_file /sys/bus/i2c/devices/i2c-0
@@ -86,30 +86,30 @@ create_i2c_dev 24c02 0x57 1
 
 # initialize SFP devices
 for port in {1..48}; do
-  create_i2c_dev optoe2 0x50 $((port + 41))
+	create_i2c_dev optoe2 0x50 $((port + 41))
 done
 
 for port in {1..48}; do
-  echo "port$port" > "/sys/bus/i2c/devices/$((port + 41))-0050/port_name"
+	echo "port$port" > "/sys/bus/i2c/devices/$((port + 41))-0050/port_name"
 done
 
 # initialize QSFP devices
 for port in {49..54}; do
-  create_i2c_dev optoe1 0x50 $((port - 23))
-  echo 0 > "/sys/bus/i2c/devices/3-0062/module_reset_$port"
+	create_i2c_dev optoe1 0x50 $((port - 23))
+	echo 0 > "/sys/bus/i2c/devices/3-0062/module_reset_$port"
 done
 
 port=49
 for sfp_no in 28 29 26 30 31 27; do
-  echo "port$port" > "/sys/bus/i2c/devices/$sfp_no-0050/port_name"
-  port=$(( port + 1 ))
+	echo "port$port" > "/sys/bus/i2c/devices/$sfp_no-0050/port_name"
+	port=$((port + 1))
 done
 
 # Set disable tx_disable to sfp port
 for port in {1..38}; do
-  echo 0 > "/sys/bus/i2c/devices/3-0061/module_tx_disable_$port"
+	echo 0 > "/sys/bus/i2c/devices/3-0061/module_tx_disable_$port"
 done
 
 for port in {39..48}; do
-  echo 0 > "/sys/bus/i2c/devices/3-0062/module_tx_disable_$port"
+	echo 0 > "/sys/bus/i2c/devices/3-0062/module_tx_disable_$port"
 done

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Platform init for as5835-54x
 #

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
@@ -8,17 +8,6 @@
 
 set -o errexit -o nounset
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 create_i2c_dev() {
 	local i2c_dev_name=$1
 	local i2c_dev_addr=$2

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -4,17 +4,6 @@ create_i2c_dev() {
 	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 # IR3570A chip casue problem when read eeprom by i2c-block mode.
 # It happen when read 16th-byte offset that value is 0x8. So disable chip
 ir3570_check() {

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -13,11 +13,6 @@ ir3570_check() {
 	fi
 }
 
-add_port() {
-	create_i2c_dev optoe1 0x50 ${2}
-	echo "port${1}" > "/sys/bus/i2c/devices/${2}-0050/port_name"
-}
-
 setup_10g() {
 	# Jitter Adjustment
 	i2cset -y 16 0x18 0xff 0x4
@@ -118,33 +113,33 @@ setup_10g "sfp"
 
 # add QSFP28 ports
 for port in {1..4}; do
-	add_port $port $((port + 20))
+	add_port 'optoe1' $port $((port + 20))
 done
 
-add_port 5 26
-add_port 6 25
-add_port 7 28
-add_port 8 27
+add_port 'optoe1' 5 26
+add_port 'optoe1' 6 25
+add_port 'optoe1' 7 28
+add_port 'optoe1' 8 27
 
 for port in {9..12}; do
-	add_port $port $((port + 8))
+	add_port 'optoe1' $port $((port + 8))
 done
 for port in {13..16}; do
-	add_port $port $((port + 16))
+	add_port 'optoe1' $port $((port + 16))
 done
 for port in {17..20}; do
-	add_port $port $((port + 16))
+	add_port 'optoe1' $port $((port + 16))
 done
 for port in {21..24}; do
-	add_port $port $((port + 24))
+	add_port 'optoe1' $port $((port + 24))
 done
 for port in {25..32}; do
-	add_port $port $((port + 12))
+	add_port 'optoe1' $port $((port + 12))
 done
 
 # add SFP+ ports
 for port in {33..34}; do
-	add_port $port $((port - 18))
+	add_port 'optoe1' $port $((port - 18))
 done
 
 # add EEPROM

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 create_i2c_dev() {
-  echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1
@@ -46,7 +46,7 @@ setup_10g() {
 	ic2set -y 16 0x18 0x2d 0x81
 
 	# Check devices
-	i2cget -y 14 0x58 0x00 b >/dev/null || return 1
+	i2cget -y 14 0x58 0x00 b > /dev/null || return 1
 
 	# VOD DEM EQ Adjustment
 	i2cset -y 14 0x58 0x06 0x18
@@ -133,7 +133,7 @@ setup_10g "sfp"
 
 # add QSFP28 ports
 for port in {1..4}; do
-	add_port $port $((port+20))
+	add_port $port $((port + 20))
 done
 
 add_port 5 26
@@ -142,24 +142,24 @@ add_port 7 28
 add_port 8 27
 
 for port in {9..12}; do
-	add_port $port $((port+8))
+	add_port $port $((port + 8))
 done
 for port in {13..16}; do
-	add_port $port $((port+16))
+	add_port $port $((port + 16))
 done
 for port in {17..20}; do
-	add_port $port $((port+16))
+	add_port $port $((port + 16))
 done
 for port in {21..24}; do
-	add_port $port $((port+24))
+	add_port $port $((port + 24))
 done
 for port in {25..32}; do
-	add_port $port $((port+12))
+	add_port $port $((port + 12))
 done
 
 # add SFP+ ports
 for port in {33..34}; do
-	add_port $port $((port-18))
+	add_port $port $((port - 18))
 done
 
 # add EEPROM

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 create_i2c_dev() {
   echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-create_i2c_dev() {
-	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
-}
-
 # IR3570A chip casue problem when read eeprom by i2c-block mode.
 # It happen when read 16th-byte offset that value is 0x8. So disable chip
 ir3570_check() {

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -139,7 +139,7 @@ done
 
 # add SFP+ ports
 for port in {33..34}; do
-	add_port 'optoe1' $port $((port - 18))
+	add_port 'optoe2' $port $((port - 18))
 done
 
 # add EEPROM

--- a/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
 create_i2c_dev() {
-  echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1

--- a/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
@@ -4,16 +4,6 @@ create_i2c_dev() {
 	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
 # make sure i2c-i801 is present
 wait_for_file /sys/bus/i2c/devices/i2c-0
 

--- a/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-create_i2c_dev() {
-	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
-}
-
 # make sure i2c-i801 is present
 wait_for_file /sys/bus/i2c/devices/i2c-0
 

--- a/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
@@ -7,7 +7,6 @@ wait_for_file /sys/bus/i2c/devices/i2c-0
 modprobe i2c-ismt
 
 # PCA9547 modulize
-wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev 24lc64t 0x56 1
 
 # load baseboard cpld module

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -4,17 +4,6 @@ create_i2c_dev() {
 	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 # Occasionally the management interface goes missing, a reboot seems to fix it.
 # Until we can find the root cause, check for its presence and reboot if not found.
 

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 create_i2c_dev() {
-  echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
+	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
 }
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1
@@ -19,7 +19,7 @@ function wait_for_file() {
 # Until we can find the root cause, check for its presence and reboot if not found.
 
 MGMT_STATE="FAILURE"
-wait_for_file /sys/class/net/enp0s20 &&	MGMT_STATE="SUCCESS"
+wait_for_file /sys/class/net/enp0s20 && MGMT_STATE="SUCCESS"
 
 [ -f "/var/last_boot.log" ] && LAST_STATE="$(tail -n 1 /var/last_boot.log | awk '{print $1;}')"
 echo "$MGMT_STATE $(date)" >> /var/last_boot.log

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-create_i2c_dev() {
-	echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device
-}
-
 # Occasionally the management interface goes missing, a reboot seems to fix it.
 # Until we can find the root cause, check for its presence and reboot if not found.
 

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 create_i2c_dev() {
   echo $1 $2 > /sys/bus/i2c/devices/i2c-${3}/new_device

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -27,12 +27,10 @@ wait_for_file /sys/bus/i2c/devices/i2c-0
 modprobe i2c-ismt
 
 # PCA9547 modulize
-wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev pca9548 0x70 1
 
 # Insert swpld module and create devs
 modprobe i2c_cpld
-wait_for_file /sys/bus/i2c/devices/i2c-2
 create_i2c_dev cpld 0x31 2
 create_i2c_dev cpld 0x35 2
 create_i2c_dev cpld 0x39 2

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
@@ -21,17 +21,6 @@ enable_qsfp() {
 	i2cset -y 2 0x32 0x0d 0x3f
 }
 
-wait_for_file() {
-	FILE=$1
-	i=0
-	while [ $i -lt 10 ]; do
-		test -e $FILE && return 0
-		i=$((i + 1))
-		sleep 1
-	done
-	return 1
-}
-
 BOOT_STATE="success"
 wait_for_file /sys/class/net/enp0s20f0 || BOOT_STATE="failure"
 if [ "$BOOT_STATE" != "success" ]; then

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function set_clocksouce() {
 	echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-function set_clocksouce() {
+set_clocksouce() {
 	echo tsc > /sys/devices/system/clocksource/clocksource0/current_clocksource
 }
 
-function enable_tx() {
+enable_tx() {
 	# Set Module TX-Disable Registers
 	i2cset -y 2 0x33 0x08 0x00
 	i2cset -y 2 0x33 0x09 0x00
@@ -14,19 +14,19 @@ function enable_tx() {
 	i2cset -y 2 0x33 0x0d 0x00
 }
 
-function enable_qsfp() {
+enable_qsfp() {
 	# disable LP Mode
 	i2cset -y 2 0x32 0x0b 0xc0
 	# clear ResetL
 	i2cset -y 2 0x32 0x0d 0x3f
 }
 
-function wait_for_file() {
+wait_for_file() {
 	FILE=$1
 	i=0
 	while [ $i -lt 10 ]; do
 		test -e $FILE && return 0
-		i=$(( i + 1 ))
+		i=$((i + 1))
 		sleep 1
 	done
 	return 1

--- a/recipes-core/platform-onl-init/platform-onl-init_0.1.bb
+++ b/recipes-core/platform-onl-init/platform-onl-init_0.1.bb
@@ -8,6 +8,8 @@ inherit systemd
 # provide it so Yocto will be happy.
 RPROVIDES:${PN} += " u-boot-default-env"
 
+RDEPENDS:${PN} += "bash"
+
 SRC_URI += " \
     file://8v89307_init.sh \
     file://platform-onl-init.service \


### PR DESCRIPTION
Since the different platform init code was initially written as distinct scripts, there is a lot of code duplication between them. So clean that up, unify the code style, and then improve the available functions.

Does the following things:

1. unify code style
2. use common wait_for_file(), create_i2c_dev(), add_port() functions
3. use unique as4610-30/54 and as4630-54pe/te init scripts
4. fix as7726-32x sfp+ port optoe driver type

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>