### PR TITLE
cel-questone-2a: drop old platform questone-2a rdepends

### DIFF
--- a/conf/machine/cel-questone-2a.conf
+++ b/conf/machine/cel-questone-2a.conf
@@ -33,6 +33,5 @@ MACHINE_EXTRA_RDEPENDS += " \
     kernel-module-mc24lc64t \
     platform-onl-init \
 "
-MACHINE_EXTRA_RDEPENDS += "platform-questone-2a"
 
 OFDPA_SWITCH_SUPPORT = "BCM56770"


### PR DESCRIPTION
When moving questone-2a to the generic platform-onl-init, the old RDEPENDS was accidentally left in. This package does not exist anymore so remove it.

Fixes the following build error:

```
ERROR: Nothing RPROVIDES 'platform-questone-2a' (but /builds/yocto-projects/switch-image-builder/poky/meta/recipes-core/packagegroups/packagegroup-base.bb RDEPENDS on or otherwise requires it)
Dec 07 18:05:25 NOTE: Runtime target 'platform-questone-2a' is unbuildable, removing...
Dec 07 18:05:25 Missing or unbuildable dependency chain was: ['platform-questone-2a']
Dec 07 18:05:25 NOTE: Runtime target 'packagegroup-base-extended' is unbuildable, removing...
Dec 07 18:05:25 Missing or unbuildable dependency chain was: ['packagegroup-base-extended', 'platform-questone-2a']
ERROR: Required build target 'full' has no buildable providers. Missing or unbuildable dependency chain was: ['full', 'packagegroup-base-extended', 'platform-questone-2a']
```

Fixes: 8ab5031bd1e1 ("platform-questone-2a: merge into platform-onl-init")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>