### PR TITLE
linux-yocto-onl/6.1: update to 6.1.38

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.31"
+LINUX_VERSION ?= "6.1.38"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "d2869ace6eeb8ea8a6e70e6904524c5a6456d3fb"
+SRCREV_machine ?= "61fd484b2cf6bc8022e8e5ea6f693a9991740ac2"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "61b6de9402762b8e9fa21c0f1c463591048cd194"
+SRCREV_meta ?= "2eaed50911009f9ddbc74460093e17b22ef7daa0"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 6.1.38 and kernel meta accordingly.

Contains the usual mix of bug and security fixes for various subsystems.

CVEs fixed:

* CVE-2023-35788
* CVE-2023-34255
* CVE-2023-2124
* CVE-2023-3212
* CVE-2022-48425
* CVE-2023-3390
* CVE-2023-3269

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.38
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.37
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.36
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.35
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.34
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.33
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.32