### PR TITLE
platform-onl-init: manually load i2c-ismt

### DIFF
--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as4630-54pe-r0-init.sh
@@ -40,12 +40,17 @@ case "$onl_platform" in
 		;;
 esac
 
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
+
 # load modules
+modprobe i2c-ismt
 modprobe x86-64-accton-as4630-${variant}-cpld
 modprobe x86-64-accton-as4630-${variant}-psu
 modprobe x86-64-accton-as4630-${variant}-leds
 
 # init mux (PCA9548)
+wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev pca9548 0x77 1
 echo '-2' > /sys/bus/i2c/devices/1-0077/idle_state
 create_i2c_dev pca9548 0x71 2

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as5835-54x-r0-init.sh
@@ -36,8 +36,11 @@ create_i2c_dev() {
     echo '-2' > /sys/bus/i2c/devices/$i2c_bus_no-$i2c_dev_addr_4/idle_state
   fi
 }
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
 
 # load modules
+modprobe i2c-ismt
 modprobe x86-64-accton-as5835-54x-cpld
 modprobe x86-64-accton-as5835-54x-psu
 modprobe x86-64-accton-as5835-54x-leds

--- a/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-accton-as7726-32x-r0-init.sh
@@ -80,17 +80,20 @@ setup_10g() {
 		return 1
 	fi
 }
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
 
 # load modules
+modprobe i2c-ismt
 modprobe x86-64-accton-as7726-32x-cpld
 modprobe x86-64-accton-as7726-32x-fan
 modprobe x86-64-accton-as7726-32x-psu
 modprobe x86-64-accton-as7726-32x-leds
 
 # add PCA9548 muxes and enable disconnect on idle
-wait_for_file /sys/bus/i2c/devices/i2c-0
 create_i2c_dev pca9548 0x77 0
 echo '-2' > /sys/bus/i2c/devices/0-0077/idle_state
+wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev pca9548 0x76 1
 echo '-2' > /sys/bus/i2c/devices/1-0076/idle_state
 create_i2c_dev pca9548 0x72 1

--- a/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-cel-questone-2a-r0-init.sh
@@ -14,6 +14,11 @@ function wait_for_file() {
 	done
 	return 1
 }
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
+
+# load modules
+modprobe i2c-ismt
 
 # PCA9547 modulize
 wait_for_file /sys/bus/i2c/devices/i2c-1

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag5648-r0-init.sh
@@ -35,6 +35,12 @@ else
 	echo "Management interface present."
 fi
 
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
+
+# load modules
+modprobe i2c-ismt
+
 # PCA9547 modulize
 wait_for_file /sys/bus/i2c/devices/i2c-1
 create_i2c_dev pca9548 0x70 1

--- a/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-x86-64-delta-ag7648-r0-init.sh
@@ -59,5 +59,11 @@ if [ "$BOOT_STATE" != "success" ]; then
 	fi
 fi
 
+# make sure i2c-i801 is present
+wait_for_file /sys/bus/i2c/devices/i2c-0
+
+# load modules
+modprobe i2c-ismt
+
 wait_for_file /sys/bus/i2c/devices/0-0069 && set_clocksouce
 wait_for_file /sys/bus/i2c/devices/i2c-2 && enable_tx && enable_qsfp

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -39,7 +39,7 @@ DEPENDS += "gmp-native libmpc-native"
 # With i2c-i801 and i2c-ismt built as modules there is no guarantee one or the
 # other will be probed first and gets bus 0, but platforms use hardcoded paths
 # assuming bus 0 is i2c-i801.
-# So mark i2c-i801 as to be loaded before i2c-ismt to make sure it is probed
-# first.
+# So blacklist i2c-ismt to load it via platform code once i2c-i801 finished
+# registering its i2c bus.
 KERNEL_MODULE_PROBECONF:append:x86-64 = " i2c-ismt"
-module_conf_i2c-ismt = "softdep i2c-ismt pre: i2c-i801"
+module_conf_i2c-ismt = "blacklist i2c-ismt"

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -39,10 +39,10 @@ DEPENDS += "gmp-native libmpc-native"
 # With i2c-i801 and i2c-ismt built as modules there is no guarantee one or the
 # other will be probed first and gets bus 0, but platforms use hardcoded paths
 # assuming bus 0 is i2c-i801.
-# So mark i2c-i801 as to be loaded before i2c-ismt to make sure it is probed
-# first.
+# So blacklist i2c-ismt to load it via platform code once i2c-i801 finished
+# registering its i2c bus.
 KERNEL_MODULE_PROBECONF:append:x86-64 = " i2c-ismt"
-module_conf_i2c-ismt = "softdep i2c-ismt pre: i2c-i801"
+module_conf_i2c-ismt = "blacklist i2c-ismt"
 
 # meta-virtualization does not provide a linux-yocto_6.1_virtualization.inc,
 # so we need to include it directly.


### PR DESCRIPTION
Using the pre: softdep for forcing a load order of i2c-ismt and i2c-i801 still leaves a window where the i2c-i801 driver has loaded, but not attached, and consequently i2c-ismt may still occationally win the race for the first i2c bus.

Since there is no way to specify any sleeps or waits in the modprobe configuration, blacklist the module and let platforms ensure that the i2c busses are registeredd in the right order in a deterministic way.

Fixes: e024e2ad3dd7 ("linux-yocto-onl: build i2c_i801 as a module and fix probe order")
Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>