### PR TITLE
linux-yocto-onl/6.1: update to 6.1.8

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -15,7 +15,7 @@ SRCREV_machine ?= "830b3c68c1fb1e9176028d02ef86f3cf76aa2476"
 SRCREV_meta ?= "185bcfcbe480c742247d9117011794c69682914f"
 
 SRC_URI += "\
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=master;destsuffix=kernel-meta \
+    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \
     file://bisdn-kmeta;type=kmeta;name=bisdn-kmeta;destsuffix=bisdn-kmeta \
 "
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1"
+LINUX_VERSION ?= "6.1.8"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "830b3c68c1fb1e9176028d02ef86f3cf76aa2476"
+SRCREV_machine ?= "93f875a8526a291005e7f38478079526c843cbec"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "185bcfcbe480c742247d9117011794c69682914f"
+SRCREV_meta ?= "fdad265d2bff2ddb937b3eebdabe344d1f450cf4"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 6.1.8 and kernel meta to HEAD in absence
of a 6.1.8 commit. Also switch kernel-meta to now existing yocto-6.1 branch.

Contains the usual mix of bug fixes for various subsystems.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.8
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.7
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.6
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.5
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.4
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.3
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.2
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.1

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>