### PR TITLE
linux-yocto-onl/6.1: update to 6.1.47

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -6,13 +6,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.46"
+LINUX_VERSION ?= "6.1.47"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "6c44e13dc284f7f4db17706ca48fd016d6b3d49a"
+SRCREV_machine ?= "802aacbbffe2512dce9f8f33ad99d01cfec435de"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "8da434f09dc2892d8ec26325f0856aabccc17bed"
+SRCREV_meta ?= "7929c8cf5d28763fb1796bb598065242cdb978a6"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update the kernel to 6.1.47. Update kmeta to HEAD in absence of a kver bump.

Contains the usual mix of bug fixes for various subsystems.

Most interesting changes are:

* sock: Fix misuse of sk_under_memory_pressure()
* team: Fix incorrect deletion of ETH_P_8021AD protocol vid from slaves
* i2c: bcm-iproc: Fix bcm_iproc_i2c_isr deadlock issue

Full changelog:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.47