### PR TITLE
linux-yocto-onl: add missing module conf for i2c-ismt

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -36,6 +36,14 @@ DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
 DEPENDS += "openssl-native util-linux-native"
 DEPENDS += "gmp-native libmpc-native"
 
+# With i2c-i801 and i2c-ismt built as modules there is no guarantee one or the
+# other will be probed first and gets bus 0, but platforms use hardcoded paths
+# assuming bus 0 is i2c-i801.
+# So mark i2c-i801 as to be loaded before i2c-ismt to make sure it is probed
+# first.
+KERNEL_MODULE_PROBECONF:append:x86-64 = " i2c-ismt"
+module_conf_i2c-ismt = "softdep i2c-ismt pre: i2c-i801"
+
 # meta-virtualization does not provide a linux-yocto_6.1_virtualization.inc,
 # so we need to include it directly.
 include ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'recipes-kernel/linux/linux-yocto_virtualization.inc', '', d)}


### PR DESCRIPTION
While testing/preparing the 6.1 kernel, the i2c-ismt module conf was not properly added to the recipe, causing failures due to unexpected bus numbers again.

So add it again.

Fixes: 32cede492ebc ("linux-yocto-onl: add linux 6.1 support")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>