### PR TITLE
RFC: add generic onl machines

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -1,0 +1,61 @@
+#@TYPE: Machine
+#@NAME: onl-armel-iproc
+
+#@DESCRIPTION: Machine configuration for generic armel iProc ONL image
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
+PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
+
+KMACHINE:onl-armel-iproc = "armel-iproc"
+KERNEL_FEATURES += "bsp/armel-iproc"
+
+DEFAULTTUNE ?= "cortexa9"
+require conf/machine/include/qemu.inc
+require conf/machine/include/arm/armv7a/tune-cortexa9.inc
+require conf/machine/include/onl.inc
+
+MACHINE_FEATURES += "pcbios"
+MACHINE_FEATURES:remove = "alsa"
+
+KERNEL_FEATURES:remove = "features/debug/printk.scc features/kernel-sample/kernel-sample.scc"
+
+# https://git.yoctoproject.org/poky/tree/meta/classes/kernel-fitimage.bbclass
+KERNEL_CLASSES += "kernel-fitimage"
+
+KERNEL_IMAGETYPE = "fitImage"
+UBOOT_ENTRYPOINT="0x61008000"
+UBOOT_RD_LOADADDRESS = "0x00000000"
+UBOOT_RD_ENTRYPOINT = "0x00000000"
+# AS4610 U-Boot does not support sha256
+FIT_HASH_ALG = "sha1"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+KERNEL_DEVICETREE = " \
+    arm-accton-as4610.dtb \
+    arm-accton-as4610-30t.dtb \
+    arm-accton-as4610-30p.dtb \
+    arm-accton-as4610-54t.dtb \
+    arm-accton-as4610-54p.dtb \
+"
+
+BISDN_ARCH = "u-boot-arch"
+
+ONL_PLATFORM_SUPPORT = " \
+    arm-accton_as4610_30-r0 \
+    arm-accton_as4610_54-r0 \
+"
+
+MACHINE_EXTRA_RDEPENDS += " \
+    accton-as4610-poe-mcu-mod \
+    kernel-module-accton-as4610-cpld \
+    kernel-module-accton-as4610-fan \
+    kernel-module-accton-as4610-leds \
+    kernel-module-accton-as4610-psu \
+    kernel-module-optoe \
+    kernel-module-ym2651y \
+    platform-onl-init \
+"
+
+UBOOT_CONFIG = "sandbox"
+UBOOT_CONFIG[sandbox] = "sandbox_defconfig"
+
+PREFERRED_RPROVIDER_u-boot-default-env = "platform-onl-init"

--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -1,0 +1,66 @@
+#@TYPE: Machine
+#@NAME: generic x86-64 ONL image
+
+#@DESCRIPTION: Machine configuration for generic x86-64 ONL image
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
+PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
+
+KMACHINE:onl-x86-64 = "x86_64-intel"
+KERNEL_FEATURES += "bsp/x86_64-intel"
+
+DEFAULTTUNE ?= "corei7-64"
+
+require conf/machine/include/x86/tune-corei7.inc
+require conf/machine/include/x86/x86-base.inc
+require conf/machine/include/onl.inc
+
+MACHINE_FEATURES += "pcbios efi"
+MACHINE_FEATURES:remove = "alsa"
+
+ONL_PLATFORM_SUPPORT = " \
+    x86_64-accton_as4630_54pe-r0 \
+    x86_64-accton_as4630_54te-r0 \
+    x86_64-accton_as7726_32x-r0 \
+    x86_64-accton_as5835_54x-r0 \
+    x86_64-delta_ag5648-r0 \
+    x86_64-delta_ag5648v1-r0 \
+    x86_64-delta_ag7648-r0 \
+    x86_64-cel_questone_2a-r0 \
+"
+
+# delta-ag5648's i2c-cpld is part of delta's common vendor modules
+ONL_MODULE_VENDORS = "delta"
+
+MACHINE_EXTRA_RDEPENDS += " \
+    accton-as4630-54pe-poe-mcu-mod \
+    ipmitool \
+    kernel-module-optoe \
+    kernel-module-x86-64-accton-as4630-54pe-cpld \
+    kernel-module-x86-64-accton-as4630-54pe-leds \
+    kernel-module-x86-64-accton-as4630-54pe-psu \
+    kernel-module-x86-64-accton-as4630-54te-cpld \
+    kernel-module-x86-64-accton-as4630-54te-leds \
+    kernel-module-x86-64-accton-as4630-54te-psu \
+    kernel-module-x86-64-accton-as7726-32x-cpld \
+    kernel-module-x86-64-accton-as7726-32x-fan \
+    kernel-module-x86-64-accton-as7726-32x-leds \
+    kernel-module-x86-64-accton-as7726-32x-psu \
+    kernel-module-x86-64-accton-as5835-54x-cpld \
+    kernel-module-x86-64-accton-as5835-54x-fan \
+    kernel-module-x86-64-accton-as5835-54x-leds \
+    kernel-module-x86-64-accton-as5835-54x-psu \
+    kernel-module-x86-64-delta-ag7648-cpld-mux-1 \
+    kernel-module-x86-64-delta-ag7648-cpld-mux-2 \
+    kernel-module-x86-64-delta-ag7648-i2c-mux-setting \
+    kernel-module-dni-ag5648-psu \
+    kernel-module-dni-ag5648-sfp \
+    kernel-module-dni-emc2305 \
+    kernel-module-i2c-cpld \
+    kernel-module-mc24lc64t \
+    kernel-module-optoe \
+    kernel-module-questone2a-baseboard-cpld \
+    kernel-module-questone2a-switchboard \
+    kernel-module-ym2651y \
+    platform-onl-init \
+"

--- a/recipes-bsp/formfactor/formfactor/generic-armel-iproc/machconfig
+++ b/recipes-bsp/formfactor/formfactor/generic-armel-iproc/machconfig
@@ -1,0 +1,3 @@
+# Assume neither USB mouse nor keyboard is connected
+HAVE_TOUCHSCREEN=0
+HAVE_KEYBOARD=0

--- a/recipes-bsp/formfactor/formfactor/generic-x86-64/machconfig
+++ b/recipes-bsp/formfactor/formfactor/generic-x86-64/machconfig
@@ -1,0 +1,3 @@
+# Assume neither USB mouse nor keyboard is connected
+HAVE_TOUCHSCREEN=0
+HAVE_KEYBOARD=0


### PR DESCRIPTION
Now that everything is in place to support multiple machines at the same time, add generic onl machines that have support for all verified platforms enabled, called onl-\<arch\>.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>