### PR TITLE
linux-yocto-onl/5.15: update to 5.15.114

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "5.15.108"
+LINUX_VERSION ?= "5.15.114"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-5.15.y
-SRCREV_machine ?= "3299fb36854fdc288bddc2c4d265f8a2e5105944"
+SRCREV_machine ?= "0ab06468cbd149aac0d7f216ec00452ff8c74e0b"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-5.15
-SRCREV_meta ?= "246b4be32d9bdd003f1b8142334bab7e3d54d8c8"
+SRCREV_meta ?= "ba0876ac0b787294ecb502d82c057ac71fd3fe3d"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel 5.15 to 5.15.114 and kmeta accordingly.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.114
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.113
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.112
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.111
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.110
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-5.15.109