### PR TITLE
conf/machine: remove unused variables

### DIFF
--- a/conf/machine/accton-as4610.conf
+++ b/conf/machine/accton-as4610.conf
@@ -30,8 +30,6 @@ UBOOT_RD_ENTRYPOINT = "0x00000000"
 FIT_HASH_ALG = "sha1"
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 KERNEL_DEVICETREE = "arm-accton-as4610.dtb arm-accton-as4610-30t.dtb arm-accton-as4610-30p.dtb arm-accton-as4610-54t.dtb arm-accton-as4610-54p.dtb"
-PLATFORM_VENDOR = "accton"
-BISDN_ONIE_MACHINE = "as4610"
 BISDN_ARCH = "u-boot-arch"
 
 ONIE_VENDOR = "accton"

--- a/conf/machine/accton-as4630-54pe.conf
+++ b/conf/machine/accton-as4630-54pe.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "accton"
-BISDN_ONIE_MACHINE = "as4630-54pe"
-
 ONIE_VENDOR = "accton"
 ONIE_MACHINE_TYPE = "as4630_54pe"
 

--- a/conf/machine/accton-as5835-54x.conf
+++ b/conf/machine/accton-as5835-54x.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "accton"
-BISDN_ONIE_MACHINE = "as5835-54x"
-
 ONIE_VENDOR = "accton"
 ONIE_MACHINE_TYPE = "as5835_54x"
 

--- a/conf/machine/accton-as7726-32x.conf
+++ b/conf/machine/accton-as7726-32x.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "accton"
-BISDN_ONIE_MACHINE = "as7726-32x"
-
 ONIE_VENDOR = "accton"
 ONIE_MACHINE_TYPE = "as7726_32x"
 

--- a/conf/machine/agema-ag5648.conf
+++ b/conf/machine/agema-ag5648.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "agema"
-BISDN_ONIE_MACHINE = "ag5648"
-
 ONIE_VENDOR = "delta"
 ONIE_MACHINE_TYPE = "ag5648"
 

--- a/conf/machine/agema-ag7648.conf
+++ b/conf/machine/agema-ag7648.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "agema"
-BISDN_ONIE_MACHINE = "ag7648"
-
 ONIE_VENDOR = "delta"
 ONIE_MACHINE_TYPE = "ag7648"
 

--- a/conf/machine/cel-questone-2a.conf
+++ b/conf/machine/cel-questone-2a.conf
@@ -18,9 +18,6 @@ require conf/machine/include/onl.inc
 MACHINE_FEATURES += "pcbios efi"
 MACHINE_FEATURES:remove = "alsa"
 
-PLATFORM_VENDOR = "celestica"
-BISDN_ONIE_MACHINE = "questone-2a"
-
 ONIE_VENDOR = "celestica"
 ONIE_VENDOR_SHORT = "cel"
 ONIE_MACHINE_TYPE = "questone_2a"


### PR DESCRIPTION
Use of BISDN_ONIE_MACHINE has ended with [1].
Use of PLATFORM_VENDOR has ended with [2].

[1] mk_bisdn_yocto_image.sh: drop machine= from machine.conf
    https://github.com/bisdn/bisdn-onie-additions/commit/2efb8c8ea3eb16afaa2ffc7101b1c33c232c6d07
[2] installer: flatten machines and use ONIE names
    https://github.com/bisdn/meta-switch/commit/322da89169544e0fcd401d1112587420163c3e64