### PR TITLE
linux-yocto-onl/6.1: update to 6.1.14

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.8"
+LINUX_VERSION ?= "6.1.13"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "93f875a8526a291005e7f38478079526c843cbec"
+SRCREV_machine ?= "1ac8758e027247774464c808447a9c2f1f97b637"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "fdad265d2bff2ddb937b3eebdabe344d1f450cf4"
+SRCREV_meta ?= "6c723fc4d35fbdb277e28d0072f8117e43679528"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,9 +6,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.13"
+LINUX_VERSION ?= "6.1.14"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "1ac8758e027247774464c808447a9c2f1f97b637"
+SRCREV_machine ?= "7d54cb2c26dad1264ecca85992bfe8984df4b7b5"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1


### PR DESCRIPTION
Update the kernel to latest 6.1.13 and kernel meta to HEAD in absence of a 6.1.14 commit.

Contains the usual mix of bug fixes for various subsystems.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.14
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.13
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.12
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.11
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.10
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.9

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>