### PR TITLE
linux-yocto-onl/6.1: update to 6.1.31

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.25"
+LINUX_VERSION ?= "6.1.31"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "f17b0ab65d17988d5e6d6fe22f708ef3721080bf"
+SRCREV_machine ?= "d2869ace6eeb8ea8a6e70e6904524c5a6456d3fb"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "36901b5b298e601fe73dd79aaff8b615a7762013"
+SRCREV_meta ?= "61b6de9402762b8e9fa21c0f1c463591048cd194"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 6.1.31 and kernel meta accordingly.

Contains the usual mix of bug fixes for various subsystems.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.31
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.30
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.29
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.28
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.27
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.26