### PR TITLE
accton-as4610-poe-mcu: only load module on demand

### DIFF
--- a/recipes-kernel/accton-as4610-poe-mcu/accton-as4610-poe-mcu-mod_1.0.bb
+++ b/recipes-kernel/accton-as4610-poe-mcu/accton-as4610-poe-mcu-mod_1.0.bb
@@ -12,8 +12,6 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-KERNEL_MODULE_AUTOLOAD += "accton_as4610_poe_mcu"
-
 EXTRA_OEMAKE += " KBUILD_MODPOST_WARN=1"
 
 FILES:${PN} += "${sbindir}/poectl"

--- a/recipes-kernel/accton-as4610-poe-mcu/files/accton_as4610_poe_mcu.c
+++ b/recipes-kernel/accton-as4610-poe-mcu/files/accton_as4610_poe_mcu.c
@@ -854,8 +854,10 @@ static void as4610_poe_pse_remove(struct serdev_device *serdev)
 }
 
 static const struct of_device_id as4610_poe_pse_of_match[] = {
-	{ .compatible = "accton,as4610-poe-pse", }
+	{ .compatible = "accton,as4610-poe-pse", },
+	{ },
 };
+MODULE_DEVICE_TABLE(of, as4610_poe_pse_of_match);
 
 static struct serdev_device_driver as4610_poe_pse_driver = {
 	.probe = as4610_poe_pse_probe,


### PR DESCRIPTION
There is no need to force load the module, the kernel is capable of requesting it when it encounters a device handled by it. To do that, the module needs to expose the handled device names via `MODULE_DEVICE_TABLE()`. So add one and drop the forced load on boot.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>