### PR TITLE
linux-yocto-onl/6.1: update to 6.1.46

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,9 +6,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.45"
+LINUX_VERSION ?= "6.1.46"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "1321ab403b38366a4cfb283145bb2c005becb1e5"
+SRCREV_machine ?= "6c44e13dc284f7f4db17706ca48fd016d6b3d49a"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.44"
+LINUX_VERSION ?= "6.1.45"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "0a4a7855302d56a1d75cec3aa9a6914a3af9c6af"
+SRCREV_machine ?= "1321ab403b38366a4cfb283145bb2c005becb1e5"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "fd76f76e2b84ddc47ade29ca3118ff14c2b9b67e"
+SRCREV_meta ?= "8da434f09dc2892d8ec26325f0856aabccc17bed"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to latest 6.1.46 and kernel meta to 6.1.45, as there is no .46 bump yet.

Contains the usual mix of bug fixes for various subsystems.

Most interesting change are:

4.1.45:

* vxlan: Fix nexthop hash size
  (fixes a crash with multiple nexthops)

4.1.46:

* nexthop: Fix infinite nexthop bucket dump when using maximum nexthop ID
* nexthop: Fix infinite nexthop dump when using maximum nexthop ID
* bonding: Fix incorrect deletion of ETH_P_8021AD protocol vid from slaves

Full changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.45
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.46