### PR TITLE
conf/machine: fix generic machine KMACHINE definition

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -1,12 +1,12 @@
 #@TYPE: Machine
-#@NAME: onl-armel-iproc
+#@NAME: generic armel iProc ONL image
 
 #@DESCRIPTION: Machine configuration for generic armel iProc ONL image
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
 PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
 
-KMACHINE:onl-armel-iproc = "armel-iproc"
+KMACHINE:generic-armel-iproc = "armel-iproc"
 KERNEL_FEATURES += "bsp/armel-iproc"
 
 DEFAULTTUNE ?= "cortexa9"

--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -6,7 +6,7 @@
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
 PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
 
-KMACHINE:onl-x86-64 = "x86_64-intel"
+KMACHINE:generic-x86-64 = "x86_64-intel"
 KERNEL_FEATURES += "bsp/x86_64-intel"
 
 DEFAULTTUNE ?= "corei7-64"


### PR DESCRIPTION
When renaming the generic machines from onl- to generic- renaming the KMACHINE definitions was missed, breaking the build.

Fix this by updating them accordingly.