### PR TITLE
inux-yocto-onl: add generated CVE exclusion lists

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_5.15.inc
+++ b/recipes-kernel/linux/cve-exclusion_5.15.inc
@@ -1,0 +1,7232 @@
+
+# Auto-generated CVE metadata, DO NOT EDIT BY HAND.
+# Generated at 2023-09-13 07:44:51.307613 for version 5.15.114
+
+python check_kernel_cve_status_version() {
+    this_version = "5.15.114"
+    kernel_version = d.getVar("LINUX_VERSION")
+    if kernel_version != this_version:
+        bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
+}
+do_cve_check[prefuncs] += "check_kernel_cve_status_version"
+
+# fixed-version: Fixed after version 2.6.12rc2
+CVE_CHECK_IGNORE += "CVE-2003-1604"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2004-0230"
+
+# CVE-2005-3660 has no known resolution
+
+# fixed-version: Fixed after version 2.6.26rc5
+CVE_CHECK_IGNORE += "CVE-2006-3635"
+
+# fixed-version: Fixed after version 2.6.19rc3
+CVE_CHECK_IGNORE += "CVE-2006-5331"
+
+# fixed-version: Fixed after version 2.6.19rc2
+CVE_CHECK_IGNORE += "CVE-2006-6128"
+
+# CVE-2007-3719 has no known resolution
+
+# fixed-version: Fixed after version 2.6.12rc2
+CVE_CHECK_IGNORE += "CVE-2007-4774"
+
+# fixed-version: Fixed after version 2.6.24rc6
+CVE_CHECK_IGNORE += "CVE-2007-6761"
+
+# fixed-version: Fixed after version 2.6.20rc5
+CVE_CHECK_IGNORE += "CVE-2007-6762"
+
+# CVE-2008-2544 has no known resolution
+
+# CVE-2008-4609 has no known resolution
+
+# fixed-version: Fixed after version 2.6.25rc1
+CVE_CHECK_IGNORE += "CVE-2008-7316"
+
+# fixed-version: Fixed after version 2.6.31rc6
+CVE_CHECK_IGNORE += "CVE-2009-2692"
+
+# fixed-version: Fixed after version 2.6.23rc9
+CVE_CHECK_IGNORE += "CVE-2010-0008"
+
+# fixed-version: Fixed after version 2.6.36rc5
+CVE_CHECK_IGNORE += "CVE-2010-3432"
+
+# CVE-2010-4563 has no known resolution
+
+# fixed-version: Fixed after version 2.6.37rc6
+CVE_CHECK_IGNORE += "CVE-2010-4648"
+
+# fixed-version: Fixed after version 2.6.38rc1
+CVE_CHECK_IGNORE += "CVE-2010-5313"
+
+# CVE-2010-5321 has no known resolution
+
+# fixed-version: Fixed after version 2.6.35rc1
+CVE_CHECK_IGNORE += "CVE-2010-5328"
+
+# fixed-version: Fixed after version 2.6.39rc1
+CVE_CHECK_IGNORE += "CVE-2010-5329"
+
+# fixed-version: Fixed after version 2.6.34rc7
+CVE_CHECK_IGNORE += "CVE-2010-5331"
+
+# fixed-version: Fixed after version 2.6.37rc1
+CVE_CHECK_IGNORE += "CVE-2010-5332"
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-4098"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2011-4131"
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-4915"
+
+# CVE-2011-4916 has no known resolution
+
+# CVE-2011-4917 has no known resolution
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-5321"
+
+# fixed-version: Fixed after version 3.1rc1
+CVE_CHECK_IGNORE += "CVE-2011-5327"
+
+# fixed-version: Fixed after version 3.7rc2
+CVE_CHECK_IGNORE += "CVE-2012-0957"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2119"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2136"
+
+# fixed-version: Fixed after version 3.5rc2
+CVE_CHECK_IGNORE += "CVE-2012-2137"
+
+# fixed-version: Fixed after version 3.4rc6
+CVE_CHECK_IGNORE += "CVE-2012-2313"
+
+# fixed-version: Fixed after version 3.4rc6
+CVE_CHECK_IGNORE += "CVE-2012-2319"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2012-2372"
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-2375"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2390"
+
+# fixed-version: Fixed after version 3.5rc4
+CVE_CHECK_IGNORE += "CVE-2012-2669"
+
+# fixed-version: Fixed after version 2.6.34rc1
+CVE_CHECK_IGNORE += "CVE-2012-2744"
+
+# fixed-version: Fixed after version 3.4rc3
+CVE_CHECK_IGNORE += "CVE-2012-2745"
+
+# fixed-version: Fixed after version 3.5rc6
+CVE_CHECK_IGNORE += "CVE-2012-3364"
+
+# fixed-version: Fixed after version 3.4rc5
+CVE_CHECK_IGNORE += "CVE-2012-3375"
+
+# fixed-version: Fixed after version 3.5rc5
+CVE_CHECK_IGNORE += "CVE-2012-3400"
+
+# fixed-version: Fixed after version 3.6rc2
+CVE_CHECK_IGNORE += "CVE-2012-3412"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-3430"
+
+# fixed-version: Fixed after version 2.6.19rc4
+CVE_CHECK_IGNORE += "CVE-2012-3510"
+
+# fixed-version: Fixed after version 3.5rc6
+CVE_CHECK_IGNORE += "CVE-2012-3511"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-3520"
+
+# fixed-version: Fixed after version 3.0rc1
+CVE_CHECK_IGNORE += "CVE-2012-3552"
+
+# Skipping CVE-2012-4220, no affected_versions
+
+# Skipping CVE-2012-4221, no affected_versions
+
+# Skipping CVE-2012-4222, no affected_versions
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-4398"
+
+# fixed-version: Fixed after version 2.6.36rc4
+CVE_CHECK_IGNORE += "CVE-2012-4444"
+
+# fixed-version: Fixed after version 3.7rc6
+CVE_CHECK_IGNORE += "CVE-2012-4461"
+
+# fixed-version: Fixed after version 3.6rc5
+CVE_CHECK_IGNORE += "CVE-2012-4467"
+
+# fixed-version: Fixed after version 3.7rc3
+CVE_CHECK_IGNORE += "CVE-2012-4508"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-4530"
+
+# CVE-2012-4542 has no known resolution
+
+# fixed-version: Fixed after version 3.7rc4
+CVE_CHECK_IGNORE += "CVE-2012-4565"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-5374"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-5375"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-5517"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6536"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6537"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6538"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6539"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6540"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6541"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6542"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6543"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6544"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6545"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6546"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6547"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6548"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6549"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2012-6638"
+
+# fixed-version: Fixed after version 3.6rc2
+CVE_CHECK_IGNORE += "CVE-2012-6647"
+
+# fixed-version: Fixed after version 3.6
+CVE_CHECK_IGNORE += "CVE-2012-6657"
+
+# fixed-version: Fixed after version 3.6rc5
+CVE_CHECK_IGNORE += "CVE-2012-6689"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-6701"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2012-6703"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-6704"
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-6712"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-0160"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0190"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0216"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0217"
+
+# fixed-version: Fixed after version 3.8
+CVE_CHECK_IGNORE += "CVE-2013-0228"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0231"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-0268"
+
+# fixed-version: Fixed after version 3.8
+CVE_CHECK_IGNORE += "CVE-2013-0290"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2013-0309"
+
+# fixed-version: Fixed after version 3.5
+CVE_CHECK_IGNORE += "CVE-2013-0310"
+
+# fixed-version: Fixed after version 3.7rc8
+CVE_CHECK_IGNORE += "CVE-2013-0311"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0313"
+
+# fixed-version: Fixed after version 3.11rc7
+CVE_CHECK_IGNORE += "CVE-2013-0343"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-0349"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0871"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-0913"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-0914"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-1059"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-1763"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-1767"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2013-1772"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2013-1773"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-1774"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1792"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1796"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1797"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1798"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-1819"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2013-1826"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2013-1827"
+
+# fixed-version: Fixed after version 3.9rc2
+CVE_CHECK_IGNORE += "CVE-2013-1828"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1848"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1858"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1860"
+
+# fixed-version: Fixed after version 3.7rc3
+CVE_CHECK_IGNORE += "CVE-2013-1928"
+
+# fixed-version: Fixed after version 3.9rc6
+CVE_CHECK_IGNORE += "CVE-2013-1929"
+
+# Skipping CVE-2013-1935, no affected_versions
+
+# fixed-version: Fixed after version 3.0rc1
+CVE_CHECK_IGNORE += "CVE-2013-1943"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1956"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1957"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1958"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-1959"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-1979"
+
+# fixed-version: Fixed after version 3.8rc2
+CVE_CHECK_IGNORE += "CVE-2013-2015"
+
+# fixed-version: Fixed after version 2.6.34
+CVE_CHECK_IGNORE += "CVE-2013-2017"
+
+# fixed-version: Fixed after version 3.8rc4
+CVE_CHECK_IGNORE += "CVE-2013-2058"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2094"
+
+# fixed-version: Fixed after version 2.6.34rc4
+CVE_CHECK_IGNORE += "CVE-2013-2128"
+
+# fixed-version: Fixed after version 3.11rc3
+CVE_CHECK_IGNORE += "CVE-2013-2140"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2141"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2146"
+
+# fixed-version: Fixed after version 3.12rc3
+CVE_CHECK_IGNORE += "CVE-2013-2147"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2148"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2164"
+
+# Skipping CVE-2013-2188, no affected_versions
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-2206"
+
+# Skipping CVE-2013-2224, no affected_versions
+
+# fixed-version: Fixed after version 3.10
+CVE_CHECK_IGNORE += "CVE-2013-2232"
+
+# fixed-version: Fixed after version 3.10
+CVE_CHECK_IGNORE += "CVE-2013-2234"
+
+# fixed-version: Fixed after version 3.9rc6
+CVE_CHECK_IGNORE += "CVE-2013-2237"
+
+# Skipping CVE-2013-2239, no affected_versions
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2546"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2547"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2548"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2596"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2634"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2635"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2636"
+
+# fixed-version: Fixed after version 3.10rc4
+CVE_CHECK_IGNORE += "CVE-2013-2850"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2851"
+
+# fixed-version: Fixed after version 3.10rc6
+CVE_CHECK_IGNORE += "CVE-2013-2852"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2888"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2889"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2890"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2891"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2892"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2893"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2894"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2895"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2896"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2897"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2898"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2899"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-2929"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-2930"
+
+# fixed-version: Fixed after version 3.9
+CVE_CHECK_IGNORE += "CVE-2013-3076"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3222"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3223"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3224"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3225"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3226"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3227"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3228"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3229"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3230"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3231"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3232"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3233"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3234"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3235"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3236"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3237"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3301"
+
+# fixed-version: Fixed after version 3.8rc3
+CVE_CHECK_IGNORE += "CVE-2013-3302"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4125"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4127"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4129"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4162"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4163"
+
+# fixed-version: Fixed after version 3.11rc5
+CVE_CHECK_IGNORE += "CVE-2013-4205"
+
+# fixed-version: Fixed after version 3.10rc4
+CVE_CHECK_IGNORE += "CVE-2013-4220"
+
+# fixed-version: Fixed after version 3.10rc5
+CVE_CHECK_IGNORE += "CVE-2013-4247"
+
+# fixed-version: Fixed after version 3.11rc6
+CVE_CHECK_IGNORE += "CVE-2013-4254"
+
+# fixed-version: Fixed after version 3.12rc4
+CVE_CHECK_IGNORE += "CVE-2013-4270"
+
+# fixed-version: Fixed after version 3.12rc6
+CVE_CHECK_IGNORE += "CVE-2013-4299"
+
+# fixed-version: Fixed after version 3.11
+CVE_CHECK_IGNORE += "CVE-2013-4300"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2013-4312"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-4343"
+
+# fixed-version: Fixed after version 3.13rc2
+CVE_CHECK_IGNORE += "CVE-2013-4345"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-4348"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-4350"
+
+# fixed-version: Fixed after version 3.12rc4
+CVE_CHECK_IGNORE += "CVE-2013-4387"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-4470"
+
+# fixed-version: Fixed after version 3.10rc1
+CVE_CHECK_IGNORE += "CVE-2013-4483"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4511"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4512"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4513"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4514"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4515"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4516"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-4563"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2013-4579"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-4587"
+
+# fixed-version: Fixed after version 2.6.33rc4
+CVE_CHECK_IGNORE += "CVE-2013-4588"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2013-4591"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2013-4592"
+
+# Skipping CVE-2013-4737, no affected_versions
+
+# Skipping CVE-2013-4738, no affected_versions
+
+# Skipping CVE-2013-4739, no affected_versions
+
+# fixed-version: Fixed after version 3.10rc5
+CVE_CHECK_IGNORE += "CVE-2013-5634"
+
+# fixed-version: Fixed after version 3.6rc6
+CVE_CHECK_IGNORE += "CVE-2013-6282"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6367"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6368"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6376"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6378"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6380"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6381"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6382"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-6383"
+
+# Skipping CVE-2013-6392, no affected_versions
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-6431"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6432"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2013-6885"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7026"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-7027"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7263"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7264"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7265"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7266"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7267"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7268"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7269"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7270"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7271"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7281"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2013-7339"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7348"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2013-7421"
+
+# CVE-2013-7445 has no known resolution
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2013-7446"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-7470"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-0038"
+
+# fixed-version: Fixed after version 3.14rc5
+CVE_CHECK_IGNORE += "CVE-2014-0049"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-0055"
+
+# fixed-version: Fixed after version 3.14rc4
+CVE_CHECK_IGNORE += "CVE-2014-0069"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-0077"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-0100"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-0101"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-0102"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-0131"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-0155"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-0181"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-0196"
+
+# fixed-version: Fixed after version 2.6.33rc5
+CVE_CHECK_IGNORE += "CVE-2014-0203"
+
+# fixed-version: Fixed after version 2.6.37rc1
+CVE_CHECK_IGNORE += "CVE-2014-0205"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-0206"
+
+# Skipping CVE-2014-0972, no affected_versions
+
+# fixed-version: Fixed after version 3.13
+CVE_CHECK_IGNORE += "CVE-2014-1438"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2014-1444"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2014-1445"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2014-1446"
+
+# fixed-version: Fixed after version 3.13rc8
+CVE_CHECK_IGNORE += "CVE-2014-1690"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-1737"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-1738"
+
+# fixed-version: Fixed after version 3.15rc6
+CVE_CHECK_IGNORE += "CVE-2014-1739"
+
+# fixed-version: Fixed after version 3.14rc2
+CVE_CHECK_IGNORE += "CVE-2014-1874"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-2038"
+
+# fixed-version: Fixed after version 3.14rc3
+CVE_CHECK_IGNORE += "CVE-2014-2039"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-2309"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-2523"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-2568"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2580"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2672"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2673"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2678"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2706"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2739"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-2851"
+
+# fixed-version: Fixed after version 3.2rc7
+CVE_CHECK_IGNORE += "CVE-2014-2889"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-3122"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-3144"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-3145"
+
+# fixed-version: Fixed after version 3.15
+CVE_CHECK_IGNORE += "CVE-2014-3153"
+
+# fixed-version: Fixed after version 3.17rc4
+CVE_CHECK_IGNORE += "CVE-2014-3180"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3181"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3182"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3183"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3184"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3185"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3186"
+
+# Skipping CVE-2014-3519, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc7
+CVE_CHECK_IGNORE += "CVE-2014-3534"
+
+# fixed-version: Fixed after version 2.6.36rc1
+CVE_CHECK_IGNORE += "CVE-2014-3535"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3601"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3610"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3611"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-3631"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2014-3645"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3646"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3647"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3673"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3687"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3688"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3690"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-3917"
+
+# fixed-version: Fixed after version 3.15
+CVE_CHECK_IGNORE += "CVE-2014-3940"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-4014"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-4027"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-4157"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4171"
+
+# Skipping CVE-2014-4322, no affected_versions
+
+# Skipping CVE-2014-4323, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4508"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-4608"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4611"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4652"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4653"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4654"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4655"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4656"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-4667"
+
+# fixed-version: Fixed after version 3.16rc4
+CVE_CHECK_IGNORE += "CVE-2014-4699"
+
+# fixed-version: Fixed after version 3.16rc6
+CVE_CHECK_IGNORE += "CVE-2014-4943"
+
+# fixed-version: Fixed after version 3.16rc7
+CVE_CHECK_IGNORE += "CVE-2014-5045"
+
+# fixed-version: Fixed after version 3.16
+CVE_CHECK_IGNORE += "CVE-2014-5077"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-5206"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-5207"
+
+# Skipping CVE-2014-5332, no affected_versions
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-5471"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-5472"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6410"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6416"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6417"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6418"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-7145"
+
+# Skipping CVE-2014-7207, no affected_versions
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-7283"
+
+# fixed-version: Fixed after version 3.15rc7
+CVE_CHECK_IGNORE += "CVE-2014-7284"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-7822"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-7825"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-7826"
+
+# fixed-version: Fixed after version 3.18rc5
+CVE_CHECK_IGNORE += "CVE-2014-7841"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7842"
+
+# fixed-version: Fixed after version 3.18rc5
+CVE_CHECK_IGNORE += "CVE-2014-7843"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7970"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7975"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-8086"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8133"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8134"
+
+# fixed-version: Fixed after version 4.0rc7
+CVE_CHECK_IGNORE += "CVE-2014-8159"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-8160"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2014-8171"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2014-8172"
+
+# fixed-version: Fixed after version 3.13rc5
+CVE_CHECK_IGNORE += "CVE-2014-8173"
+
+# Skipping CVE-2014-8181, no affected_versions
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8369"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8480"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8481"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8559"
+
+# fixed-version: Fixed after version 3.14rc3
+CVE_CHECK_IGNORE += "CVE-2014-8709"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-8884"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8989"
+
+# fixed-version: Fixed after version 3.18rc6
+CVE_CHECK_IGNORE += "CVE-2014-9090"
+
+# fixed-version: Fixed after version 3.18rc6
+CVE_CHECK_IGNORE += "CVE-2014-9322"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9419"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9420"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9428"
+
+# fixed-version: Fixed after version 3.19rc4
+CVE_CHECK_IGNORE += "CVE-2014-9529"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9584"
+
+# fixed-version: Fixed after version 3.19rc4
+CVE_CHECK_IGNORE += "CVE-2014-9585"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9644"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9683"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9710"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-9715"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2014-9717"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9728"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9729"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9730"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9731"
+
+# Skipping CVE-2014-9777, no affected_versions
+
+# Skipping CVE-2014-9778, no affected_versions
+
+# Skipping CVE-2014-9779, no affected_versions
+
+# Skipping CVE-2014-9780, no affected_versions
+
+# Skipping CVE-2014-9781, no affected_versions
+
+# Skipping CVE-2014-9782, no affected_versions
+
+# Skipping CVE-2014-9783, no affected_versions
+
+# Skipping CVE-2014-9784, no affected_versions
+
+# Skipping CVE-2014-9785, no affected_versions
+
+# Skipping CVE-2014-9786, no affected_versions
+
+# Skipping CVE-2014-9787, no affected_versions
+
+# Skipping CVE-2014-9788, no affected_versions
+
+# Skipping CVE-2014-9789, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-9803"
+
+# Skipping CVE-2014-9863, no affected_versions
+
+# Skipping CVE-2014-9864, no affected_versions
+
+# Skipping CVE-2014-9865, no affected_versions
+
+# Skipping CVE-2014-9866, no affected_versions
+
+# Skipping CVE-2014-9867, no affected_versions
+
+# Skipping CVE-2014-9868, no affected_versions
+
+# Skipping CVE-2014-9869, no affected_versions
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2014-9870"
+
+# Skipping CVE-2014-9871, no affected_versions
+
+# Skipping CVE-2014-9872, no affected_versions
+
+# Skipping CVE-2014-9873, no affected_versions
+
+# Skipping CVE-2014-9874, no affected_versions
+
+# Skipping CVE-2014-9875, no affected_versions
+
+# Skipping CVE-2014-9876, no affected_versions
+
+# Skipping CVE-2014-9877, no affected_versions
+
+# Skipping CVE-2014-9878, no affected_versions
+
+# Skipping CVE-2014-9879, no affected_versions
+
+# Skipping CVE-2014-9880, no affected_versions
+
+# Skipping CVE-2014-9881, no affected_versions
+
+# Skipping CVE-2014-9882, no affected_versions
+
+# Skipping CVE-2014-9883, no affected_versions
+
+# Skipping CVE-2014-9884, no affected_versions
+
+# Skipping CVE-2014-9885, no affected_versions
+
+# Skipping CVE-2014-9886, no affected_versions
+
+# Skipping CVE-2014-9887, no affected_versions
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2014-9888"
+
+# Skipping CVE-2014-9889, no affected_versions
+
+# Skipping CVE-2014-9890, no affected_versions
+
+# Skipping CVE-2014-9891, no affected_versions
+
+# Skipping CVE-2014-9892, no affected_versions
+
+# Skipping CVE-2014-9893, no affected_versions
+
+# Skipping CVE-2014-9894, no affected_versions
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2014-9895"
+
+# Skipping CVE-2014-9896, no affected_versions
+
+# Skipping CVE-2014-9897, no affected_versions
+
+# Skipping CVE-2014-9898, no affected_versions
+
+# Skipping CVE-2014-9899, no affected_versions
+
+# Skipping CVE-2014-9900, no affected_versions
+
+# fixed-version: Fixed after version 3.14rc4
+CVE_CHECK_IGNORE += "CVE-2014-9903"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-9904"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-9914"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-9922"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9940"
+
+# fixed-version: Fixed after version 3.19rc6
+CVE_CHECK_IGNORE += "CVE-2015-0239"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2015-0274"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-0275"
+
+# Skipping CVE-2015-0777, no affected_versions
+
+# Skipping CVE-2015-1328, no affected_versions
+
+# fixed-version: Fixed after version 4.2rc5
+CVE_CHECK_IGNORE += "CVE-2015-1333"
+
+# fixed-version: Fixed after version 4.4rc5
+CVE_CHECK_IGNORE += "CVE-2015-1339"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2015-1350"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-1420"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-1421"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-1465"
+
+# fixed-version: Fixed after version 3.19rc5
+CVE_CHECK_IGNORE += "CVE-2015-1573"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-1593"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2015-1805"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-2041"
+
+# fixed-version: Fixed after version 3.19
+CVE_CHECK_IGNORE += "CVE-2015-2042"
+
+# fixed-version: Fixed after version 4.0rc4
+CVE_CHECK_IGNORE += "CVE-2015-2150"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-2666"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-2672"
+
+# fixed-version: Fixed after version 4.0rc6
+CVE_CHECK_IGNORE += "CVE-2015-2686"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-2830"
+
+# CVE-2015-2877 has no known resolution
+
+# fixed-version: Fixed after version 4.0rc7
+CVE_CHECK_IGNORE += "CVE-2015-2922"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-2925"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-3212"
+
+# fixed-version: Fixed after version 2.6.33rc8
+CVE_CHECK_IGNORE += "CVE-2015-3214"
+
+# fixed-version: Fixed after version 4.2rc2
+CVE_CHECK_IGNORE += "CVE-2015-3288"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-3290"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-3291"
+
+# fixed-version: Fixed after version 4.0rc5
+CVE_CHECK_IGNORE += "CVE-2015-3331"
+
+# Skipping CVE-2015-3332, no affected_versions
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-3339"
+
+# fixed-version: Fixed after version 4.1rc2
+CVE_CHECK_IGNORE += "CVE-2015-3636"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4001"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4002"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4003"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-4004"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-4036"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-4167"
+
+# fixed-version: Fixed after version 3.13rc5
+CVE_CHECK_IGNORE += "CVE-2015-4170"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4176"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4177"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4178"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-4692"
+
+# fixed-version: Fixed after version 4.1rc6
+CVE_CHECK_IGNORE += "CVE-2015-4700"
+
+# fixed-version: Fixed after version 4.2rc7
+CVE_CHECK_IGNORE += "CVE-2015-5156"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-5157"
+
+# fixed-version: Fixed after version 4.3rc3
+CVE_CHECK_IGNORE += "CVE-2015-5257"
+
+# fixed-version: Fixed after version 4.3rc3
+CVE_CHECK_IGNORE += "CVE-2015-5283"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-5307"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-5327"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-5364"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-5366"
+
+# fixed-version: Fixed after version 4.2rc6
+CVE_CHECK_IGNORE += "CVE-2015-5697"
+
+# fixed-version: Fixed after version 4.1rc3
+CVE_CHECK_IGNORE += "CVE-2015-5706"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-5707"
+
+# fixed-version: Fixed after version 4.2rc5
+CVE_CHECK_IGNORE += "CVE-2015-6252"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-6526"
+
+# CVE-2015-6619 has no known resolution
+
+# CVE-2015-6646 has no known resolution
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-6937"
+
+# Skipping CVE-2015-7312, no affected_versions
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2015-7509"
+
+# fixed-version: Fixed after version 4.4rc7
+CVE_CHECK_IGNORE += "CVE-2015-7513"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-7515"
+
+# fixed-version: Fixed after version 4.4rc8
+CVE_CHECK_IGNORE += "CVE-2015-7550"
+
+# Skipping CVE-2015-7553, no affected_versions
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2015-7566"
+
+# fixed-version: Fixed after version 4.3rc4
+CVE_CHECK_IGNORE += "CVE-2015-7613"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7799"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2015-7833"
+
+# Skipping CVE-2015-7837, no affected_versions
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2015-7872"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7884"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7885"
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2015-7990"
+
+# Skipping CVE-2015-8019, no affected_versions
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8104"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-8215"
+
+# fixed-version: Fixed after version 2.6.34rc1
+CVE_CHECK_IGNORE += "CVE-2015-8324"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8374"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8539"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8543"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8550"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8551"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8552"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8553"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8569"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8575"
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2015-8660"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2015-8709"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-8746"
+
+# fixed-version: Fixed after version 4.3rc4
+CVE_CHECK_IGNORE += "CVE-2015-8767"
+
+# fixed-version: Fixed after version 4.4rc5
+CVE_CHECK_IGNORE += "CVE-2015-8785"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8787"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8812"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8816"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-8830"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8839"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8844"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8845"
+
+# Skipping CVE-2015-8937, no affected_versions
+
+# Skipping CVE-2015-8938, no affected_versions
+
+# Skipping CVE-2015-8939, no affected_versions
+
+# Skipping CVE-2015-8940, no affected_versions
+
+# Skipping CVE-2015-8941, no affected_versions
+
+# Skipping CVE-2015-8942, no affected_versions
+
+# Skipping CVE-2015-8943, no affected_versions
+
+# Skipping CVE-2015-8944, no affected_versions
+
+# fixed-version: Fixed after version 4.1rc2
+CVE_CHECK_IGNORE += "CVE-2015-8950"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2015-8952"
+
+# fixed-version: Fixed after version 4.3
+CVE_CHECK_IGNORE += "CVE-2015-8953"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-8955"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-8956"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8961"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8962"
+
+# fixed-version: Fixed after version 4.4
+CVE_CHECK_IGNORE += "CVE-2015-8963"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8964"
+
+# fixed-version: Fixed after version 4.4rc8
+CVE_CHECK_IGNORE += "CVE-2015-8966"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-8967"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8970"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-9004"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-9016"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-9289"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-0617"
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2016-0723"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-0728"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-0758"
+
+# Skipping CVE-2016-0774, no affected_versions
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2016-0821"
+
+# fixed-version: Fixed after version 4.0rc5
+CVE_CHECK_IGNORE += "CVE-2016-0823"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-10044"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10088"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-10147"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-10150"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10153"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10154"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-10200"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10208"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-10229"
+
+# fixed-version: Fixed after version 4.8rc6
+CVE_CHECK_IGNORE += "CVE-2016-10318"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2016-10723"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10741"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10764"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-10905"
+
+# fixed-version: Fixed after version 4.5rc6
+CVE_CHECK_IGNORE += "CVE-2016-10906"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-10907"
+
+# fixed-version: Fixed after version 4.7rc5
+CVE_CHECK_IGNORE += "CVE-2016-1237"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-1575"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-1576"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-1583"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2016-2053"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2069"
+
+# fixed-version: Fixed after version 4.4
+CVE_CHECK_IGNORE += "CVE-2016-2070"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2085"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-2117"
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-2143"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2184"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2185"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2186"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-2187"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2016-2188"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2383"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2384"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2543"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2544"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2545"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2546"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2547"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2548"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2549"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2550"
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2016-2782"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2847"
+
+# Skipping CVE-2016-2853, no affected_versions
+
+# Skipping CVE-2016-2854, no affected_versions
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-3044"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2016-3070"
+
+# fixed-version: Fixed after version 4.6rc2
+CVE_CHECK_IGNORE += "CVE-2016-3134"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3135"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3136"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3137"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3138"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2016-3139"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3140"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3156"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3157"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3672"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3689"
+
+# Skipping CVE-2016-3695, no affected_versions
+
+# Skipping CVE-2016-3699, no affected_versions
+
+# Skipping CVE-2016-3707, no affected_versions
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-3713"
+
+# CVE-2016-3775 has no known resolution
+
+# CVE-2016-3802 has no known resolution
+
+# CVE-2016-3803 has no known resolution
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2016-3841"
+
+# fixed-version: Fixed after version 4.8rc2
+CVE_CHECK_IGNORE += "CVE-2016-3857"
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-3951"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3955"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-3961"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4440"
+
+# fixed-version: Fixed after version 4.7rc4
+CVE_CHECK_IGNORE += "CVE-2016-4470"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4482"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4485"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4486"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4557"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-4558"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4565"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4568"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4569"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4578"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4580"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-4581"
+
+# fixed-version: Fixed after version 4.7rc4
+CVE_CHECK_IGNORE += "CVE-2016-4794"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-4805"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4913"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4951"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4997"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4998"
+
+# fixed-version: Fixed after version 4.9rc2
+CVE_CHECK_IGNORE += "CVE-2016-5195"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-5243"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-5244"
+
+# Skipping CVE-2016-5340, no affected_versions
+
+# Skipping CVE-2016-5342, no affected_versions
+
+# Skipping CVE-2016-5343, no affected_versions
+
+# Skipping CVE-2016-5344, no affected_versions
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-5400"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-5412"
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-5696"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-5728"
+
+# fixed-version: Fixed after version 4.7rc6
+CVE_CHECK_IGNORE += "CVE-2016-5828"
+
+# fixed-version: Fixed after version 4.7rc5
+CVE_CHECK_IGNORE += "CVE-2016-5829"
+
+# CVE-2016-5870 has no known resolution
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-6130"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-6136"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-6156"
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-6162"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-6187"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-6197"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-6198"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-6213"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-6327"
+
+# fixed-version: Fixed after version 4.8rc3
+CVE_CHECK_IGNORE += "CVE-2016-6480"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-6516"
+
+# Skipping CVE-2016-6753, no affected_versions
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2016-6786"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2016-6787"
+
+# fixed-version: Fixed after version 4.8rc5
+CVE_CHECK_IGNORE += "CVE-2016-6828"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-7039"
+
+# fixed-version: Fixed after version 4.9rc3
+CVE_CHECK_IGNORE += "CVE-2016-7042"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-7097"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7117"
+
+# Skipping CVE-2016-7118, no affected_versions
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-7425"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-7910"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-7911"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-7912"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7913"
+
+# fixed-version: Fixed after version 4.6rc4
+CVE_CHECK_IGNORE += "CVE-2016-7914"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7915"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-7916"
+
+# fixed-version: Fixed after version 4.5rc6
+CVE_CHECK_IGNORE += "CVE-2016-7917"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-8399"
+
+# Skipping CVE-2016-8401, no affected_versions
+
+# Skipping CVE-2016-8402, no affected_versions
+
+# Skipping CVE-2016-8403, no affected_versions
+
+# Skipping CVE-2016-8404, no affected_versions
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2016-8405"
+
+# Skipping CVE-2016-8406, no affected_versions
+
+# Skipping CVE-2016-8407, no affected_versions
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-8630"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-8632"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-8633"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2016-8636"
+
+# fixed-version: Fixed after version 4.9rc6
+CVE_CHECK_IGNORE += "CVE-2016-8645"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2016-8646"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-8650"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-8655"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-8658"
+
+# CVE-2016-8660 has no known resolution
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-8666"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9083"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9084"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-9120"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-9178"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2016-9191"
+
+# fixed-version: Fixed after version 4.9rc3
+CVE_CHECK_IGNORE += "CVE-2016-9313"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9555"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-9576"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-9588"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2016-9604"
+
+# Skipping CVE-2016-9644, no affected_versions
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-9685"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9754"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9755"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-9756"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-9777"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9793"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9794"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9806"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9919"
+
+# Skipping CVE-2017-0403, no affected_versions
+
+# Skipping CVE-2017-0404, no affected_versions
+
+# Skipping CVE-2017-0426, no affected_versions
+
+# Skipping CVE-2017-0427, no affected_versions
+
+# CVE-2017-0507 has no known resolution
+
+# CVE-2017-0508 has no known resolution
+
+# Skipping CVE-2017-0510, no affected_versions
+
+# Skipping CVE-2017-0528, no affected_versions
+
+# Skipping CVE-2017-0537, no affected_versions
+
+# CVE-2017-0564 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-0605"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-0627"
+
+# CVE-2017-0630 has no known resolution
+
+# CVE-2017-0749 has no known resolution
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2017-0750"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-0786"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-0861"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000111"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000112"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000251"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000252"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000253"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000255"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-1000363"
+
+# fixed-version: Fixed after version 4.12rc6
+CVE_CHECK_IGNORE += "CVE-2017-1000364"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-1000365"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000370"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000371"
+
+# fixed-version: Fixed after version 4.12rc6
+CVE_CHECK_IGNORE += "CVE-2017-1000379"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000380"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-1000405"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-1000407"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-1000410"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-10661"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-10662"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-10663"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-10810"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-10911"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-11089"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-11176"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-11472"
+
+# fixed-version: Fixed after version 4.13rc2
+CVE_CHECK_IGNORE += "CVE-2017-11473"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-11600"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-12134"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-12146"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2017-12153"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-12154"
+
+# fixed-version: Fixed after version 4.9rc6
+CVE_CHECK_IGNORE += "CVE-2017-12168"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-12188"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-12190"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-12192"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-12193"
+
+# fixed-version: Fixed after version 4.13rc4
+CVE_CHECK_IGNORE += "CVE-2017-12762"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-13080"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-13166"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2017-13167"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2017-13168"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2017-13215"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-13216"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2017-13220"
+
+# CVE-2017-13221 has no known resolution
+
+# CVE-2017-13222 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-13305"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-13686"
+
+# CVE-2017-13693 has no known resolution
+
+# CVE-2017-13694 has no known resolution
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2017-13695"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2017-13715"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14051"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-14106"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-14140"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14156"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14340"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-14489"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-14497"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-14954"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2017-14991"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2017-15102"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15115"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2017-15116"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-15121"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-15126"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-15127"
+
+# fixed-version: Fixed after version 4.14rc8
+CVE_CHECK_IGNORE += "CVE-2017-15128"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-15129"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-15265"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-15274"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15299"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-15306"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-15537"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-15649"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2017-15868"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15951"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16525"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16526"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16527"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-16528"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16529"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16530"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16531"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16532"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16533"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16534"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-16535"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16536"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16537"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-16538"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-16643"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-16644"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-16645"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16646"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16647"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16648"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16649"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16650"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16911"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16912"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16913"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16914"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-16939"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16994"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-16995"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-16996"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-17052"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-17053"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17448"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17449"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17450"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17558"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17712"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17741"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17805"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17806"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-17807"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17852"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17853"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17854"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17855"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17856"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17857"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-17862"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17863"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17864"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2017-17975"
+
+# fixed-version: Fixed after version 4.11rc7
+CVE_CHECK_IGNORE += "CVE-2017-18017"
+
+# fixed-version: Fixed after version 4.15rc7
+CVE_CHECK_IGNORE += "CVE-2017-18075"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18079"
+
+# CVE-2017-18169 has no known resolution
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2017-18174"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18193"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-18200"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-18202"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18203"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18204"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-18208"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18216"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18218"
+
+# fixed-version: Fixed after version 4.12rc4
+CVE_CHECK_IGNORE += "CVE-2017-18221"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-18222"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18224"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-18232"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18241"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-18249"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18255"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18257"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-18261"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-18270"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-18344"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-18360"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-18379"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18509"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18549"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18550"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2017-18551"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18552"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2017-18595"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-2583"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-2584"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-2596"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-2618"
+
+# fixed-version: Fixed after version 2.6.25rc1
+CVE_CHECK_IGNORE += "CVE-2017-2634"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-2636"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2017-2647"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-2671"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-5123"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5546"
+
+# fixed-version: Fixed after version 4.10rc5
+CVE_CHECK_IGNORE += "CVE-2017-5547"
+
+# fixed-version: Fixed after version 4.10rc5
+CVE_CHECK_IGNORE += "CVE-2017-5548"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5549"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5550"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5551"
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2017-5576"
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2017-5577"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-5669"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-5715"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-5753"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-5754"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5897"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-5967"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5970"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2017-5972"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5986"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-6001"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6074"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-6214"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6345"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6346"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-6347"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6348"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-6353"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-6874"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2017-6951"
+
+# fixed-version: Fixed after version 4.11rc5
+CVE_CHECK_IGNORE += "CVE-2017-7184"
+
+# fixed-version: Fixed after version 4.11rc5
+CVE_CHECK_IGNORE += "CVE-2017-7187"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7261"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-7273"
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-7277"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7294"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7308"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-7346"
+
+# CVE-2017-7369 has no known resolution
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-7374"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7472"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7477"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-7482"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-7487"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2017-7495"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-7518"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-7533"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-7541"
+
+# fixed-version: Fixed after version 4.13rc2
+CVE_CHECK_IGNORE += "CVE-2017-7542"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-7558"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7616"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7618"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7645"
+
+# fixed-version: Fixed after version 4.11rc7
+CVE_CHECK_IGNORE += "CVE-2017-7889"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7895"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7979"
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-8061"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8062"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8063"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8064"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8065"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8066"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8067"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8068"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8069"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8070"
+
+# fixed-version: Fixed after version 4.10rc7
+CVE_CHECK_IGNORE += "CVE-2017-8071"
+
+# fixed-version: Fixed after version 4.10rc7
+CVE_CHECK_IGNORE += "CVE-2017-8072"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-8106"
+
+# fixed-version: Fixed after version 3.19rc6
+CVE_CHECK_IGNORE += "CVE-2017-8240"
+
+# CVE-2017-8242 has no known resolution
+
+# CVE-2017-8244 has no known resolution
+
+# CVE-2017-8245 has no known resolution
+
+# CVE-2017-8246 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-8797"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-8824"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-8831"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-8890"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8924"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8925"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-9059"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9074"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9075"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9076"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9077"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-9150"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-9211"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-9242"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-9605"
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2017-9725"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-9984"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-9985"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-9986"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-1000004"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-1000026"
+
+# fixed-version: Fixed after version 4.15
+CVE_CHECK_IGNORE += "CVE-2018-1000028"
+
+# fixed-version: Fixed after version 4.16
+CVE_CHECK_IGNORE += "CVE-2018-1000199"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2018-1000200"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-1000204"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-10021"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-10074"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-10087"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-10124"
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-10322"
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-10323"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-1065"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-1066"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2018-10675"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-1068"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-10840"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-10853"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-1087"
+
+# CVE-2018-10872 has no known resolution
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10876"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10877"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10878"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10879"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10880"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10881"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10882"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10883"
+
+# fixed-version: Fixed after version 2.6.36rc1
+CVE_CHECK_IGNORE += "CVE-2018-10901"
+
+# fixed-version: Fixed after version 4.18rc6
+CVE_CHECK_IGNORE += "CVE-2018-10902"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2018-1091"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1092"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1093"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2018-10938"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1094"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-10940"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1095"
+
+# fixed-version: Fixed after version 4.17rc2
+CVE_CHECK_IGNORE += "CVE-2018-1108"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-1118"
+
+# fixed-version: Fixed after version 4.17rc6
+CVE_CHECK_IGNORE += "CVE-2018-1120"
+
+# CVE-2018-1121 has no known resolution
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-11232"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-1128"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-1129"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-1130"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-11412"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-11506"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2018-11508"
+
+# CVE-2018-11987 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12126"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12127"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12130"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2018-12207"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12232"
+
+# fixed-version: Fixed after version 4.18rc2
+CVE_CHECK_IGNORE += "CVE-2018-12233"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12633"
+
+# fixed-version: Fixed after version 4.18rc2
+CVE_CHECK_IGNORE += "CVE-2018-12714"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-12896"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12904"
+
+# CVE-2018-12928 has no known resolution
+
+# CVE-2018-12929 has no known resolution
+
+# CVE-2018-12930 has no known resolution
+
+# CVE-2018-12931 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13053"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13093"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13094"
+
+# fixed-version: Fixed after version 4.18rc3
+CVE_CHECK_IGNORE += "CVE-2018-13095"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13096"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13097"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13098"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13099"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13100"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-13405"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13406"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14609"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14610"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14611"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14612"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14613"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14614"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14615"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14616"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14617"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2018-14619"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-14625"
+
+# fixed-version: Fixed after version 4.19rc6
+CVE_CHECK_IGNORE += "CVE-2018-14633"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-14634"
+
+# fixed-version: Fixed after version 4.19rc4
+CVE_CHECK_IGNORE += "CVE-2018-14641"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-14646"
+
+# fixed-version: Fixed after version 4.19rc2
+CVE_CHECK_IGNORE += "CVE-2018-14656"
+
+# fixed-version: Fixed after version 4.18rc8
+CVE_CHECK_IGNORE += "CVE-2018-14678"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-14734"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-15471"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-15572"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-15594"
+
+# fixed-version: Fixed after version 4.18rc5
+CVE_CHECK_IGNORE += "CVE-2018-16276"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2018-16597"
+
+# fixed-version: Fixed after version 4.19rc2
+CVE_CHECK_IGNORE += "CVE-2018-16658"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-16862"
+
+# fixed-version: Fixed after version 4.20rc3
+CVE_CHECK_IGNORE += "CVE-2018-16871"
+
+# fixed-version: Fixed after version 5.0rc5
+CVE_CHECK_IGNORE += "CVE-2018-16880"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2018-16882"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-16884"
+
+# CVE-2018-16885 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc4
+CVE_CHECK_IGNORE += "CVE-2018-17182"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-17972"
+
+# CVE-2018-17977 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-18021"
+
+# fixed-version: Fixed after version 4.19
+CVE_CHECK_IGNORE += "CVE-2018-18281"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2018-18386"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-18397"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-18445"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-18559"
+
+# CVE-2018-18653 has no known resolution
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-18690"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-18710"
+
+# fixed-version: Fixed after version 4.20rc2
+CVE_CHECK_IGNORE += "CVE-2018-18955"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-19406"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-19407"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-19824"
+
+# fixed-version: Fixed after version 4.20rc3
+CVE_CHECK_IGNORE += "CVE-2018-19854"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2018-19985"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-20169"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-20449"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2018-20509"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-20510"
+
+# fixed-version: Fixed after version 4.19rc5
+CVE_CHECK_IGNORE += "CVE-2018-20511"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-20669"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-20784"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-20836"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-20854"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-20855"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-20856"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-20961"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-20976"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-21008"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-25015"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-25020"
+
+# CVE-2018-3574 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3620"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-3639"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3646"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2018-3665"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3693"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5332"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5333"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5344"
+
+# fixed-version: Fixed after version 4.18rc7
+CVE_CHECK_IGNORE += "CVE-2018-5390"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-5391"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-5703"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5750"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5803"
+
+# fixed-version: Fixed after version 4.17rc6
+CVE_CHECK_IGNORE += "CVE-2018-5814"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5848"
+
+# Skipping CVE-2018-5856, no affected_versions
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2018-5873"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-5953"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-5995"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-6412"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-6554"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-6555"
+
+# CVE-2018-6559 has no known resolution
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-6927"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2018-7191"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-7273"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-7480"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2018-7492"
+
+# fixed-version: Fixed after version 4.16rc2
+CVE_CHECK_IGNORE += "CVE-2018-7566"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-7740"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-7754"
+
+# fixed-version: Fixed after version 4.19rc5
+CVE_CHECK_IGNORE += "CVE-2018-7755"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-7757"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-7995"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-8043"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-8087"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8781"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8822"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8897"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-9363"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-9385"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-9415"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2018-9422"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2018-9465"
+
+# fixed-version: Fixed after version 4.18rc5
+CVE_CHECK_IGNORE += "CVE-2018-9516"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2018-9517"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-9518"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2018-9568"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-0136"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0145"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0146"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0147"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0148"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-0149"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-0154"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-0155"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-10124"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-10125"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-10126"
+
+# CVE-2019-10140 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-10142"
+
+# fixed-version: Fixed after version 5.3rc3
+CVE_CHECK_IGNORE += "CVE-2019-10207"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-10220"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-10638"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-10639"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-11085"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11091"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-11135"
+
+# fixed-version: Fixed after version 4.8rc5
+CVE_CHECK_IGNORE += "CVE-2019-11190"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11191"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-1125"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11477"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11478"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11479"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-11486"
+
+# fixed-version: Fixed after version 5.1rc5
+CVE_CHECK_IGNORE += "CVE-2019-11487"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-11599"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-11683"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11810"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11811"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-11815"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11833"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11884"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12378"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12379"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12380"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12381"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12382"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12454"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12455"
+
+# CVE-2019-12456 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12614"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-12615"
+
+# fixed-version: Fixed after version 5.2rc7
+CVE_CHECK_IGNORE += "CVE-2019-12817"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-12818"
+
+# fixed-version: Fixed after version 5.0rc8
+CVE_CHECK_IGNORE += "CVE-2019-12819"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2019-12881"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-12984"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-13233"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-13272"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-13631"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-13648"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-14283"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-14284"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2019-14615"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2019-14763"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14814"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14815"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14816"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-14821"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14835"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-14895"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2019-14896"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2019-14897"
+
+# CVE-2019-14898 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-14901"
+
+# fixed-version: Fixed after version 5.3rc8
+CVE_CHECK_IGNORE += "CVE-2019-15030"
+
+# fixed-version: Fixed after version 5.3rc8
+CVE_CHECK_IGNORE += "CVE-2019-15031"
+
+# fixed-version: Fixed after version 5.2rc2
+CVE_CHECK_IGNORE += "CVE-2019-15090"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-15098"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-15099"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-15117"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-15118"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15211"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15212"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15213"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15214"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15215"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-15216"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15217"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15218"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15219"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15220"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-15221"
+
+# fixed-version: Fixed after version 5.3rc3
+CVE_CHECK_IGNORE += "CVE-2019-15222"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15223"
+
+# CVE-2019-15239 has no known resolution
+
+# CVE-2019-15290 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-15291"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15292"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-15504"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-15505"
+
+# fixed-version: Fixed after version 5.3rc6
+CVE_CHECK_IGNORE += "CVE-2019-15538"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-15666"
+
+# CVE-2019-15791 has no known resolution
+
+# CVE-2019-15792 has no known resolution
+
+# CVE-2019-15793 has no known resolution
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2019-15794"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15807"
+
+# CVE-2019-15902 has no known resolution
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15916"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15917"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15918"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15919"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15920"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-15921"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15922"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15923"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15924"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15925"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15926"
+
+# fixed-version: Fixed after version 5.0rc2
+CVE_CHECK_IGNORE += "CVE-2019-15927"
+
+# CVE-2019-16089 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16229"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16230"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-16231"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16232"
+
+# fixed-version: Fixed after version 5.4rc5
+CVE_CHECK_IGNORE += "CVE-2019-16233"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-16234"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-16413"
+
+# fixed-version: Fixed after version 5.3rc7
+CVE_CHECK_IGNORE += "CVE-2019-16714"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-16746"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2019-16921"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-16994"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-16995"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17052"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17053"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17054"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17055"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17056"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-17075"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-17133"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-17351"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-17666"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-18198"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-18282"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18660"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2019-18675"
+
+# CVE-2019-18680 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18683"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18786"
+
+# fixed-version: Fixed after version 5.1rc7
+CVE_CHECK_IGNORE += "CVE-2019-18805"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18806"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18807"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18808"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18809"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18810"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-18811"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-18812"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-18813"
+
+# fixed-version: Fixed after version 5.7rc7
+CVE_CHECK_IGNORE += "CVE-2019-18814"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-18885"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19036"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-19037"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2019-19039"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19043"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19044"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19045"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19046"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19047"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19048"
+
+# fixed-version: Fixed after version 5.4rc5
+CVE_CHECK_IGNORE += "CVE-2019-19049"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19050"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19051"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19052"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19053"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19054"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19055"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19056"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19057"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19058"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19059"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19060"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19061"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19062"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19063"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19064"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19065"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19066"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19067"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19068"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19069"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19070"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19071"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19072"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19073"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19074"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19075"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19076"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19077"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19078"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-19079"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19080"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19081"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19082"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19083"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-19227"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19241"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19252"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19318"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19319"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19332"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19338"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2019-19377"
+
+# CVE-2019-19378 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19447"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2019-19448"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2019-19449"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2019-19462"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19523"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-19524"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19525"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19526"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19527"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19528"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19529"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-19530"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19531"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19532"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19533"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19534"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19535"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19536"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-19537"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19543"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19602"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19767"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2019-19768"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2019-19769"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2019-19770"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19807"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19813"
+
+# CVE-2019-19814 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-19815"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19816"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19922"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-19927"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-19947"
+
+# fixed-version: Fixed after version 5.5rc2
+CVE_CHECK_IGNORE += "CVE-2019-19965"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19966"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-1999"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-20054"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-20095"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-20096"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2019-2024"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2019-2025"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-20422"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2019-2054"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2019-20636"
+
+# CVE-2019-20794 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-20806"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2019-20810"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-20811"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-20812"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-20908"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-20934"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-2101"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-2181"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2019-2182"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-2213"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-2214"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2019-2215"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-25044"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-25045"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2019-3016"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-3459"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-3460"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-3701"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-3819"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2019-3837"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-3846"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-3874"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-3882"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-3887"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-3892"
+
+# fixed-version: Fixed after version 2.6.35rc1
+CVE_CHECK_IGNORE += "CVE-2019-3896"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-3900"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2019-3901"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-5108"
+
+# Skipping CVE-2019-5489, no affected_versions
+
+# fixed-version: Fixed after version 5.0rc2
+CVE_CHECK_IGNORE += "CVE-2019-6133"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-6974"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-7221"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-7222"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-7308"
+
+# fixed-version: Fixed after version 5.0rc8
+CVE_CHECK_IGNORE += "CVE-2019-8912"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-8956"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-8980"
+
+# fixed-version: Fixed after version 5.0rc4
+CVE_CHECK_IGNORE += "CVE-2019-9003"
+
+# fixed-version: Fixed after version 5.0rc7
+CVE_CHECK_IGNORE += "CVE-2019-9162"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-9213"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-9245"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2019-9444"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9445"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-9453"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2019-9454"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-9455"
+
+# fixed-version: Fixed after version 4.16rc6
+CVE_CHECK_IGNORE += "CVE-2019-9456"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2019-9457"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2019-9458"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9466"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9500"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9503"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-9506"
+
+# fixed-version: Fixed after version 5.1rc2
+CVE_CHECK_IGNORE += "CVE-2019-9857"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-0009"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2020-0030"
+
+# fixed-version: Fixed after version 5.5rc2
+CVE_CHECK_IGNORE += "CVE-2020-0041"
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2020-0066"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-0067"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-0110"
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-0255"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-0305"
+
+# CVE-2020-0347 has no known resolution
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-0404"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-0423"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-0427"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2020-0429"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2020-0430"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-0431"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-0432"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2020-0433"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2020-0435"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-0444"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-0465"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-0466"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-0543"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10135"
+
+# fixed-version: Fixed after version 5.5rc5
+CVE_CHECK_IGNORE += "CVE-2020-10690"
+
+# CVE-2020-10708 has no known resolution
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-10711"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2020-10720"
+
+# fixed-version: Fixed after version 5.7
+CVE_CHECK_IGNORE += "CVE-2020-10732"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2020-10742"
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-10751"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10757"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10766"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10767"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10768"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2020-10769"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2020-10773"
+
+# CVE-2020-10774 has no known resolution
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2020-10781"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-10942"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11494"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11565"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11608"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11609"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11668"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2020-11669"
+
+# CVE-2020-11725 has no known resolution
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-11884"
+
+# CVE-2020-11935 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2020-12114"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-12351"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-12352"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12362"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12363"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12364"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-12464"
+
+# fixed-version: Fixed after version 5.6rc6
+CVE_CHECK_IGNORE += "CVE-2020-12465"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2020-12652"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-12653"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-12654"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12655"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-12656"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12657"
+
+# fixed-version: Fixed after version 5.7rc2
+CVE_CHECK_IGNORE += "CVE-2020-12659"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-12768"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-12769"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-12770"
+
+# fixed-version: Fixed after version 5.8rc2
+CVE_CHECK_IGNORE += "CVE-2020-12771"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12826"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-12888"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2020-12912"
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-13143"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-13974"
+
+# CVE-2020-14304 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-14305"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-14314"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-14331"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-14351"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2020-14353"
+
+# fixed-version: Fixed after version 5.8rc5
+CVE_CHECK_IGNORE += "CVE-2020-14356"
+
+# fixed-version: Fixed after version 5.6rc6
+CVE_CHECK_IGNORE += "CVE-2020-14381"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-14385"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-14386"
+
+# fixed-version: Fixed after version 5.9rc6
+CVE_CHECK_IGNORE += "CVE-2020-14390"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2020-14416"
+
+# fixed-version: Fixed after version 5.8rc3
+CVE_CHECK_IGNORE += "CVE-2020-15393"
+
+# fixed-version: Fixed after version 5.8rc2
+CVE_CHECK_IGNORE += "CVE-2020-15436"
+
+# fixed-version: Fixed after version 5.8rc7
+CVE_CHECK_IGNORE += "CVE-2020-15437"
+
+# fixed-version: Fixed after version 5.8rc3
+CVE_CHECK_IGNORE += "CVE-2020-15780"
+
+# CVE-2020-15802 has no known resolution
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2020-15852"
+
+# fixed-version: Fixed after version 5.15rc2
+CVE_CHECK_IGNORE += "CVE-2020-16119"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-16120"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2020-16166"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-1749"
+
+# fixed-version: Fixed after version 5.8rc4
+CVE_CHECK_IGNORE += "CVE-2020-24394"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2020-24490"
+
+# CVE-2020-24502 has no known resolution
+
+# CVE-2020-24503 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-24504"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24586"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24587"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24588"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25211"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-25212"
+
+# CVE-2020-25220 has no known resolution
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25221"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-25284"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25285"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-25639"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25641"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25643"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25645"
+
+# fixed-version: Fixed after version 5.10rc2
+CVE_CHECK_IGNORE += "CVE-2020-25656"
+
+# CVE-2020-25661 has no known resolution
+
+# CVE-2020-25662 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-25668"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-25669"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25670"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25671"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25672"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25673"
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-25704"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-25705"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-26088"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26139"
+
+# CVE-2020-26140 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26141"
+
+# CVE-2020-26142 has no known resolution
+
+# CVE-2020-26143 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26145"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26147"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26541"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26555"
+
+# CVE-2020-26556 has no known resolution
+
+# CVE-2020-26557 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26558"
+
+# CVE-2020-26559 has no known resolution
+
+# CVE-2020-26560 has no known resolution
+
+# fixed-version: Fixed after version 5.6
+CVE_CHECK_IGNORE += "CVE-2020-27066"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2020-27067"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-27068"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27152"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2020-27170"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2020-27171"
+
+# fixed-version: Fixed after version 5.9
+CVE_CHECK_IGNORE += "CVE-2020-27194"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-2732"
+
+# CVE-2020-27418 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27673"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27675"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27777"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27784"
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-27786"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-27815"
+
+# cpe-stable-backport: Backported in 5.15.5
+CVE_CHECK_IGNORE += "CVE-2020-27820"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27825"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-27830"
+
+# fixed-version: Fixed after version 5.10rc6
+CVE_CHECK_IGNORE += "CVE-2020-27835"
+
+# fixed-version: Fixed after version 5.9rc6
+CVE_CHECK_IGNORE += "CVE-2020-28097"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2020-28374"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-28588"
+
+# fixed-version: Fixed after version 5.9
+CVE_CHECK_IGNORE += "CVE-2020-28915"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-28941"
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-28974"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-29368"
+
+# fixed-version: Fixed after version 5.8rc7
+CVE_CHECK_IGNORE += "CVE-2020-29369"
+
+# fixed-version: Fixed after version 5.6rc7
+CVE_CHECK_IGNORE += "CVE-2020-29370"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-29371"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-29372"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-29373"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-29374"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-29534"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-29568"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-29569"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-29660"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-29661"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-35499"
+
+# CVE-2020-35501 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-35508"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2020-35513"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-35519"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-36158"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-36310"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-36311"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-36312"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36313"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-36322"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-36385"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-36386"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-36387"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2020-36516"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36557"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-36558"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-36691"
+
+# fixed-version: Fixed after version 5.10
+CVE_CHECK_IGNORE += "CVE-2020-36694"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-3702"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-4788"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2020-7053"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2020-8428"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2020-8647"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-8648"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2020-8649"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2020-8694"
+
+# CVE-2020-8832 has no known resolution
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2020-8834"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-8835"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-8992"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-9383"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-9391"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-0129"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2021-0342"
+
+# CVE-2021-0399 has no known resolution
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-0447"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2021-0448"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-0512"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2021-0605"
+
+# CVE-2021-0606 has no known resolution
+
+# CVE-2021-0695 has no known resolution
+
+# fixed-version: Fixed after version 5.11rc3
+CVE_CHECK_IGNORE += "CVE-2021-0707"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-0920"
+
+# CVE-2021-0924 has no known resolution
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2021-0929"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-0935"
+
+# CVE-2021-0936 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-0937"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2021-0938"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-0941"
+
+# CVE-2021-0961 has no known resolution
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2021-1048"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2021-20177"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2021-20194"
+
+# CVE-2021-20219 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2021-20226"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2021-20239"
+
+# fixed-version: Fixed after version 4.5rc5
+CVE_CHECK_IGNORE += "CVE-2021-20261"
+
+# fixed-version: Fixed after version 4.5rc3
+CVE_CHECK_IGNORE += "CVE-2021-20265"
+
+# fixed-version: Fixed after version 5.11rc5
+CVE_CHECK_IGNORE += "CVE-2021-20268"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2021-20292"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2021-20317"
+
+# fixed-version: Fixed after version 5.15rc3
+CVE_CHECK_IGNORE += "CVE-2021-20320"
+
+# fixed-version: Fixed after version 5.15rc5
+CVE_CHECK_IGNORE += "CVE-2021-20321"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-20322"
+
+# fixed-version: Fixed after version 5.11rc7
+CVE_CHECK_IGNORE += "CVE-2021-21781"
+
+# fixed-version: Fixed after version 5.13
+CVE_CHECK_IGNORE += "CVE-2021-22543"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-22555"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-22600"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-23133"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-23134"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2021-26401"
+
+# fixed-version: Fixed after version 5.11rc7
+CVE_CHECK_IGNORE += "CVE-2021-26708"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26930"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26931"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26932"
+
+# CVE-2021-26934 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27363"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27364"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27365"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28038"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28039"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-28375"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-28660"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-28688"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-28691"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-28711"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-28712"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-28713"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-28714"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-28715"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28950"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28951"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28952"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28964"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28971"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28972"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-29154"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-29155"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-29264"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-29265"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-29266"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29646"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29647"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29648"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29649"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29650"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-29657"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-30002"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-30178"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-31440"
+
+# fixed-version: Fixed after version 5.11rc5
+CVE_CHECK_IGNORE += "CVE-2021-3178"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-31829"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-31916"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-32078"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-32399"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-32606"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-33033"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-33034"
+
+# CVE-2021-33061 needs backporting (fixed from 5.18rc1)
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-33098"
+
+# cpe-stable-backport: Backported in 5.15.29
+CVE_CHECK_IGNORE += "CVE-2021-33135"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-33200"
+
+# fixed-version: Fixed after version 5.11rc6
+CVE_CHECK_IGNORE += "CVE-2021-3347"
+
+# fixed-version: Fixed after version 5.11rc6
+CVE_CHECK_IGNORE += "CVE-2021-3348"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-33624"
+
+# cpe-stable-backport: Backported in 5.15.54
+CVE_CHECK_IGNORE += "CVE-2021-33655"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-33656"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-33909"
+
+# fixed-version: Fixed after version 5.10
+CVE_CHECK_IGNORE += "CVE-2021-3411"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2021-3428"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-3444"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-34556"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-34693"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-3483"
+
+# fixed-version: Fixed after version 5.14
+CVE_CHECK_IGNORE += "CVE-2021-34866"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-3489"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-3490"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3491"
+
+# CVE-2021-3492 has no known resolution
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2021-3493"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-34981"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-3501"
+
+# fixed-version: Fixed after version 5.13
+CVE_CHECK_IGNORE += "CVE-2021-35039"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3506"
+
+# CVE-2021-3542 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3543"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-35477"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3564"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3573"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3587"
+
+# fixed-version: Fixed after version 5.11
+CVE_CHECK_IGNORE += "CVE-2021-3600"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-3609"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-3612"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2021-3635"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2021-3640"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-3653"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-3655"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-3656"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-3659"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3669"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-3679"
+
+# CVE-2021-3714 has no known resolution
+
+# fixed-version: Fixed after version 5.6
+CVE_CHECK_IGNORE += "CVE-2021-3715"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-37159"
+
+# fixed-version: Fixed after version 5.14rc6
+CVE_CHECK_IGNORE += "CVE-2021-3732"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3736"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3739"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-3743"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-3744"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2021-3752"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3753"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-37576"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3759"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3760"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-3764"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-3772"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38160"
+
+# fixed-version: Fixed after version 5.14rc6
+CVE_CHECK_IGNORE += "CVE-2021-38166"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-38198"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38199"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38200"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38201"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38202"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2021-38203"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-38204"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38205"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38206"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38207"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-38208"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-38209"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-38300"
+
+# CVE-2021-3847 has no known resolution
+
+# CVE-2021-3864 has no known resolution
+
+# CVE-2021-3892 has no known resolution
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3894"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3896"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2021-3923"
+
+# fixed-version: Fixed after version 5.14
+CVE_CHECK_IGNORE += "CVE-2021-39633"
+
+# fixed-version: Fixed after version 5.9rc8
+CVE_CHECK_IGNORE += "CVE-2021-39634"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-39636"
+
+# fixed-version: Fixed after version 5.11rc3
+CVE_CHECK_IGNORE += "CVE-2021-39648"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-39656"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2021-39657"
+
+# cpe-stable-backport: Backported in 5.15.8
+CVE_CHECK_IGNORE += "CVE-2021-39685"
+
+# cpe-stable-backport: Backported in 5.15.2
+CVE_CHECK_IGNORE += "CVE-2021-39686"
+
+# cpe-stable-backport: Backported in 5.15.8
+CVE_CHECK_IGNORE += "CVE-2021-39698"
+
+# fixed-version: Fixed after version 4.18rc6
+CVE_CHECK_IGNORE += "CVE-2021-39711"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2021-39713"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-39714"
+
+# CVE-2021-39800 has no known resolution
+
+# CVE-2021-39801 has no known resolution
+
+# CVE-2021-39802 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.5
+CVE_CHECK_IGNORE += "CVE-2021-4001"
+
+# cpe-stable-backport: Backported in 5.15.5
+CVE_CHECK_IGNORE += "CVE-2021-4002"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-4023"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-4028"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4032"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-4037"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-40490"
+
+# cpe-stable-backport: Backported in 5.15.7
+CVE_CHECK_IGNORE += "CVE-2021-4083"
+
+# cpe-stable-backport: Backported in 5.15.5
+CVE_CHECK_IGNORE += "CVE-2021-4090"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4093"
+
+# CVE-2021-4095 needs backporting (fixed from 5.17rc1)
+
+# fixed-version: Fixed after version 5.15rc2
+CVE_CHECK_IGNORE += "CVE-2021-41073"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-4135"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-4148"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-4149"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4150"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2021-4154"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2021-4155"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-4157"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2021-4159"
+
+# fixed-version: Fixed after version 5.15rc5
+CVE_CHECK_IGNORE += "CVE-2021-41864"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2021-4197"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-42008"
+
+# cpe-stable-backport: Backported in 5.15.5
+CVE_CHECK_IGNORE += "CVE-2021-4202"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-4203"
+
+# CVE-2021-4204 needs backporting (fixed from 5.17rc1)
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2021-4218"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-42252"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-42327"
+
+# cpe-stable-backport: Backported in 5.15.1
+CVE_CHECK_IGNORE += "CVE-2021-42739"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-43056"
+
+# fixed-version: Fixed after version 5.15rc3
+CVE_CHECK_IGNORE += "CVE-2021-43057"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-43267"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-43389"
+
+# cpe-stable-backport: Backported in 5.15.7
+CVE_CHECK_IGNORE += "CVE-2021-43975"
+
+# cpe-stable-backport: Backported in 5.15.17
+CVE_CHECK_IGNORE += "CVE-2021-43976"
+
+# cpe-stable-backport: Backported in 5.15.12
+CVE_CHECK_IGNORE += "CVE-2021-44733"
+
+# cpe-stable-backport: Backported in 5.15.17
+CVE_CHECK_IGNORE += "CVE-2021-44879"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2021-45095"
+
+# cpe-stable-backport: Backported in 5.15.12
+CVE_CHECK_IGNORE += "CVE-2021-45100"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-45402"
+
+# cpe-stable-backport: Backported in 5.15.12
+CVE_CHECK_IGNORE += "CVE-2021-45469"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2021-45480"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-45485"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-45486"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2021-45868"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-46283"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-0001"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-0002"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-0168"
+
+# cpe-stable-backport: Backported in 5.15.70
+CVE_CHECK_IGNORE += "CVE-2022-0171"
+
+# cpe-stable-backport: Backported in 5.15.16
+CVE_CHECK_IGNORE += "CVE-2022-0185"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2022-0264"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2022-0286"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2022-0322"
+
+# cpe-stable-backport: Backported in 5.15.18
+CVE_CHECK_IGNORE += "CVE-2022-0330"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2022-0382"
+
+# CVE-2022-0400 has no known resolution
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-0433"
+
+# cpe-stable-backport: Backported in 5.15.23
+CVE_CHECK_IGNORE += "CVE-2022-0435"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-0480"
+
+# cpe-stable-backport: Backported in 5.15.23
+CVE_CHECK_IGNORE += "CVE-2022-0487"
+
+# cpe-stable-backport: Backported in 5.15.20
+CVE_CHECK_IGNORE += "CVE-2022-0492"
+
+# cpe-stable-backport: Backported in 5.15.27
+CVE_CHECK_IGNORE += "CVE-2022-0494"
+
+# cpe-stable-backport: Backported in 5.15.37
+CVE_CHECK_IGNORE += "CVE-2022-0500"
+
+# cpe-stable-backport: Backported in 5.15.23
+CVE_CHECK_IGNORE += "CVE-2022-0516"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2022-0617"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2022-0644"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-0646"
+
+# cpe-stable-backport: Backported in 5.15.27
+CVE_CHECK_IGNORE += "CVE-2022-0742"
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2022-0812"
+
+# cpe-stable-backport: Backported in 5.15.25
+CVE_CHECK_IGNORE += "CVE-2022-0847"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2022-0850"
+
+# fixed-version: only affects 5.17rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2022-0854"
+
+# cpe-stable-backport: Backported in 5.15.29
+CVE_CHECK_IGNORE += "CVE-2022-0995"
+
+# CVE-2022-0998 needs backporting (fixed from 5.17rc1)
+
+# cpe-stable-backport: Backported in 5.15.29
+CVE_CHECK_IGNORE += "CVE-2022-1011"
+
+# cpe-stable-backport: Backported in 5.15.41
+CVE_CHECK_IGNORE += "CVE-2022-1012"
+
+# cpe-stable-backport: Backported in 5.15.32
+CVE_CHECK_IGNORE += "CVE-2022-1015"
+
+# cpe-stable-backport: Backported in 5.15.32
+CVE_CHECK_IGNORE += "CVE-2022-1016"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2022-1043"
+
+# cpe-stable-backport: Backported in 5.15.32
+CVE_CHECK_IGNORE += "CVE-2022-1048"
+
+# cpe-stable-backport: Backported in 5.15.20
+CVE_CHECK_IGNORE += "CVE-2022-1055"
+
+# CVE-2022-1116 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1158"
+
+# cpe-stable-backport: Backported in 5.15.46
+CVE_CHECK_IGNORE += "CVE-2022-1184"
+
+# cpe-stable-backport: Backported in 5.15.12
+CVE_CHECK_IGNORE += "CVE-2022-1195"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1198"
+
+# cpe-stable-backport: Backported in 5.15.29
+CVE_CHECK_IGNORE += "CVE-2022-1199"
+
+# cpe-stable-backport: Backported in 5.15.35
+CVE_CHECK_IGNORE += "CVE-2022-1204"
+
+# fixed-version: only affects 5.17rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2022-1205"
+
+# CVE-2022-1247 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.34
+CVE_CHECK_IGNORE += "CVE-2022-1263"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-1280"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1353"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2022-1419"
+
+# cpe-stable-backport: Backported in 5.15.58
+CVE_CHECK_IGNORE += "CVE-2022-1462"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-1508"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1516"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1651"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2022-1652"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-1671"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2022-1678"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-1679"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2022-1729"
+
+# cpe-stable-backport: Backported in 5.15.39
+CVE_CHECK_IGNORE += "CVE-2022-1734"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-1786"
+
+# cpe-stable-backport: Backported in 5.15.44
+CVE_CHECK_IGNORE += "CVE-2022-1789"
+
+# cpe-stable-backport: Backported in 5.15.37
+CVE_CHECK_IGNORE += "CVE-2022-1836"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-1852"
+
+# fixed-version: only affects 5.17rc8 onwards
+CVE_CHECK_IGNORE += "CVE-2022-1882"
+
+# cpe-stable-backport: Backported in 5.15.40
+CVE_CHECK_IGNORE += "CVE-2022-1943"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-1966"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-1972"
+
+# cpe-stable-backport: Backported in 5.15.46
+CVE_CHECK_IGNORE += "CVE-2022-1973"
+
+# cpe-stable-backport: Backported in 5.15.39
+CVE_CHECK_IGNORE += "CVE-2022-1974"
+
+# cpe-stable-backport: Backported in 5.15.39
+CVE_CHECK_IGNORE += "CVE-2022-1975"
+
+# fixed-version: only affects 5.18rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2022-1976"
+
+# cpe-stable-backport: Backported in 5.15.20
+CVE_CHECK_IGNORE += "CVE-2022-1998"
+
+# cpe-stable-backport: Backported in 5.15.25
+CVE_CHECK_IGNORE += "CVE-2022-20008"
+
+# cpe-stable-backport: Backported in 5.15.8
+CVE_CHECK_IGNORE += "CVE-2022-20132"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-20141"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2022-20148"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2022-20153"
+
+# cpe-stable-backport: Backported in 5.15.13
+CVE_CHECK_IGNORE += "CVE-2022-20154"
+
+# cpe-stable-backport: Backported in 5.15.31
+CVE_CHECK_IGNORE += "CVE-2022-20158"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2022-20166"
+
+# cpe-stable-backport: Backported in 5.15.31
+CVE_CHECK_IGNORE += "CVE-2022-20368"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-20369"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20409"
+
+# cpe-stable-backport: Backported in 5.15.66
+CVE_CHECK_IGNORE += "CVE-2022-20421"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-20422"
+
+# fixed-version: only affects 5.17rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2022-20423"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20424"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2022-20565"
+
+# cpe-stable-backport: Backported in 5.15.59
+CVE_CHECK_IGNORE += "CVE-2022-20566"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2022-20567"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20568"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-20572"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-2078"
+
+# cpe-stable-backport: Backported in 5.15.48
+CVE_CHECK_IGNORE += "CVE-2022-21123"
+
+# cpe-stable-backport: Backported in 5.15.48
+CVE_CHECK_IGNORE += "CVE-2022-21125"
+
+# cpe-stable-backport: Backported in 5.15.48
+CVE_CHECK_IGNORE += "CVE-2022-21166"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2022-21385"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2022-21499"
+
+# cpe-stable-backport: Backported in 5.15.58
+CVE_CHECK_IGNORE += "CVE-2022-21505"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-2153"
+
+# cpe-stable-backport: Backported in 5.15.96
+CVE_CHECK_IGNORE += "CVE-2022-2196"
+
+# CVE-2022-2209 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.18
+CVE_CHECK_IGNORE += "CVE-2022-22942"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23036"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23037"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23038"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23039"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23040"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23041"
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23042"
+
+# cpe-stable-backport: Backported in 5.15.72
+CVE_CHECK_IGNORE += "CVE-2022-2308"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-2318"
+
+# cpe-stable-backport: Backported in 5.15.37
+CVE_CHECK_IGNORE += "CVE-2022-23222"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-2327"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-2380"
+
+# cpe-stable-backport: Backported in 5.15.57
+CVE_CHECK_IGNORE += "CVE-2022-23816"
+
+# CVE-2022-23825 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.28
+CVE_CHECK_IGNORE += "CVE-2022-23960"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2022-24122"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2022-24448"
+
+# cpe-stable-backport: Backported in 5.15.27
+CVE_CHECK_IGNORE += "CVE-2022-24958"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2022-24959"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-2503"
+
+# cpe-stable-backport: Backported in 5.15.24
+CVE_CHECK_IGNORE += "CVE-2022-25258"
+
+# CVE-2022-25265 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.24
+CVE_CHECK_IGNORE += "CVE-2022-25375"
+
+# cpe-stable-backport: Backported in 5.15.26
+CVE_CHECK_IGNORE += "CVE-2022-25636"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-2585"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-2586"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-2588"
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-2590"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-2602"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-26365"
+
+# cpe-stable-backport: Backported in 5.15.60
+CVE_CHECK_IGNORE += "CVE-2022-26373"
+
+# cpe-stable-backport: Backported in 5.15.36
+CVE_CHECK_IGNORE += "CVE-2022-2639"
+
+# cpe-stable-backport: Backported in 5.15.32
+CVE_CHECK_IGNORE += "CVE-2022-26490"
+
+# cpe-stable-backport: Backported in 5.15.68
+CVE_CHECK_IGNORE += "CVE-2022-2663"
+
+# CVE-2022-26878 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.26
+CVE_CHECK_IGNORE += "CVE-2022-26966"
+
+# cpe-stable-backport: Backported in 5.15.26
+CVE_CHECK_IGNORE += "CVE-2022-27223"
+
+# cpe-stable-backport: Backported in 5.15.29
+CVE_CHECK_IGNORE += "CVE-2022-27666"
+
+# cpe-stable-backport: Backported in 5.15.94
+CVE_CHECK_IGNORE += "CVE-2022-27672"
+
+# fixed-version: only affects 5.18rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-2785"
+
+# cpe-stable-backport: Backported in 5.15.25
+CVE_CHECK_IGNORE += "CVE-2022-27950"
+
+# cpe-stable-backport: Backported in 5.15.32
+CVE_CHECK_IGNORE += "CVE-2022-28356"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-28388"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-28389"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-28390"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-2873"
+
+# fixed-version: only affects 5.17rc3 onwards
+CVE_CHECK_IGNORE += "CVE-2022-28796"
+
+# cpe-stable-backport: Backported in 5.15.41
+CVE_CHECK_IGNORE += "CVE-2022-28893"
+
+# cpe-stable-backport: Backported in 5.15.64
+CVE_CHECK_IGNORE += "CVE-2022-2905"
+
+# cpe-stable-backport: Backported in 5.15.26
+CVE_CHECK_IGNORE += "CVE-2022-29156"
+
+# cpe-stable-backport: Backported in 5.15.19
+CVE_CHECK_IGNORE += "CVE-2022-2938"
+
+# cpe-stable-backport: Backported in 5.15.36
+CVE_CHECK_IGNORE += "CVE-2022-29581"
+
+# cpe-stable-backport: Backported in 5.15.34
+CVE_CHECK_IGNORE += "CVE-2022-29582"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-2959"
+
+# CVE-2022-2961 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.24
+CVE_CHECK_IGNORE += "CVE-2022-2964"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-2977"
+
+# cpe-stable-backport: Backported in 5.15.73
+CVE_CHECK_IGNORE += "CVE-2022-2978"
+
+# cpe-stable-backport: Backported in 5.15.57
+CVE_CHECK_IGNORE += "CVE-2022-29900"
+
+# cpe-stable-backport: Backported in 5.15.57
+CVE_CHECK_IGNORE += "CVE-2022-29901"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-2991"
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-29968"
+
+# cpe-stable-backport: Backported in 5.15.64
+CVE_CHECK_IGNORE += "CVE-2022-3028"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-30594"
+
+# cpe-stable-backport: Backported in 5.15.70
+CVE_CHECK_IGNORE += "CVE-2022-3061"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-3077"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-3078"
+
+# fixed-version: only affects 6.0rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3103"
+
+# cpe-stable-backport: Backported in 5.15.47
+CVE_CHECK_IGNORE += "CVE-2022-3104"
+
+# cpe-stable-backport: Backported in 5.15.14
+CVE_CHECK_IGNORE += "CVE-2022-3105"
+
+# cpe-stable-backport: Backported in 5.15.11
+CVE_CHECK_IGNORE += "CVE-2022-3106"
+
+# cpe-stable-backport: Backported in 5.15.31
+CVE_CHECK_IGNORE += "CVE-2022-3107"
+
+# cpe-stable-backport: Backported in 5.15.27
+CVE_CHECK_IGNORE += "CVE-2022-3108"
+
+# cpe-stable-backport: Backported in 5.15.47
+CVE_CHECK_IGNORE += "CVE-2022-3110"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-3111"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-3112"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-3113"
+
+# CVE-2022-3114 needs backporting (fixed from 5.19rc1)
+
+# cpe-stable-backport: Backported in 5.15.46
+CVE_CHECK_IGNORE += "CVE-2022-3115"
+
+# cpe-stable-backport: Backported in 5.15.80
+CVE_CHECK_IGNORE += "CVE-2022-3169"
+
+# fixed-version: only affects 6.0rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3170"
+
+# cpe-stable-backport: Backported in 5.15.65
+CVE_CHECK_IGNORE += "CVE-2022-3176"
+
+# cpe-stable-backport: Backported in 5.15.34
+CVE_CHECK_IGNORE += "CVE-2022-3202"
+
+# cpe-stable-backport: Backported in 5.15.45
+CVE_CHECK_IGNORE += "CVE-2022-32250"
+
+# cpe-stable-backport: Backported in 5.15.41
+CVE_CHECK_IGNORE += "CVE-2022-32296"
+
+# CVE-2022-3238 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2022-3239"
+
+# cpe-stable-backport: Backported in 5.15.47
+CVE_CHECK_IGNORE += "CVE-2022-32981"
+
+# cpe-stable-backport: Backported in 5.15.68
+CVE_CHECK_IGNORE += "CVE-2022-3303"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2022-3344"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-33740"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-33741"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-33742"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-33743"
+
+# cpe-stable-backport: Backported in 5.15.53
+CVE_CHECK_IGNORE += "CVE-2022-33744"
+
+# cpe-stable-backport: Backported in 5.15.37
+CVE_CHECK_IGNORE += "CVE-2022-33981"
+
+# cpe-stable-backport: Backported in 5.15.86
+CVE_CHECK_IGNORE += "CVE-2022-3424"
+
+# fixed-version: only affects 5.18rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3435"
+
+# cpe-stable-backport: Backported in 5.15.47
+CVE_CHECK_IGNORE += "CVE-2022-34494"
+
+# cpe-stable-backport: Backported in 5.15.47
+CVE_CHECK_IGNORE += "CVE-2022-34495"
+
+# cpe-stable-backport: Backported in 5.15.54
+CVE_CHECK_IGNORE += "CVE-2022-34918"
+
+# cpe-stable-backport: Backported in 5.15.80
+CVE_CHECK_IGNORE += "CVE-2022-3521"
+
+# CVE-2022-3522 needs backporting (fixed from 6.1rc1)
+
+# CVE-2022-3523 needs backporting (fixed from 6.1rc1)
+
+# cpe-stable-backport: Backported in 5.15.77
+CVE_CHECK_IGNORE += "CVE-2022-3524"
+
+# cpe-stable-backport: Backported in 5.15.35
+CVE_CHECK_IGNORE += "CVE-2022-3526"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3531"
+
+# fixed-version: only affects 6.1rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3532"
+
+# CVE-2022-3533 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.86
+CVE_CHECK_IGNORE += "CVE-2022-3534"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-3535"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3541"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-3542"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-3543"
+
+# CVE-2022-3544 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.84
+CVE_CHECK_IGNORE += "CVE-2022-3545"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-3564"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-3565"
+
+# CVE-2022-3566 needs backporting (fixed from 6.1rc1)
+
+# CVE-2022-3567 needs backporting (fixed from 6.1rc1)
+
+# cpe-stable-backport: Backported in 5.15.46
+CVE_CHECK_IGNORE += "CVE-2022-3577"
+
+# cpe-stable-backport: Backported in 5.15.68
+CVE_CHECK_IGNORE += "CVE-2022-3586"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-3594"
+
+# CVE-2022-3595 needs backporting (fixed from 6.1rc1)
+
+# CVE-2022-3606 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.56
+CVE_CHECK_IGNORE += "CVE-2022-36123"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-3619"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-3621"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-3623"
+
+# CVE-2022-3624 needs backporting (fixed from 6.0rc1)
+
+# cpe-stable-backport: Backported in 5.15.63
+CVE_CHECK_IGNORE += "CVE-2022-3625"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-3628"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2022-36280"
+
+# cpe-stable-backport: Backported in 5.15.63
+CVE_CHECK_IGNORE += "CVE-2022-3629"
+
+# fixed-version: only affects 5.19rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3630"
+
+# cpe-stable-backport: Backported in 5.15.63
+CVE_CHECK_IGNORE += "CVE-2022-3633"
+
+# cpe-stable-backport: Backported in 5.15.63
+CVE_CHECK_IGNORE += "CVE-2022-3635"
+
+# CVE-2022-3636 needs backporting (fixed from 5.19rc1)
+
+# fixed-version: only affects 5.19 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3640"
+
+# CVE-2022-36402 has no known resolution
+
+# CVE-2022-3642 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.83
+CVE_CHECK_IGNORE += "CVE-2022-3643"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-3646"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-3649"
+
+# cpe-stable-backport: Backported in 5.15.58
+CVE_CHECK_IGNORE += "CVE-2022-36879"
+
+# cpe-stable-backport: Backported in 5.15.59
+CVE_CHECK_IGNORE += "CVE-2022-36946"
+
+# cpe-stable-backport: Backported in 5.15.96
+CVE_CHECK_IGNORE += "CVE-2022-3707"
+
+# CVE-2022-38096 has no known resolution
+
+# CVE-2022-38457 needs backporting (fixed from 6.2rc4)
+
+# CVE-2022-3903 needs backporting (fixed from 6.1rc2)
+
+# fixed-version: only affects 5.18 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3910"
+
+# CVE-2022-39188 needs backporting (fixed from 5.19rc8)
+
+# cpe-stable-backport: Backported in 5.15.60
+CVE_CHECK_IGNORE += "CVE-2022-39189"
+
+# cpe-stable-backport: Backported in 5.15.64
+CVE_CHECK_IGNORE += "CVE-2022-39190"
+
+# fixed-version: only affects 5.18rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-3977"
+
+# cpe-stable-backport: Backported in 5.15.70
+CVE_CHECK_IGNORE += "CVE-2022-39842"
+
+# CVE-2022-40133 needs backporting (fixed from 6.2rc4)
+
+# cpe-stable-backport: Backported in 5.15.68
+CVE_CHECK_IGNORE += "CVE-2022-40307"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-40476"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-40768"
+
+# cpe-stable-backport: Backported in 5.15.66
+CVE_CHECK_IGNORE += "CVE-2022-4095"
+
+# CVE-2022-40982 needs backporting (fixed from 5.15.125)
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2022-41218"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2022-41222"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-4127"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2022-4128"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2022-4129"
+
+# fixed-version: only affects 5.17rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2022-4139"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-41674"
+
+# CVE-2022-41848 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-41849"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-41850"
+
+# cpe-stable-backport: Backported in 5.15.35
+CVE_CHECK_IGNORE += "CVE-2022-41858"
+
+# fixed-version: only affects 5.16rc7 onwards
+CVE_CHECK_IGNORE += "CVE-2022-42328"
+
+# fixed-version: only affects 5.16rc7 onwards
+CVE_CHECK_IGNORE += "CVE-2022-42329"
+
+# cpe-stable-backport: Backported in 5.15.71
+CVE_CHECK_IGNORE += "CVE-2022-42432"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2022-4269"
+
+# cpe-stable-backport: Backported in 5.15.65
+CVE_CHECK_IGNORE += "CVE-2022-42703"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-42719"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-42720"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-42721"
+
+# cpe-stable-backport: Backported in 5.15.74
+CVE_CHECK_IGNORE += "CVE-2022-42722"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-42895"
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2022-42896"
+
+# cpe-stable-backport: Backported in 5.15.73
+CVE_CHECK_IGNORE += "CVE-2022-43750"
+
+# cpe-stable-backport: Backported in 5.15.82
+CVE_CHECK_IGNORE += "CVE-2022-4378"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2022-4379"
+
+# cpe-stable-backport: Backported in 5.15.90
+CVE_CHECK_IGNORE += "CVE-2022-4382"
+
+# cpe-stable-backport: Backported in 5.15.75
+CVE_CHECK_IGNORE += "CVE-2022-43945"
+
+# CVE-2022-44032 needs backporting (fixed from 6.4rc1)
+
+# CVE-2022-44033 needs backporting (fixed from 6.4rc1)
+
+# CVE-2022-44034 has no known resolution
+
+# CVE-2022-4543 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.82
+CVE_CHECK_IGNORE += "CVE-2022-45869"
+
+# CVE-2022-45884 has no known resolution
+
+# CVE-2022-45885 has no known resolution
+
+# CVE-2022-45886 needs backporting (fixed from 5.15.116)
+
+# CVE-2022-45887 needs backporting (fixed from 5.15.116)
+
+# CVE-2022-45888 needs backporting (fixed from 6.2rc1)
+
+# CVE-2022-45919 needs backporting (fixed from 5.15.116)
+
+# cpe-stable-backport: Backported in 5.15.85
+CVE_CHECK_IGNORE += "CVE-2022-45934"
+
+# cpe-stable-backport: Backported in 5.15.66
+CVE_CHECK_IGNORE += "CVE-2022-4662"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-4696"
+
+# cpe-stable-backport: Backported in 5.15.12
+CVE_CHECK_IGNORE += "CVE-2022-4744"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2022-47518"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2022-47519"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2022-47520"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2022-47521"
+
+# cpe-stable-backport: Backported in 5.15.88
+CVE_CHECK_IGNORE += "CVE-2022-47929"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-47938"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-47939"
+
+# CVE-2022-47940 needs backporting (fixed from 5.19rc1)
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2022-47941"
+
+# cpe-stable-backport: Backported in 5.15.62
+CVE_CHECK_IGNORE += "CVE-2022-47942"
+
+# cpe-stable-backport: Backported in 5.15.62
+CVE_CHECK_IGNORE += "CVE-2022-47943"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2022-47946"
+
+# cpe-stable-backport: Backported in 5.15.90
+CVE_CHECK_IGNORE += "CVE-2022-4842"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2022-48423"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2022-48424"
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2022-48425"
+
+# CVE-2022-48502 needs backporting (fixed from 5.15.121)
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-0030"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2023-0045"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2023-0047"
+
+# fixed-version: only affects 6.0rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-0122"
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-0160"
+
+# cpe-stable-backport: Backported in 5.15.89
+CVE_CHECK_IGNORE += "CVE-2023-0179"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2023-0210"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2023-0240"
+
+# cpe-stable-backport: Backported in 5.15.88
+CVE_CHECK_IGNORE += "CVE-2023-0266"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-0386"
+
+# cpe-stable-backport: Backported in 5.15.89
+CVE_CHECK_IGNORE += "CVE-2023-0394"
+
+# cpe-stable-backport: Backported in 5.15.90
+CVE_CHECK_IGNORE += "CVE-2023-0458"
+
+# cpe-stable-backport: Backported in 5.15.96
+CVE_CHECK_IGNORE += "CVE-2023-0459"
+
+# cpe-stable-backport: Backported in 5.15.88
+CVE_CHECK_IGNORE += "CVE-2023-0461"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-0468"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-0469"
+
+# cpe-stable-backport: Backported in 5.15.76
+CVE_CHECK_IGNORE += "CVE-2023-0590"
+
+# CVE-2023-0597 needs backporting (fixed from 6.2rc1)
+
+# cpe-stable-backport: Backported in 5.15.77
+CVE_CHECK_IGNORE += "CVE-2023-0615"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-1032"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-1073"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-1074"
+
+# CVE-2023-1075 needs backporting (fixed from 6.2rc7)
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-1076"
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-1077"
+
+# cpe-stable-backport: Backported in 5.15.94
+CVE_CHECK_IGNORE += "CVE-2023-1078"
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-1079"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2023-1095"
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-1118"
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-1192"
+
+# CVE-2023-1193 has no known resolution
+
+# CVE-2023-1194 has no known resolution
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-1195"
+
+# CVE-2023-1206 needs backporting (fixed from 5.15.124)
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2023-1249"
+
+# cpe-stable-backport: Backported in 5.15.3
+CVE_CHECK_IGNORE += "CVE-2023-1252"
+
+# cpe-stable-backport: Backported in 5.15.95
+CVE_CHECK_IGNORE += "CVE-2023-1281"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2023-1295"
+
+# cpe-stable-backport: Backported in 5.15.110
+CVE_CHECK_IGNORE += "CVE-2023-1380"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2023-1382"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2023-1390"
+
+# cpe-stable-backport: Backported in 5.15.95
+CVE_CHECK_IGNORE += "CVE-2023-1513"
+
+# cpe-stable-backport: Backported in 5.15.25
+CVE_CHECK_IGNORE += "CVE-2023-1582"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-1583"
+
+# cpe-stable-backport: Backported in 5.15.106
+CVE_CHECK_IGNORE += "CVE-2023-1611"
+
+# cpe-stable-backport: Backported in 5.15.34
+CVE_CHECK_IGNORE += "CVE-2023-1637"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-1652"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-1670"
+
+# cpe-stable-backport: Backported in 5.15.100
+CVE_CHECK_IGNORE += "CVE-2023-1829"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2023-1838"
+
+# cpe-stable-backport: Backported in 5.15.104
+CVE_CHECK_IGNORE += "CVE-2023-1855"
+
+# cpe-stable-backport: Backported in 5.15.108
+CVE_CHECK_IGNORE += "CVE-2023-1859"
+
+# CVE-2023-1872 needs backporting (fixed from 5.18rc2)
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-1989"
+
+# cpe-stable-backport: Backported in 5.15.104
+CVE_CHECK_IGNORE += "CVE-2023-1990"
+
+# fixed-version: only affects 5.19rc7 onwards
+CVE_CHECK_IGNORE += "CVE-2023-1998"
+
+# cpe-stable-backport: Backported in 5.15.110
+CVE_CHECK_IGNORE += "CVE-2023-2002"
+
+# cpe-stable-backport: Backported in 5.15.81
+CVE_CHECK_IGNORE += "CVE-2023-2006"
+
+# CVE-2023-2007 needs backporting (fixed from 6.0rc1)
+
+# cpe-stable-backport: Backported in 5.15.51
+CVE_CHECK_IGNORE += "CVE-2023-2008"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2023-2019"
+
+# CVE-2023-20569 needs backporting (fixed from 5.15.125)
+
+# CVE-2023-20588 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-20593 needs backporting (fixed from 5.15.122)
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2023-20928"
+
+# CVE-2023-20937 has no known resolution
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-20938"
+
+# CVE-2023-20941 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.90
+CVE_CHECK_IGNORE += "CVE-2023-21102"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-21106"
+
+# CVE-2023-2124 needs backporting (fixed from 5.15.117)
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-21255"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-21264"
+
+# CVE-2023-21400 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.109
+CVE_CHECK_IGNORE += "CVE-2023-2156"
+
+# cpe-stable-backport: Backported in 5.15.93
+CVE_CHECK_IGNORE += "CVE-2023-2162"
+
+# cpe-stable-backport: Backported in 5.15.109
+CVE_CHECK_IGNORE += "CVE-2023-2163"
+
+# cpe-stable-backport: Backported in 5.15.83
+CVE_CHECK_IGNORE += "CVE-2023-2166"
+
+# CVE-2023-2176 needs backporting (fixed from 6.3rc1)
+
+# cpe-stable-backport: Backported in 5.15.59
+CVE_CHECK_IGNORE += "CVE-2023-2177"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-2194"
+
+# cpe-stable-backport: Backported in 5.15.104
+CVE_CHECK_IGNORE += "CVE-2023-2235"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-2236"
+
+# cpe-stable-backport: Backported in 5.15.109
+CVE_CHECK_IGNORE += "CVE-2023-2248"
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-2269"
+
+# CVE-2023-22995 needs backporting (fixed from 5.17rc1)
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-22996"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-22997"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2023-22998"
+
+# cpe-stable-backport: Backported in 5.15.17
+CVE_CHECK_IGNORE += "CVE-2023-22999"
+
+# CVE-2023-23000 needs backporting (fixed from 5.17rc1)
+
+# cpe-stable-backport: Backported in 5.15.17
+CVE_CHECK_IGNORE += "CVE-2023-23001"
+
+# cpe-stable-backport: Backported in 5.15.17
+CVE_CHECK_IGNORE += "CVE-2023-23002"
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-23003"
+
+# cpe-stable-backport: Backported in 5.15.100
+CVE_CHECK_IGNORE += "CVE-2023-23004"
+
+# fixed-version: only affects 6.1rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-23005"
+
+# cpe-stable-backport: Backported in 5.15.13
+CVE_CHECK_IGNORE += "CVE-2023-23006"
+
+# CVE-2023-23039 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2023-23454"
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2023-23455"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-23559"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2023-23586"
+
+# CVE-2023-2430 needs backporting (fixed from 6.2rc5)
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-2483"
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-25012"
+
+# cpe-stable-backport: Backported in 5.15.61
+CVE_CHECK_IGNORE += "CVE-2023-2513"
+
+# CVE-2023-25775 has no known resolution
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-2598"
+
+# CVE-2023-26242 has no known resolution
+
+# CVE-2023-2640 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.87
+CVE_CHECK_IGNORE += "CVE-2023-26544"
+
+# cpe-stable-backport: Backported in 5.15.95
+CVE_CHECK_IGNORE += "CVE-2023-26545"
+
+# fixed-version: only affects 6.1rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-26605"
+
+# cpe-stable-backport: Backported in 5.15.86
+CVE_CHECK_IGNORE += "CVE-2023-26606"
+
+# cpe-stable-backport: Backported in 5.15.80
+CVE_CHECK_IGNORE += "CVE-2023-26607"
+
+# cpe-stable-backport: Backported in 5.15.83
+CVE_CHECK_IGNORE += "CVE-2023-28327"
+
+# cpe-stable-backport: Backported in 5.15.86
+CVE_CHECK_IGNORE += "CVE-2023-28328"
+
+# cpe-stable-backport: Backported in 5.15.33
+CVE_CHECK_IGNORE += "CVE-2023-28410"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-28464"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-28466"
+
+# cpe-stable-backport: Backported in 5.15.68
+CVE_CHECK_IGNORE += "CVE-2023-2860"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2023-28772"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-28866"
+
+# CVE-2023-2898 needs backporting (fixed from 5.15.121)
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-2985"
+
+# cpe-stable-backport: Backported in 5.15.77
+CVE_CHECK_IGNORE += "CVE-2023-3006"
+
+# Skipping CVE-2023-3022, no affected_versions
+
+# cpe-stable-backport: Backported in 5.15.104
+CVE_CHECK_IGNORE += "CVE-2023-30456"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-30772"
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-3090"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2023-3106"
+
+# Skipping CVE-2023-3108, no affected_versions
+
+# CVE-2023-31081 has no known resolution
+
+# CVE-2023-31082 has no known resolution
+
+# CVE-2023-31083 has no known resolution
+
+# CVE-2023-31084 needs backporting (fixed from 6.4rc3)
+
+# CVE-2023-31085 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.63
+CVE_CHECK_IGNORE += "CVE-2023-3111"
+
+# CVE-2023-3117 needs backporting (fixed from 5.15.118)
+
+# CVE-2023-31248 needs backporting (fixed from 5.15.121)
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-3141"
+
+# cpe-stable-backport: Backported in 5.15.109
+CVE_CHECK_IGNORE += "CVE-2023-31436"
+
+# cpe-stable-backport: Backported in 5.15.39
+CVE_CHECK_IGNORE += "CVE-2023-3159"
+
+# cpe-stable-backport: Backported in 5.15.93
+CVE_CHECK_IGNORE += "CVE-2023-3161"
+
+# CVE-2023-3212 needs backporting (fixed from 5.15.116)
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-3220"
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-32233"
+
+# CVE-2023-32247 needs backporting (fixed from 6.4rc1)
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-32248"
+
+# CVE-2023-32250 needs backporting (fixed from 6.4rc1)
+
+# CVE-2023-32252 needs backporting (fixed from 6.4rc1)
+
+# CVE-2023-32254 needs backporting (fixed from 6.4rc1)
+
+# CVE-2023-32257 needs backporting (fixed from 6.4rc1)
+
+# CVE-2023-32258 needs backporting (fixed from 6.4rc1)
+
+# cpe-stable-backport: Backported in 5.15.93
+CVE_CHECK_IGNORE += "CVE-2023-32269"
+
+# CVE-2023-32629 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-3268"
+
+# fixed-version: only affects 6.1rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3269"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3312"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3317"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-33203"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-33250"
+
+# cpe-stable-backport: Backported in 5.15.105
+CVE_CHECK_IGNORE += "CVE-2023-33288"
+
+# CVE-2023-3338 needs backporting (fixed from 5.15.118)
+
+# cpe-stable-backport: Backported in 5.15.99
+CVE_CHECK_IGNORE += "CVE-2023-3355"
+
+# cpe-stable-backport: Backported in 5.15.86
+CVE_CHECK_IGNORE += "CVE-2023-3357"
+
+# cpe-stable-backport: Backported in 5.15.91
+CVE_CHECK_IGNORE += "CVE-2023-3358"
+
+# fixed-version: only affects 5.18rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3359"
+
+# CVE-2023-3389 needs backporting (fixed from 6.0rc1)
+
+# CVE-2023-3390 needs backporting (fixed from 5.15.118)
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-33951"
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-33952"
+
+# CVE-2023-3397 has no known resolution
+
+# CVE-2023-34255 needs backporting (fixed from 5.15.117)
+
+# cpe-stable-backport: Backported in 5.15.112
+CVE_CHECK_IGNORE += "CVE-2023-34256"
+
+# fixed-version: only affects 6.1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-34319"
+
+# CVE-2023-3439 needs backporting (fixed from 5.18rc5)
+
+# CVE-2023-35001 needs backporting (fixed from 5.15.121)
+
+# cpe-stable-backport: Backported in 5.15.93
+CVE_CHECK_IGNORE += "CVE-2023-3567"
+
+# CVE-2023-35693 has no known resolution
+
+# CVE-2023-35788 needs backporting (fixed from 5.15.116)
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-35823"
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-35824"
+
+# fixed-version: only affects 5.18rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-35826"
+
+# CVE-2023-35827 has no known resolution
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-35828"
+
+# cpe-stable-backport: Backported in 5.15.111
+CVE_CHECK_IGNORE += "CVE-2023-35829"
+
+# CVE-2023-3609 needs backporting (fixed from 5.15.118)
+
+# CVE-2023-3610 needs backporting (fixed from 5.15.119)
+
+# CVE-2023-3611 needs backporting (fixed from 5.15.121)
+
+# CVE-2023-3640 has no known resolution
+
+# CVE-2023-37453 has no known resolution
+
+# CVE-2023-37454 has no known resolution
+
+# CVE-2023-3772 needs backporting (fixed from 5.15.128)
+
+# fixed-version: only affects 5.17rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3773"
+
+# CVE-2023-3776 needs backporting (fixed from 5.15.121)
+
+# CVE-2023-3777 needs backporting (fixed from 5.15.123)
+
+# cpe-stable-backport: Backported in 5.15.78
+CVE_CHECK_IGNORE += "CVE-2023-3812"
+
+# fixed-version: only affects 5.19rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-38409"
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-38426"
+
+# CVE-2023-38427 needs backporting (fixed from 6.4rc6)
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-38428"
+
+# cpe-stable-backport: Backported in 5.15.113
+CVE_CHECK_IGNORE += "CVE-2023-38429"
+
+# CVE-2023-38430 needs backporting (fixed from 6.4rc6)
+
+# CVE-2023-38431 needs backporting (fixed from 6.4rc6)
+
+# CVE-2023-38432 needs backporting (fixed from 5.15.121)
+
+# CVE-2023-3863 needs backporting (fixed from 5.15.121)
+
+# CVE-2023-4004 needs backporting (fixed from 5.15.123)
+
+# CVE-2023-4010 has no known resolution
+
+# CVE-2023-4015 needs backporting (fixed from 5.15.124)
+
+# CVE-2023-40283 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-4128 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-4132 needs backporting (fixed from 5.15.121)
+
+# CVE-2023-4133 needs backporting (fixed from 6.3)
+
+# CVE-2023-4134 needs backporting (fixed from 6.5rc1)
+
+# CVE-2023-4147 needs backporting (fixed from 5.15.124)
+
+# CVE-2023-4155 needs backporting (fixed from 6.5rc6)
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4194"
+
+# CVE-2023-4206 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-4207 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-4208 needs backporting (fixed from 5.15.126)
+
+# CVE-2023-4273 needs backporting (fixed from 5.15.128)
+
+# cpe-stable-backport: Backported in 5.15.46
+CVE_CHECK_IGNORE += "CVE-2023-4385"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2023-4387"
+
+# cpe-stable-backport: Backported in 5.15.35
+CVE_CHECK_IGNORE += "CVE-2023-4389"
+
+# fixed-version: only affects 5.16rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4394"
+
+# cpe-stable-backport: Backported in 5.15.42
+CVE_CHECK_IGNORE += "CVE-2023-4459"
+
+# CVE-2023-4563 needs backporting (fixed from 6.5rc6)
+
+# CVE-2023-4569 needs backporting (fixed from 5.15.128)
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4611"
+
+# CVE-2023-4622 needs backporting (fixed from 6.5rc1)
+
+# CVE-2023-4623 has no known resolution
+

--- a/recipes-kernel/linux/cve-exclusion_6.1.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.1.inc
@@ -1,0 +1,7302 @@
+
+# Auto-generated CVE metadata, DO NOT EDIT BY HAND.
+# Generated at 2023-09-13 07:46:38.039798 for version 6.1.47
+
+python check_kernel_cve_status_version() {
+    this_version = "6.1.47"
+    kernel_version = d.getVar("LINUX_VERSION")
+    if kernel_version != this_version:
+        bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
+}
+do_cve_check[prefuncs] += "check_kernel_cve_status_version"
+
+# fixed-version: Fixed after version 2.6.12rc2
+CVE_CHECK_IGNORE += "CVE-2003-1604"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2004-0230"
+
+# CVE-2005-3660 has no known resolution
+
+# fixed-version: Fixed after version 2.6.26rc5
+CVE_CHECK_IGNORE += "CVE-2006-3635"
+
+# fixed-version: Fixed after version 2.6.19rc3
+CVE_CHECK_IGNORE += "CVE-2006-5331"
+
+# fixed-version: Fixed after version 2.6.19rc2
+CVE_CHECK_IGNORE += "CVE-2006-6128"
+
+# CVE-2007-3719 has no known resolution
+
+# fixed-version: Fixed after version 2.6.12rc2
+CVE_CHECK_IGNORE += "CVE-2007-4774"
+
+# fixed-version: Fixed after version 2.6.24rc6
+CVE_CHECK_IGNORE += "CVE-2007-6761"
+
+# fixed-version: Fixed after version 2.6.20rc5
+CVE_CHECK_IGNORE += "CVE-2007-6762"
+
+# CVE-2008-2544 has no known resolution
+
+# CVE-2008-4609 has no known resolution
+
+# fixed-version: Fixed after version 2.6.25rc1
+CVE_CHECK_IGNORE += "CVE-2008-7316"
+
+# fixed-version: Fixed after version 2.6.31rc6
+CVE_CHECK_IGNORE += "CVE-2009-2692"
+
+# fixed-version: Fixed after version 2.6.23rc9
+CVE_CHECK_IGNORE += "CVE-2010-0008"
+
+# fixed-version: Fixed after version 2.6.36rc5
+CVE_CHECK_IGNORE += "CVE-2010-3432"
+
+# CVE-2010-4563 has no known resolution
+
+# fixed-version: Fixed after version 2.6.37rc6
+CVE_CHECK_IGNORE += "CVE-2010-4648"
+
+# fixed-version: Fixed after version 2.6.38rc1
+CVE_CHECK_IGNORE += "CVE-2010-5313"
+
+# CVE-2010-5321 has no known resolution
+
+# fixed-version: Fixed after version 2.6.35rc1
+CVE_CHECK_IGNORE += "CVE-2010-5328"
+
+# fixed-version: Fixed after version 2.6.39rc1
+CVE_CHECK_IGNORE += "CVE-2010-5329"
+
+# fixed-version: Fixed after version 2.6.34rc7
+CVE_CHECK_IGNORE += "CVE-2010-5331"
+
+# fixed-version: Fixed after version 2.6.37rc1
+CVE_CHECK_IGNORE += "CVE-2010-5332"
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-4098"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2011-4131"
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-4915"
+
+# CVE-2011-4916 has no known resolution
+
+# CVE-2011-4917 has no known resolution
+
+# fixed-version: Fixed after version 3.2rc1
+CVE_CHECK_IGNORE += "CVE-2011-5321"
+
+# fixed-version: Fixed after version 3.1rc1
+CVE_CHECK_IGNORE += "CVE-2011-5327"
+
+# fixed-version: Fixed after version 3.7rc2
+CVE_CHECK_IGNORE += "CVE-2012-0957"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2119"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2136"
+
+# fixed-version: Fixed after version 3.5rc2
+CVE_CHECK_IGNORE += "CVE-2012-2137"
+
+# fixed-version: Fixed after version 3.4rc6
+CVE_CHECK_IGNORE += "CVE-2012-2313"
+
+# fixed-version: Fixed after version 3.4rc6
+CVE_CHECK_IGNORE += "CVE-2012-2319"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2012-2372"
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-2375"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-2390"
+
+# fixed-version: Fixed after version 3.5rc4
+CVE_CHECK_IGNORE += "CVE-2012-2669"
+
+# fixed-version: Fixed after version 2.6.34rc1
+CVE_CHECK_IGNORE += "CVE-2012-2744"
+
+# fixed-version: Fixed after version 3.4rc3
+CVE_CHECK_IGNORE += "CVE-2012-2745"
+
+# fixed-version: Fixed after version 3.5rc6
+CVE_CHECK_IGNORE += "CVE-2012-3364"
+
+# fixed-version: Fixed after version 3.4rc5
+CVE_CHECK_IGNORE += "CVE-2012-3375"
+
+# fixed-version: Fixed after version 3.5rc5
+CVE_CHECK_IGNORE += "CVE-2012-3400"
+
+# fixed-version: Fixed after version 3.6rc2
+CVE_CHECK_IGNORE += "CVE-2012-3412"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-3430"
+
+# fixed-version: Fixed after version 2.6.19rc4
+CVE_CHECK_IGNORE += "CVE-2012-3510"
+
+# fixed-version: Fixed after version 3.5rc6
+CVE_CHECK_IGNORE += "CVE-2012-3511"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-3520"
+
+# fixed-version: Fixed after version 3.0rc1
+CVE_CHECK_IGNORE += "CVE-2012-3552"
+
+# Skipping CVE-2012-4220, no affected_versions
+
+# Skipping CVE-2012-4221, no affected_versions
+
+# Skipping CVE-2012-4222, no affected_versions
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-4398"
+
+# fixed-version: Fixed after version 2.6.36rc4
+CVE_CHECK_IGNORE += "CVE-2012-4444"
+
+# fixed-version: Fixed after version 3.7rc6
+CVE_CHECK_IGNORE += "CVE-2012-4461"
+
+# fixed-version: Fixed after version 3.6rc5
+CVE_CHECK_IGNORE += "CVE-2012-4467"
+
+# fixed-version: Fixed after version 3.7rc3
+CVE_CHECK_IGNORE += "CVE-2012-4508"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-4530"
+
+# CVE-2012-4542 has no known resolution
+
+# fixed-version: Fixed after version 3.7rc4
+CVE_CHECK_IGNORE += "CVE-2012-4565"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-5374"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2012-5375"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-5517"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6536"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6537"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2012-6538"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6539"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6540"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6541"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6542"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6543"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6544"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6545"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2012-6546"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6547"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6548"
+
+# fixed-version: Fixed after version 3.6rc1
+CVE_CHECK_IGNORE += "CVE-2012-6549"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2012-6638"
+
+# fixed-version: Fixed after version 3.6rc2
+CVE_CHECK_IGNORE += "CVE-2012-6647"
+
+# fixed-version: Fixed after version 3.6
+CVE_CHECK_IGNORE += "CVE-2012-6657"
+
+# fixed-version: Fixed after version 3.6rc5
+CVE_CHECK_IGNORE += "CVE-2012-6689"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-6701"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2012-6703"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2012-6704"
+
+# fixed-version: Fixed after version 3.4rc1
+CVE_CHECK_IGNORE += "CVE-2012-6712"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-0160"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0190"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0216"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0217"
+
+# fixed-version: Fixed after version 3.8
+CVE_CHECK_IGNORE += "CVE-2013-0228"
+
+# fixed-version: Fixed after version 3.8rc7
+CVE_CHECK_IGNORE += "CVE-2013-0231"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-0268"
+
+# fixed-version: Fixed after version 3.8
+CVE_CHECK_IGNORE += "CVE-2013-0290"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2013-0309"
+
+# fixed-version: Fixed after version 3.5
+CVE_CHECK_IGNORE += "CVE-2013-0310"
+
+# fixed-version: Fixed after version 3.7rc8
+CVE_CHECK_IGNORE += "CVE-2013-0311"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0313"
+
+# fixed-version: Fixed after version 3.11rc7
+CVE_CHECK_IGNORE += "CVE-2013-0343"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-0349"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-0871"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-0913"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-0914"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-1059"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-1763"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-1767"
+
+# fixed-version: Fixed after version 3.5rc1
+CVE_CHECK_IGNORE += "CVE-2013-1772"
+
+# fixed-version: Fixed after version 3.3rc1
+CVE_CHECK_IGNORE += "CVE-2013-1773"
+
+# fixed-version: Fixed after version 3.8rc5
+CVE_CHECK_IGNORE += "CVE-2013-1774"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1792"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1796"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1797"
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-1798"
+
+# fixed-version: Fixed after version 3.8rc6
+CVE_CHECK_IGNORE += "CVE-2013-1819"
+
+# fixed-version: Fixed after version 3.6rc7
+CVE_CHECK_IGNORE += "CVE-2013-1826"
+
+# fixed-version: Fixed after version 3.6rc3
+CVE_CHECK_IGNORE += "CVE-2013-1827"
+
+# fixed-version: Fixed after version 3.9rc2
+CVE_CHECK_IGNORE += "CVE-2013-1828"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1848"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1858"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-1860"
+
+# fixed-version: Fixed after version 3.7rc3
+CVE_CHECK_IGNORE += "CVE-2013-1928"
+
+# fixed-version: Fixed after version 3.9rc6
+CVE_CHECK_IGNORE += "CVE-2013-1929"
+
+# Skipping CVE-2013-1935, no affected_versions
+
+# fixed-version: Fixed after version 3.0rc1
+CVE_CHECK_IGNORE += "CVE-2013-1943"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1956"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1957"
+
+# fixed-version: Fixed after version 3.9rc5
+CVE_CHECK_IGNORE += "CVE-2013-1958"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-1959"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-1979"
+
+# fixed-version: Fixed after version 3.8rc2
+CVE_CHECK_IGNORE += "CVE-2013-2015"
+
+# fixed-version: Fixed after version 2.6.34
+CVE_CHECK_IGNORE += "CVE-2013-2017"
+
+# fixed-version: Fixed after version 3.8rc4
+CVE_CHECK_IGNORE += "CVE-2013-2058"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2094"
+
+# fixed-version: Fixed after version 2.6.34rc4
+CVE_CHECK_IGNORE += "CVE-2013-2128"
+
+# fixed-version: Fixed after version 3.11rc3
+CVE_CHECK_IGNORE += "CVE-2013-2140"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2141"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2146"
+
+# fixed-version: Fixed after version 3.12rc3
+CVE_CHECK_IGNORE += "CVE-2013-2147"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2148"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2164"
+
+# Skipping CVE-2013-2188, no affected_versions
+
+# fixed-version: Fixed after version 3.9rc4
+CVE_CHECK_IGNORE += "CVE-2013-2206"
+
+# Skipping CVE-2013-2224, no affected_versions
+
+# fixed-version: Fixed after version 3.10
+CVE_CHECK_IGNORE += "CVE-2013-2232"
+
+# fixed-version: Fixed after version 3.10
+CVE_CHECK_IGNORE += "CVE-2013-2234"
+
+# fixed-version: Fixed after version 3.9rc6
+CVE_CHECK_IGNORE += "CVE-2013-2237"
+
+# Skipping CVE-2013-2239, no affected_versions
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2546"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2547"
+
+# fixed-version: Fixed after version 3.9rc1
+CVE_CHECK_IGNORE += "CVE-2013-2548"
+
+# fixed-version: Fixed after version 3.9rc8
+CVE_CHECK_IGNORE += "CVE-2013-2596"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2634"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2635"
+
+# fixed-version: Fixed after version 3.9rc3
+CVE_CHECK_IGNORE += "CVE-2013-2636"
+
+# fixed-version: Fixed after version 3.10rc4
+CVE_CHECK_IGNORE += "CVE-2013-2850"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-2851"
+
+# fixed-version: Fixed after version 3.10rc6
+CVE_CHECK_IGNORE += "CVE-2013-2852"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2888"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2889"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2890"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2891"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2892"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2893"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2894"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2895"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2896"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-2897"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2898"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-2899"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-2929"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-2930"
+
+# fixed-version: Fixed after version 3.9
+CVE_CHECK_IGNORE += "CVE-2013-3076"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3222"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3223"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3224"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3225"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3226"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3227"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3228"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3229"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3230"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3231"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3232"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3233"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3234"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3235"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3236"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3237"
+
+# fixed-version: Fixed after version 3.9rc7
+CVE_CHECK_IGNORE += "CVE-2013-3301"
+
+# fixed-version: Fixed after version 3.8rc3
+CVE_CHECK_IGNORE += "CVE-2013-3302"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4125"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4127"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4129"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4162"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2013-4163"
+
+# fixed-version: Fixed after version 3.11rc5
+CVE_CHECK_IGNORE += "CVE-2013-4205"
+
+# fixed-version: Fixed after version 3.10rc4
+CVE_CHECK_IGNORE += "CVE-2013-4220"
+
+# fixed-version: Fixed after version 3.10rc5
+CVE_CHECK_IGNORE += "CVE-2013-4247"
+
+# fixed-version: Fixed after version 3.11rc6
+CVE_CHECK_IGNORE += "CVE-2013-4254"
+
+# fixed-version: Fixed after version 3.12rc4
+CVE_CHECK_IGNORE += "CVE-2013-4270"
+
+# fixed-version: Fixed after version 3.12rc6
+CVE_CHECK_IGNORE += "CVE-2013-4299"
+
+# fixed-version: Fixed after version 3.11
+CVE_CHECK_IGNORE += "CVE-2013-4300"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2013-4312"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-4343"
+
+# fixed-version: Fixed after version 3.13rc2
+CVE_CHECK_IGNORE += "CVE-2013-4345"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-4348"
+
+# fixed-version: Fixed after version 3.12rc2
+CVE_CHECK_IGNORE += "CVE-2013-4350"
+
+# fixed-version: Fixed after version 3.12rc4
+CVE_CHECK_IGNORE += "CVE-2013-4387"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-4470"
+
+# fixed-version: Fixed after version 3.10rc1
+CVE_CHECK_IGNORE += "CVE-2013-4483"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4511"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4512"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4513"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4514"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4515"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-4516"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-4563"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2013-4579"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-4587"
+
+# fixed-version: Fixed after version 2.6.33rc4
+CVE_CHECK_IGNORE += "CVE-2013-4588"
+
+# fixed-version: Fixed after version 3.8rc1
+CVE_CHECK_IGNORE += "CVE-2013-4591"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2013-4592"
+
+# Skipping CVE-2013-4737, no affected_versions
+
+# Skipping CVE-2013-4738, no affected_versions
+
+# Skipping CVE-2013-4739, no affected_versions
+
+# fixed-version: Fixed after version 3.10rc5
+CVE_CHECK_IGNORE += "CVE-2013-5634"
+
+# fixed-version: Fixed after version 3.6rc6
+CVE_CHECK_IGNORE += "CVE-2013-6282"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6367"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6368"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6376"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6378"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6380"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6381"
+
+# fixed-version: Fixed after version 3.13rc4
+CVE_CHECK_IGNORE += "CVE-2013-6382"
+
+# fixed-version: Fixed after version 3.12
+CVE_CHECK_IGNORE += "CVE-2013-6383"
+
+# Skipping CVE-2013-6392, no affected_versions
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2013-6431"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-6432"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2013-6885"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7026"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-7027"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7263"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7264"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7265"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7266"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7267"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7268"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7269"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7270"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7271"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7281"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2013-7339"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2013-7348"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2013-7421"
+
+# CVE-2013-7445 has no known resolution
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2013-7446"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2013-7470"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-0038"
+
+# fixed-version: Fixed after version 3.14rc5
+CVE_CHECK_IGNORE += "CVE-2014-0049"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-0055"
+
+# fixed-version: Fixed after version 3.14rc4
+CVE_CHECK_IGNORE += "CVE-2014-0069"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-0077"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-0100"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-0101"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-0102"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-0131"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-0155"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-0181"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-0196"
+
+# fixed-version: Fixed after version 2.6.33rc5
+CVE_CHECK_IGNORE += "CVE-2014-0203"
+
+# fixed-version: Fixed after version 2.6.37rc1
+CVE_CHECK_IGNORE += "CVE-2014-0205"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-0206"
+
+# Skipping CVE-2014-0972, no affected_versions
+
+# fixed-version: Fixed after version 3.13
+CVE_CHECK_IGNORE += "CVE-2014-1438"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2014-1444"
+
+# fixed-version: Fixed after version 3.12rc7
+CVE_CHECK_IGNORE += "CVE-2014-1445"
+
+# fixed-version: Fixed after version 3.13rc7
+CVE_CHECK_IGNORE += "CVE-2014-1446"
+
+# fixed-version: Fixed after version 3.13rc8
+CVE_CHECK_IGNORE += "CVE-2014-1690"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-1737"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2014-1738"
+
+# fixed-version: Fixed after version 3.15rc6
+CVE_CHECK_IGNORE += "CVE-2014-1739"
+
+# fixed-version: Fixed after version 3.14rc2
+CVE_CHECK_IGNORE += "CVE-2014-1874"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-2038"
+
+# fixed-version: Fixed after version 3.14rc3
+CVE_CHECK_IGNORE += "CVE-2014-2039"
+
+# fixed-version: Fixed after version 3.14rc7
+CVE_CHECK_IGNORE += "CVE-2014-2309"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-2523"
+
+# fixed-version: Fixed after version 3.14
+CVE_CHECK_IGNORE += "CVE-2014-2568"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2580"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2672"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2673"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2678"
+
+# fixed-version: Fixed after version 3.14rc6
+CVE_CHECK_IGNORE += "CVE-2014-2706"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-2739"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-2851"
+
+# fixed-version: Fixed after version 3.2rc7
+CVE_CHECK_IGNORE += "CVE-2014-2889"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-3122"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-3144"
+
+# fixed-version: Fixed after version 3.15rc2
+CVE_CHECK_IGNORE += "CVE-2014-3145"
+
+# fixed-version: Fixed after version 3.15
+CVE_CHECK_IGNORE += "CVE-2014-3153"
+
+# fixed-version: Fixed after version 3.17rc4
+CVE_CHECK_IGNORE += "CVE-2014-3180"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3181"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3182"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3183"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3184"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3185"
+
+# fixed-version: Fixed after version 3.17rc3
+CVE_CHECK_IGNORE += "CVE-2014-3186"
+
+# Skipping CVE-2014-3519, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc7
+CVE_CHECK_IGNORE += "CVE-2014-3534"
+
+# fixed-version: Fixed after version 2.6.36rc1
+CVE_CHECK_IGNORE += "CVE-2014-3535"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-3601"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3610"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3611"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-3631"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2014-3645"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3646"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-3647"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3673"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3687"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3688"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-3690"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-3917"
+
+# fixed-version: Fixed after version 3.15
+CVE_CHECK_IGNORE += "CVE-2014-3940"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-4014"
+
+# fixed-version: Fixed after version 3.14rc1
+CVE_CHECK_IGNORE += "CVE-2014-4027"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-4157"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4171"
+
+# Skipping CVE-2014-4322, no affected_versions
+
+# Skipping CVE-2014-4323, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4508"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-4608"
+
+# fixed-version: Fixed after version 3.16rc3
+CVE_CHECK_IGNORE += "CVE-2014-4611"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4652"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4653"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4654"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4655"
+
+# fixed-version: Fixed after version 3.16rc2
+CVE_CHECK_IGNORE += "CVE-2014-4656"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-4667"
+
+# fixed-version: Fixed after version 3.16rc4
+CVE_CHECK_IGNORE += "CVE-2014-4699"
+
+# fixed-version: Fixed after version 3.16rc6
+CVE_CHECK_IGNORE += "CVE-2014-4943"
+
+# fixed-version: Fixed after version 3.16rc7
+CVE_CHECK_IGNORE += "CVE-2014-5045"
+
+# fixed-version: Fixed after version 3.16
+CVE_CHECK_IGNORE += "CVE-2014-5077"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-5206"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-5207"
+
+# Skipping CVE-2014-5332, no affected_versions
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-5471"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-5472"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6410"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6416"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6417"
+
+# fixed-version: Fixed after version 3.17rc5
+CVE_CHECK_IGNORE += "CVE-2014-6418"
+
+# fixed-version: Fixed after version 3.17rc2
+CVE_CHECK_IGNORE += "CVE-2014-7145"
+
+# Skipping CVE-2014-7207, no affected_versions
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-7283"
+
+# fixed-version: Fixed after version 3.15rc7
+CVE_CHECK_IGNORE += "CVE-2014-7284"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-7822"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-7825"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-7826"
+
+# fixed-version: Fixed after version 3.18rc5
+CVE_CHECK_IGNORE += "CVE-2014-7841"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7842"
+
+# fixed-version: Fixed after version 3.18rc5
+CVE_CHECK_IGNORE += "CVE-2014-7843"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7970"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-7975"
+
+# fixed-version: Fixed after version 3.18rc3
+CVE_CHECK_IGNORE += "CVE-2014-8086"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8133"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8134"
+
+# fixed-version: Fixed after version 4.0rc7
+CVE_CHECK_IGNORE += "CVE-2014-8159"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-8160"
+
+# fixed-version: Fixed after version 3.12rc1
+CVE_CHECK_IGNORE += "CVE-2014-8171"
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2014-8172"
+
+# fixed-version: Fixed after version 3.13rc5
+CVE_CHECK_IGNORE += "CVE-2014-8173"
+
+# Skipping CVE-2014-8181, no affected_versions
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8369"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8480"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-8481"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8559"
+
+# fixed-version: Fixed after version 3.14rc3
+CVE_CHECK_IGNORE += "CVE-2014-8709"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2014-8884"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-8989"
+
+# fixed-version: Fixed after version 3.18rc6
+CVE_CHECK_IGNORE += "CVE-2014-9090"
+
+# fixed-version: Fixed after version 3.18rc6
+CVE_CHECK_IGNORE += "CVE-2014-9322"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9419"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9420"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9428"
+
+# fixed-version: Fixed after version 3.19rc4
+CVE_CHECK_IGNORE += "CVE-2014-9529"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9584"
+
+# fixed-version: Fixed after version 3.19rc4
+CVE_CHECK_IGNORE += "CVE-2014-9585"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9644"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9683"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9710"
+
+# fixed-version: Fixed after version 3.15rc1
+CVE_CHECK_IGNORE += "CVE-2014-9715"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2014-9717"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9728"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9729"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9730"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2014-9731"
+
+# Skipping CVE-2014-9777, no affected_versions
+
+# Skipping CVE-2014-9778, no affected_versions
+
+# Skipping CVE-2014-9779, no affected_versions
+
+# Skipping CVE-2014-9780, no affected_versions
+
+# Skipping CVE-2014-9781, no affected_versions
+
+# Skipping CVE-2014-9782, no affected_versions
+
+# Skipping CVE-2014-9783, no affected_versions
+
+# Skipping CVE-2014-9784, no affected_versions
+
+# Skipping CVE-2014-9785, no affected_versions
+
+# Skipping CVE-2014-9786, no affected_versions
+
+# Skipping CVE-2014-9787, no affected_versions
+
+# Skipping CVE-2014-9788, no affected_versions
+
+# Skipping CVE-2014-9789, no affected_versions
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-9803"
+
+# Skipping CVE-2014-9863, no affected_versions
+
+# Skipping CVE-2014-9864, no affected_versions
+
+# Skipping CVE-2014-9865, no affected_versions
+
+# Skipping CVE-2014-9866, no affected_versions
+
+# Skipping CVE-2014-9867, no affected_versions
+
+# Skipping CVE-2014-9868, no affected_versions
+
+# Skipping CVE-2014-9869, no affected_versions
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2014-9870"
+
+# Skipping CVE-2014-9871, no affected_versions
+
+# Skipping CVE-2014-9872, no affected_versions
+
+# Skipping CVE-2014-9873, no affected_versions
+
+# Skipping CVE-2014-9874, no affected_versions
+
+# Skipping CVE-2014-9875, no affected_versions
+
+# Skipping CVE-2014-9876, no affected_versions
+
+# Skipping CVE-2014-9877, no affected_versions
+
+# Skipping CVE-2014-9878, no affected_versions
+
+# Skipping CVE-2014-9879, no affected_versions
+
+# Skipping CVE-2014-9880, no affected_versions
+
+# Skipping CVE-2014-9881, no affected_versions
+
+# Skipping CVE-2014-9882, no affected_versions
+
+# Skipping CVE-2014-9883, no affected_versions
+
+# Skipping CVE-2014-9884, no affected_versions
+
+# Skipping CVE-2014-9885, no affected_versions
+
+# Skipping CVE-2014-9886, no affected_versions
+
+# Skipping CVE-2014-9887, no affected_versions
+
+# fixed-version: Fixed after version 3.13rc1
+CVE_CHECK_IGNORE += "CVE-2014-9888"
+
+# Skipping CVE-2014-9889, no affected_versions
+
+# Skipping CVE-2014-9890, no affected_versions
+
+# Skipping CVE-2014-9891, no affected_versions
+
+# Skipping CVE-2014-9892, no affected_versions
+
+# Skipping CVE-2014-9893, no affected_versions
+
+# Skipping CVE-2014-9894, no affected_versions
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2014-9895"
+
+# Skipping CVE-2014-9896, no affected_versions
+
+# Skipping CVE-2014-9897, no affected_versions
+
+# Skipping CVE-2014-9898, no affected_versions
+
+# Skipping CVE-2014-9899, no affected_versions
+
+# Skipping CVE-2014-9900, no affected_versions
+
+# fixed-version: Fixed after version 3.14rc4
+CVE_CHECK_IGNORE += "CVE-2014-9903"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2014-9904"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2014-9914"
+
+# fixed-version: Fixed after version 3.18rc2
+CVE_CHECK_IGNORE += "CVE-2014-9922"
+
+# fixed-version: Fixed after version 3.19rc1
+CVE_CHECK_IGNORE += "CVE-2014-9940"
+
+# fixed-version: Fixed after version 3.19rc6
+CVE_CHECK_IGNORE += "CVE-2015-0239"
+
+# fixed-version: Fixed after version 3.15rc5
+CVE_CHECK_IGNORE += "CVE-2015-0274"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-0275"
+
+# Skipping CVE-2015-0777, no affected_versions
+
+# Skipping CVE-2015-1328, no affected_versions
+
+# fixed-version: Fixed after version 4.2rc5
+CVE_CHECK_IGNORE += "CVE-2015-1333"
+
+# fixed-version: Fixed after version 4.4rc5
+CVE_CHECK_IGNORE += "CVE-2015-1339"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2015-1350"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-1420"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-1421"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-1465"
+
+# fixed-version: Fixed after version 3.19rc5
+CVE_CHECK_IGNORE += "CVE-2015-1573"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-1593"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2015-1805"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-2041"
+
+# fixed-version: Fixed after version 3.19
+CVE_CHECK_IGNORE += "CVE-2015-2042"
+
+# fixed-version: Fixed after version 4.0rc4
+CVE_CHECK_IGNORE += "CVE-2015-2150"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-2666"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-2672"
+
+# fixed-version: Fixed after version 4.0rc6
+CVE_CHECK_IGNORE += "CVE-2015-2686"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-2830"
+
+# CVE-2015-2877 has no known resolution
+
+# fixed-version: Fixed after version 4.0rc7
+CVE_CHECK_IGNORE += "CVE-2015-2922"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-2925"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-3212"
+
+# fixed-version: Fixed after version 2.6.33rc8
+CVE_CHECK_IGNORE += "CVE-2015-3214"
+
+# fixed-version: Fixed after version 4.2rc2
+CVE_CHECK_IGNORE += "CVE-2015-3288"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-3290"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-3291"
+
+# fixed-version: Fixed after version 4.0rc5
+CVE_CHECK_IGNORE += "CVE-2015-3331"
+
+# Skipping CVE-2015-3332, no affected_versions
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-3339"
+
+# fixed-version: Fixed after version 4.1rc2
+CVE_CHECK_IGNORE += "CVE-2015-3636"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4001"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4002"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-4003"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-4004"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-4036"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-4167"
+
+# fixed-version: Fixed after version 3.13rc5
+CVE_CHECK_IGNORE += "CVE-2015-4170"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4176"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4177"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-4178"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-4692"
+
+# fixed-version: Fixed after version 4.1rc6
+CVE_CHECK_IGNORE += "CVE-2015-4700"
+
+# fixed-version: Fixed after version 4.2rc7
+CVE_CHECK_IGNORE += "CVE-2015-5156"
+
+# fixed-version: Fixed after version 4.2rc3
+CVE_CHECK_IGNORE += "CVE-2015-5157"
+
+# fixed-version: Fixed after version 4.3rc3
+CVE_CHECK_IGNORE += "CVE-2015-5257"
+
+# fixed-version: Fixed after version 4.3rc3
+CVE_CHECK_IGNORE += "CVE-2015-5283"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-5307"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-5327"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-5364"
+
+# fixed-version: Fixed after version 4.1rc7
+CVE_CHECK_IGNORE += "CVE-2015-5366"
+
+# fixed-version: Fixed after version 4.2rc6
+CVE_CHECK_IGNORE += "CVE-2015-5697"
+
+# fixed-version: Fixed after version 4.1rc3
+CVE_CHECK_IGNORE += "CVE-2015-5706"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-5707"
+
+# fixed-version: Fixed after version 4.2rc5
+CVE_CHECK_IGNORE += "CVE-2015-6252"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-6526"
+
+# CVE-2015-6619 has no known resolution
+
+# CVE-2015-6646 has no known resolution
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-6937"
+
+# Skipping CVE-2015-7312, no affected_versions
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2015-7509"
+
+# fixed-version: Fixed after version 4.4rc7
+CVE_CHECK_IGNORE += "CVE-2015-7513"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-7515"
+
+# fixed-version: Fixed after version 4.4rc8
+CVE_CHECK_IGNORE += "CVE-2015-7550"
+
+# Skipping CVE-2015-7553, no affected_versions
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2015-7566"
+
+# fixed-version: Fixed after version 4.3rc4
+CVE_CHECK_IGNORE += "CVE-2015-7613"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7799"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2015-7833"
+
+# Skipping CVE-2015-7837, no affected_versions
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2015-7872"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7884"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-7885"
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2015-7990"
+
+# Skipping CVE-2015-8019, no affected_versions
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8104"
+
+# fixed-version: Fixed after version 4.0rc3
+CVE_CHECK_IGNORE += "CVE-2015-8215"
+
+# fixed-version: Fixed after version 2.6.34rc1
+CVE_CHECK_IGNORE += "CVE-2015-8324"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8374"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8539"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8543"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8550"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8551"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8552"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8553"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8569"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8575"
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2015-8660"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2015-8709"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-8746"
+
+# fixed-version: Fixed after version 4.3rc4
+CVE_CHECK_IGNORE += "CVE-2015-8767"
+
+# fixed-version: Fixed after version 4.4rc5
+CVE_CHECK_IGNORE += "CVE-2015-8785"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8787"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8812"
+
+# fixed-version: Fixed after version 4.4rc6
+CVE_CHECK_IGNORE += "CVE-2015-8816"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-8830"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8839"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8844"
+
+# fixed-version: Fixed after version 4.4rc3
+CVE_CHECK_IGNORE += "CVE-2015-8845"
+
+# Skipping CVE-2015-8937, no affected_versions
+
+# Skipping CVE-2015-8938, no affected_versions
+
+# Skipping CVE-2015-8939, no affected_versions
+
+# Skipping CVE-2015-8940, no affected_versions
+
+# Skipping CVE-2015-8941, no affected_versions
+
+# Skipping CVE-2015-8942, no affected_versions
+
+# Skipping CVE-2015-8943, no affected_versions
+
+# Skipping CVE-2015-8944, no affected_versions
+
+# fixed-version: Fixed after version 4.1rc2
+CVE_CHECK_IGNORE += "CVE-2015-8950"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2015-8952"
+
+# fixed-version: Fixed after version 4.3
+CVE_CHECK_IGNORE += "CVE-2015-8953"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2015-8955"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-8956"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8961"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2015-8962"
+
+# fixed-version: Fixed after version 4.4
+CVE_CHECK_IGNORE += "CVE-2015-8963"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8964"
+
+# fixed-version: Fixed after version 4.4rc8
+CVE_CHECK_IGNORE += "CVE-2015-8966"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2015-8967"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2015-8970"
+
+# fixed-version: Fixed after version 3.19rc7
+CVE_CHECK_IGNORE += "CVE-2015-9004"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2015-9016"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2015-9289"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-0617"
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2016-0723"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-0728"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-0758"
+
+# Skipping CVE-2016-0774, no affected_versions
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2016-0821"
+
+# fixed-version: Fixed after version 4.0rc5
+CVE_CHECK_IGNORE += "CVE-2016-0823"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-10044"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10088"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-10147"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-10150"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10153"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10154"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-10200"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10208"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-10229"
+
+# fixed-version: Fixed after version 4.8rc6
+CVE_CHECK_IGNORE += "CVE-2016-10318"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2016-10723"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10741"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-10764"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-10905"
+
+# fixed-version: Fixed after version 4.5rc6
+CVE_CHECK_IGNORE += "CVE-2016-10906"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-10907"
+
+# fixed-version: Fixed after version 4.7rc5
+CVE_CHECK_IGNORE += "CVE-2016-1237"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-1575"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-1576"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-1583"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2016-2053"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2069"
+
+# fixed-version: Fixed after version 4.4
+CVE_CHECK_IGNORE += "CVE-2016-2070"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2085"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-2117"
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-2143"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2184"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2185"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-2186"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-2187"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2016-2188"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2383"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2384"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2543"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2544"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2545"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2546"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2547"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2548"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2549"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2016-2550"
+
+# fixed-version: Fixed after version 4.5rc2
+CVE_CHECK_IGNORE += "CVE-2016-2782"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2016-2847"
+
+# Skipping CVE-2016-2853, no affected_versions
+
+# Skipping CVE-2016-2854, no affected_versions
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-3044"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2016-3070"
+
+# fixed-version: Fixed after version 4.6rc2
+CVE_CHECK_IGNORE += "CVE-2016-3134"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3135"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3136"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3137"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3138"
+
+# fixed-version: Fixed after version 3.17rc1
+CVE_CHECK_IGNORE += "CVE-2016-3139"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3140"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3156"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3157"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3672"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-3689"
+
+# Skipping CVE-2016-3695, no affected_versions
+
+# Skipping CVE-2016-3699, no affected_versions
+
+# Skipping CVE-2016-3707, no affected_versions
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-3713"
+
+# CVE-2016-3775 has no known resolution
+
+# CVE-2016-3802 has no known resolution
+
+# CVE-2016-3803 has no known resolution
+
+# fixed-version: Fixed after version 4.4rc4
+CVE_CHECK_IGNORE += "CVE-2016-3841"
+
+# fixed-version: Fixed after version 4.8rc2
+CVE_CHECK_IGNORE += "CVE-2016-3857"
+
+# fixed-version: Fixed after version 4.5
+CVE_CHECK_IGNORE += "CVE-2016-3951"
+
+# fixed-version: Fixed after version 4.6rc3
+CVE_CHECK_IGNORE += "CVE-2016-3955"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-3961"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4440"
+
+# fixed-version: Fixed after version 4.7rc4
+CVE_CHECK_IGNORE += "CVE-2016-4470"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4482"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4485"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4486"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4557"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-4558"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4565"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-4568"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4569"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4578"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4580"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-4581"
+
+# fixed-version: Fixed after version 4.7rc4
+CVE_CHECK_IGNORE += "CVE-2016-4794"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-4805"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-4913"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4951"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4997"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-4998"
+
+# fixed-version: Fixed after version 4.9rc2
+CVE_CHECK_IGNORE += "CVE-2016-5195"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-5243"
+
+# fixed-version: Fixed after version 4.7rc3
+CVE_CHECK_IGNORE += "CVE-2016-5244"
+
+# Skipping CVE-2016-5340, no affected_versions
+
+# Skipping CVE-2016-5342, no affected_versions
+
+# Skipping CVE-2016-5343, no affected_versions
+
+# Skipping CVE-2016-5344, no affected_versions
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-5400"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-5412"
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-5696"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-5728"
+
+# fixed-version: Fixed after version 4.7rc6
+CVE_CHECK_IGNORE += "CVE-2016-5828"
+
+# fixed-version: Fixed after version 4.7rc5
+CVE_CHECK_IGNORE += "CVE-2016-5829"
+
+# CVE-2016-5870 has no known resolution
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2016-6130"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-6136"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-6156"
+
+# fixed-version: Fixed after version 4.7
+CVE_CHECK_IGNORE += "CVE-2016-6162"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-6187"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-6197"
+
+# fixed-version: Fixed after version 4.6
+CVE_CHECK_IGNORE += "CVE-2016-6198"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-6213"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-6327"
+
+# fixed-version: Fixed after version 4.8rc3
+CVE_CHECK_IGNORE += "CVE-2016-6480"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-6516"
+
+# Skipping CVE-2016-6753, no affected_versions
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2016-6786"
+
+# fixed-version: Fixed after version 4.0rc1
+CVE_CHECK_IGNORE += "CVE-2016-6787"
+
+# fixed-version: Fixed after version 4.8rc5
+CVE_CHECK_IGNORE += "CVE-2016-6828"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-7039"
+
+# fixed-version: Fixed after version 4.9rc3
+CVE_CHECK_IGNORE += "CVE-2016-7042"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-7097"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7117"
+
+# Skipping CVE-2016-7118, no affected_versions
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2016-7425"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2016-7910"
+
+# fixed-version: Fixed after version 4.7rc7
+CVE_CHECK_IGNORE += "CVE-2016-7911"
+
+# fixed-version: Fixed after version 4.6rc5
+CVE_CHECK_IGNORE += "CVE-2016-7912"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7913"
+
+# fixed-version: Fixed after version 4.6rc4
+CVE_CHECK_IGNORE += "CVE-2016-7914"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-7915"
+
+# fixed-version: Fixed after version 4.6rc7
+CVE_CHECK_IGNORE += "CVE-2016-7916"
+
+# fixed-version: Fixed after version 4.5rc6
+CVE_CHECK_IGNORE += "CVE-2016-7917"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-8399"
+
+# Skipping CVE-2016-8401, no affected_versions
+
+# Skipping CVE-2016-8402, no affected_versions
+
+# Skipping CVE-2016-8403, no affected_versions
+
+# Skipping CVE-2016-8404, no affected_versions
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2016-8405"
+
+# Skipping CVE-2016-8406, no affected_versions
+
+# Skipping CVE-2016-8407, no affected_versions
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-8630"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-8632"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-8633"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2016-8636"
+
+# fixed-version: Fixed after version 4.9rc6
+CVE_CHECK_IGNORE += "CVE-2016-8645"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2016-8646"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-8650"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-8655"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-8658"
+
+# CVE-2016-8660 has no known resolution
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-8666"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9083"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9084"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-9120"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2016-9178"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2016-9191"
+
+# fixed-version: Fixed after version 4.9rc3
+CVE_CHECK_IGNORE += "CVE-2016-9313"
+
+# fixed-version: Fixed after version 4.9rc4
+CVE_CHECK_IGNORE += "CVE-2016-9555"
+
+# fixed-version: Fixed after version 4.9
+CVE_CHECK_IGNORE += "CVE-2016-9576"
+
+# fixed-version: Fixed after version 4.10rc1
+CVE_CHECK_IGNORE += "CVE-2016-9588"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2016-9604"
+
+# Skipping CVE-2016-9644, no affected_versions
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2016-9685"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9754"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9755"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-9756"
+
+# fixed-version: Fixed after version 4.9rc7
+CVE_CHECK_IGNORE += "CVE-2016-9777"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9793"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9794"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2016-9806"
+
+# fixed-version: Fixed after version 4.9rc8
+CVE_CHECK_IGNORE += "CVE-2016-9919"
+
+# Skipping CVE-2017-0403, no affected_versions
+
+# Skipping CVE-2017-0404, no affected_versions
+
+# Skipping CVE-2017-0426, no affected_versions
+
+# Skipping CVE-2017-0427, no affected_versions
+
+# CVE-2017-0507 has no known resolution
+
+# CVE-2017-0508 has no known resolution
+
+# Skipping CVE-2017-0510, no affected_versions
+
+# Skipping CVE-2017-0528, no affected_versions
+
+# Skipping CVE-2017-0537, no affected_versions
+
+# CVE-2017-0564 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-0605"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-0627"
+
+# CVE-2017-0630 has no known resolution
+
+# CVE-2017-0749 has no known resolution
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2017-0750"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-0786"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-0861"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000111"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000112"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000251"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000252"
+
+# fixed-version: Fixed after version 4.1rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000253"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000255"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-1000363"
+
+# fixed-version: Fixed after version 4.12rc6
+CVE_CHECK_IGNORE += "CVE-2017-1000364"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-1000365"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000370"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-1000371"
+
+# fixed-version: Fixed after version 4.12rc6
+CVE_CHECK_IGNORE += "CVE-2017-1000379"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-1000380"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-1000405"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-1000407"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-1000410"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-10661"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-10662"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-10663"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-10810"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-10911"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-11089"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-11176"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-11472"
+
+# fixed-version: Fixed after version 4.13rc2
+CVE_CHECK_IGNORE += "CVE-2017-11473"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-11600"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-12134"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-12146"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2017-12153"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-12154"
+
+# fixed-version: Fixed after version 4.9rc6
+CVE_CHECK_IGNORE += "CVE-2017-12168"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-12188"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-12190"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-12192"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-12193"
+
+# fixed-version: Fixed after version 4.13rc4
+CVE_CHECK_IGNORE += "CVE-2017-12762"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-13080"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-13166"
+
+# fixed-version: Fixed after version 4.5rc4
+CVE_CHECK_IGNORE += "CVE-2017-13167"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2017-13168"
+
+# fixed-version: Fixed after version 4.5rc1
+CVE_CHECK_IGNORE += "CVE-2017-13215"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-13216"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2017-13220"
+
+# CVE-2017-13221 has no known resolution
+
+# CVE-2017-13222 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-13305"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-13686"
+
+# CVE-2017-13693 has no known resolution
+
+# CVE-2017-13694 has no known resolution
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2017-13695"
+
+# fixed-version: Fixed after version 4.3rc1
+CVE_CHECK_IGNORE += "CVE-2017-13715"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14051"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-14106"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-14140"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14156"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-14340"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-14489"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-14497"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-14954"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2017-14991"
+
+# fixed-version: Fixed after version 4.9rc1
+CVE_CHECK_IGNORE += "CVE-2017-15102"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15115"
+
+# fixed-version: Fixed after version 4.2rc1
+CVE_CHECK_IGNORE += "CVE-2017-15116"
+
+# fixed-version: Fixed after version 3.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-15121"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-15126"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2017-15127"
+
+# fixed-version: Fixed after version 4.14rc8
+CVE_CHECK_IGNORE += "CVE-2017-15128"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-15129"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-15265"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-15274"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15299"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-15306"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-15537"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-15649"
+
+# fixed-version: Fixed after version 3.19rc3
+CVE_CHECK_IGNORE += "CVE-2017-15868"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-15951"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16525"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16526"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16527"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2017-16528"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16529"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16530"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16531"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16532"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-16533"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2017-16534"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-16535"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16536"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16537"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-16538"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-16643"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-16644"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2017-16645"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16646"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16647"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16648"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16649"
+
+# fixed-version: Fixed after version 4.14
+CVE_CHECK_IGNORE += "CVE-2017-16650"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16911"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16912"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16913"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-16914"
+
+# fixed-version: Fixed after version 4.14rc7
+CVE_CHECK_IGNORE += "CVE-2017-16939"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-16994"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-16995"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-16996"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-17052"
+
+# fixed-version: Fixed after version 4.13rc7
+CVE_CHECK_IGNORE += "CVE-2017-17053"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17448"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17449"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17450"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17558"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17712"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17741"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17805"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-17806"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-17807"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17852"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17853"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17854"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17855"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17856"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17857"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-17862"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17863"
+
+# fixed-version: Fixed after version 4.15rc5
+CVE_CHECK_IGNORE += "CVE-2017-17864"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2017-17975"
+
+# fixed-version: Fixed after version 4.11rc7
+CVE_CHECK_IGNORE += "CVE-2017-18017"
+
+# fixed-version: Fixed after version 4.15rc7
+CVE_CHECK_IGNORE += "CVE-2017-18075"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18079"
+
+# CVE-2017-18169 has no known resolution
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2017-18174"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18193"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-18200"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-18202"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18203"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18204"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2017-18208"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18216"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18218"
+
+# fixed-version: Fixed after version 4.12rc4
+CVE_CHECK_IGNORE += "CVE-2017-18221"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-18222"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-18224"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-18232"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18241"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-18249"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18255"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18257"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2017-18261"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-18270"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2017-18344"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-18360"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2017-18379"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18509"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18549"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-18550"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2017-18551"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-18552"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2017-18595"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-2583"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-2584"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-2596"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-2618"
+
+# fixed-version: Fixed after version 2.6.25rc1
+CVE_CHECK_IGNORE += "CVE-2017-2634"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-2636"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2017-2647"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-2671"
+
+# fixed-version: Fixed after version 4.14rc5
+CVE_CHECK_IGNORE += "CVE-2017-5123"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5546"
+
+# fixed-version: Fixed after version 4.10rc5
+CVE_CHECK_IGNORE += "CVE-2017-5547"
+
+# fixed-version: Fixed after version 4.10rc5
+CVE_CHECK_IGNORE += "CVE-2017-5548"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5549"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5550"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-5551"
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2017-5576"
+
+# fixed-version: Fixed after version 4.10rc6
+CVE_CHECK_IGNORE += "CVE-2017-5577"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-5669"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-5715"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2017-5753"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-5754"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5897"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-5967"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5970"
+
+# fixed-version: Fixed after version 4.4rc1
+CVE_CHECK_IGNORE += "CVE-2017-5972"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-5986"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-6001"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6074"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-6214"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6345"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6346"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-6347"
+
+# fixed-version: Fixed after version 4.10
+CVE_CHECK_IGNORE += "CVE-2017-6348"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-6353"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-6874"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2017-6951"
+
+# fixed-version: Fixed after version 4.11rc5
+CVE_CHECK_IGNORE += "CVE-2017-7184"
+
+# fixed-version: Fixed after version 4.11rc5
+CVE_CHECK_IGNORE += "CVE-2017-7187"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7261"
+
+# fixed-version: Fixed after version 4.10rc4
+CVE_CHECK_IGNORE += "CVE-2017-7273"
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-7277"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7294"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7308"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-7346"
+
+# CVE-2017-7369 has no known resolution
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-7374"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7472"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7477"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-7482"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-7487"
+
+# fixed-version: Fixed after version 4.7rc1
+CVE_CHECK_IGNORE += "CVE-2017-7495"
+
+# fixed-version: Fixed after version 4.12rc7
+CVE_CHECK_IGNORE += "CVE-2017-7518"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-7533"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-7541"
+
+# fixed-version: Fixed after version 4.13rc2
+CVE_CHECK_IGNORE += "CVE-2017-7542"
+
+# fixed-version: Fixed after version 4.13
+CVE_CHECK_IGNORE += "CVE-2017-7558"
+
+# fixed-version: Fixed after version 4.11rc6
+CVE_CHECK_IGNORE += "CVE-2017-7616"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7618"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7645"
+
+# fixed-version: Fixed after version 4.11rc7
+CVE_CHECK_IGNORE += "CVE-2017-7889"
+
+# fixed-version: Fixed after version 4.11
+CVE_CHECK_IGNORE += "CVE-2017-7895"
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2017-7979"
+
+# fixed-version: Fixed after version 4.11rc4
+CVE_CHECK_IGNORE += "CVE-2017-8061"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8062"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8063"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8064"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8065"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8066"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2017-8067"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8068"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8069"
+
+# fixed-version: Fixed after version 4.10rc8
+CVE_CHECK_IGNORE += "CVE-2017-8070"
+
+# fixed-version: Fixed after version 4.10rc7
+CVE_CHECK_IGNORE += "CVE-2017-8071"
+
+# fixed-version: Fixed after version 4.10rc7
+CVE_CHECK_IGNORE += "CVE-2017-8072"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2017-8106"
+
+# fixed-version: Fixed after version 3.19rc6
+CVE_CHECK_IGNORE += "CVE-2017-8240"
+
+# CVE-2017-8242 has no known resolution
+
+# CVE-2017-8244 has no known resolution
+
+# CVE-2017-8245 has no known resolution
+
+# CVE-2017-8246 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-8797"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2017-8824"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-8831"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-8890"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8924"
+
+# fixed-version: Fixed after version 4.11rc2
+CVE_CHECK_IGNORE += "CVE-2017-8925"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-9059"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9074"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9075"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9076"
+
+# fixed-version: Fixed after version 4.12rc2
+CVE_CHECK_IGNORE += "CVE-2017-9077"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2017-9150"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-9211"
+
+# fixed-version: Fixed after version 4.12rc3
+CVE_CHECK_IGNORE += "CVE-2017-9242"
+
+# fixed-version: Fixed after version 4.12rc5
+CVE_CHECK_IGNORE += "CVE-2017-9605"
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2017-9725"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-9984"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2017-9985"
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2017-9986"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-1000004"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-1000026"
+
+# fixed-version: Fixed after version 4.15
+CVE_CHECK_IGNORE += "CVE-2018-1000028"
+
+# fixed-version: Fixed after version 4.16
+CVE_CHECK_IGNORE += "CVE-2018-1000199"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2018-1000200"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-1000204"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-10021"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-10074"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-10087"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-10124"
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-10322"
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-10323"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-1065"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-1066"
+
+# fixed-version: Fixed after version 4.13rc6
+CVE_CHECK_IGNORE += "CVE-2018-10675"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-1068"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-10840"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-10853"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-1087"
+
+# CVE-2018-10872 has no known resolution
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10876"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10877"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10878"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10879"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10880"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10881"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10882"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-10883"
+
+# fixed-version: Fixed after version 2.6.36rc1
+CVE_CHECK_IGNORE += "CVE-2018-10901"
+
+# fixed-version: Fixed after version 4.18rc6
+CVE_CHECK_IGNORE += "CVE-2018-10902"
+
+# fixed-version: Fixed after version 4.14rc2
+CVE_CHECK_IGNORE += "CVE-2018-1091"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1092"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1093"
+
+# fixed-version: Fixed after version 4.13rc5
+CVE_CHECK_IGNORE += "CVE-2018-10938"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1094"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-10940"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-1095"
+
+# fixed-version: Fixed after version 4.17rc2
+CVE_CHECK_IGNORE += "CVE-2018-1108"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-1118"
+
+# fixed-version: Fixed after version 4.17rc6
+CVE_CHECK_IGNORE += "CVE-2018-1120"
+
+# CVE-2018-1121 has no known resolution
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-11232"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-1128"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-1129"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-1130"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-11412"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-11506"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2018-11508"
+
+# CVE-2018-11987 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12126"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12127"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2018-12130"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2018-12207"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12232"
+
+# fixed-version: Fixed after version 4.18rc2
+CVE_CHECK_IGNORE += "CVE-2018-12233"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12633"
+
+# fixed-version: Fixed after version 4.18rc2
+CVE_CHECK_IGNORE += "CVE-2018-12714"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-12896"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-12904"
+
+# CVE-2018-12928 has no known resolution
+
+# CVE-2018-12929 has no known resolution
+
+# CVE-2018-12930 has no known resolution
+
+# CVE-2018-12931 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13053"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13093"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13094"
+
+# fixed-version: Fixed after version 4.18rc3
+CVE_CHECK_IGNORE += "CVE-2018-13095"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13096"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13097"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13098"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13099"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-13100"
+
+# fixed-version: Fixed after version 4.18rc4
+CVE_CHECK_IGNORE += "CVE-2018-13405"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-13406"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14609"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14610"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14611"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14612"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14613"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14614"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14615"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14616"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-14617"
+
+# fixed-version: Fixed after version 4.15rc4
+CVE_CHECK_IGNORE += "CVE-2018-14619"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-14625"
+
+# fixed-version: Fixed after version 4.19rc6
+CVE_CHECK_IGNORE += "CVE-2018-14633"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2018-14634"
+
+# fixed-version: Fixed after version 4.19rc4
+CVE_CHECK_IGNORE += "CVE-2018-14641"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-14646"
+
+# fixed-version: Fixed after version 4.19rc2
+CVE_CHECK_IGNORE += "CVE-2018-14656"
+
+# fixed-version: Fixed after version 4.18rc8
+CVE_CHECK_IGNORE += "CVE-2018-14678"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-14734"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-15471"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-15572"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-15594"
+
+# fixed-version: Fixed after version 4.18rc5
+CVE_CHECK_IGNORE += "CVE-2018-16276"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2018-16597"
+
+# fixed-version: Fixed after version 4.19rc2
+CVE_CHECK_IGNORE += "CVE-2018-16658"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-16862"
+
+# fixed-version: Fixed after version 4.20rc3
+CVE_CHECK_IGNORE += "CVE-2018-16871"
+
+# fixed-version: Fixed after version 5.0rc5
+CVE_CHECK_IGNORE += "CVE-2018-16880"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2018-16882"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-16884"
+
+# CVE-2018-16885 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc4
+CVE_CHECK_IGNORE += "CVE-2018-17182"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-17972"
+
+# CVE-2018-17977 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-18021"
+
+# fixed-version: Fixed after version 4.19
+CVE_CHECK_IGNORE += "CVE-2018-18281"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2018-18386"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-18397"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2018-18445"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-18559"
+
+# CVE-2018-18653 has no known resolution
+
+# fixed-version: Fixed after version 4.17rc4
+CVE_CHECK_IGNORE += "CVE-2018-18690"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-18710"
+
+# fixed-version: Fixed after version 4.20rc2
+CVE_CHECK_IGNORE += "CVE-2018-18955"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-19406"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2018-19407"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-19824"
+
+# fixed-version: Fixed after version 4.20rc3
+CVE_CHECK_IGNORE += "CVE-2018-19854"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2018-19985"
+
+# fixed-version: Fixed after version 4.20rc6
+CVE_CHECK_IGNORE += "CVE-2018-20169"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-20449"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2018-20509"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-20510"
+
+# fixed-version: Fixed after version 4.19rc5
+CVE_CHECK_IGNORE += "CVE-2018-20511"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-20669"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2018-20784"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-20836"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2018-20854"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-20855"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-20856"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-20961"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-20976"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2018-21008"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-25015"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-25020"
+
+# CVE-2018-3574 has no known resolution
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3620"
+
+# fixed-version: Fixed after version 4.17rc7
+CVE_CHECK_IGNORE += "CVE-2018-3639"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3646"
+
+# fixed-version: Fixed after version 3.7rc1
+CVE_CHECK_IGNORE += "CVE-2018-3665"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-3693"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5332"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5333"
+
+# fixed-version: Fixed after version 4.15rc8
+CVE_CHECK_IGNORE += "CVE-2018-5344"
+
+# fixed-version: Fixed after version 4.18rc7
+CVE_CHECK_IGNORE += "CVE-2018-5390"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-5391"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-5703"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5750"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5803"
+
+# fixed-version: Fixed after version 4.17rc6
+CVE_CHECK_IGNORE += "CVE-2018-5814"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-5848"
+
+# Skipping CVE-2018-5856, no affected_versions
+
+# fixed-version: Fixed after version 4.11rc8
+CVE_CHECK_IGNORE += "CVE-2018-5873"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-5953"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-5995"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-6412"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-6554"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2018-6555"
+
+# CVE-2018-6559 has no known resolution
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2018-6927"
+
+# fixed-version: Fixed after version 4.14rc6
+CVE_CHECK_IGNORE += "CVE-2018-7191"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-7273"
+
+# fixed-version: Fixed after version 4.11rc1
+CVE_CHECK_IGNORE += "CVE-2018-7480"
+
+# fixed-version: Fixed after version 4.15rc3
+CVE_CHECK_IGNORE += "CVE-2018-7492"
+
+# fixed-version: Fixed after version 4.16rc2
+CVE_CHECK_IGNORE += "CVE-2018-7566"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-7740"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2018-7754"
+
+# fixed-version: Fixed after version 4.19rc5
+CVE_CHECK_IGNORE += "CVE-2018-7755"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-7757"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2018-7995"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-8043"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2018-8087"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8781"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8822"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2018-8897"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2018-9363"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-9385"
+
+# fixed-version: Fixed after version 4.17rc3
+CVE_CHECK_IGNORE += "CVE-2018-9415"
+
+# fixed-version: Fixed after version 4.6rc1
+CVE_CHECK_IGNORE += "CVE-2018-9422"
+
+# fixed-version: Fixed after version 4.15rc6
+CVE_CHECK_IGNORE += "CVE-2018-9465"
+
+# fixed-version: Fixed after version 4.18rc5
+CVE_CHECK_IGNORE += "CVE-2018-9516"
+
+# fixed-version: Fixed after version 4.14rc1
+CVE_CHECK_IGNORE += "CVE-2018-9517"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2018-9518"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2018-9568"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-0136"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0145"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0146"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0147"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-0148"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-0149"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-0154"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-0155"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-10124"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-10125"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-10126"
+
+# CVE-2019-10140 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-10142"
+
+# fixed-version: Fixed after version 5.3rc3
+CVE_CHECK_IGNORE += "CVE-2019-10207"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-10220"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-10638"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-10639"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-11085"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11091"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-11135"
+
+# fixed-version: Fixed after version 4.8rc5
+CVE_CHECK_IGNORE += "CVE-2019-11190"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11191"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-1125"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11477"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11478"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-11479"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-11486"
+
+# fixed-version: Fixed after version 5.1rc5
+CVE_CHECK_IGNORE += "CVE-2019-11487"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-11599"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-11683"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11810"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-11811"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-11815"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11833"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-11884"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12378"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12379"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12380"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-12381"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12382"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12454"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12455"
+
+# CVE-2019-12456 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-12614"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-12615"
+
+# fixed-version: Fixed after version 5.2rc7
+CVE_CHECK_IGNORE += "CVE-2019-12817"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-12818"
+
+# fixed-version: Fixed after version 5.0rc8
+CVE_CHECK_IGNORE += "CVE-2019-12819"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2019-12881"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-12984"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-13233"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-13272"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-13631"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-13648"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-14283"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-14284"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2019-14615"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2019-14763"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14814"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14815"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14816"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-14821"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-14835"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-14895"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2019-14896"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2019-14897"
+
+# CVE-2019-14898 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-14901"
+
+# fixed-version: Fixed after version 5.3rc8
+CVE_CHECK_IGNORE += "CVE-2019-15030"
+
+# fixed-version: Fixed after version 5.3rc8
+CVE_CHECK_IGNORE += "CVE-2019-15031"
+
+# fixed-version: Fixed after version 5.2rc2
+CVE_CHECK_IGNORE += "CVE-2019-15090"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-15098"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-15099"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-15117"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-15118"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15211"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15212"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15213"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15214"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15215"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-15216"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15217"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15218"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15219"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15220"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-15221"
+
+# fixed-version: Fixed after version 5.3rc3
+CVE_CHECK_IGNORE += "CVE-2019-15222"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15223"
+
+# CVE-2019-15239 has no known resolution
+
+# CVE-2019-15290 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-15291"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15292"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-15504"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-15505"
+
+# fixed-version: Fixed after version 5.3rc6
+CVE_CHECK_IGNORE += "CVE-2019-15538"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-15666"
+
+# CVE-2019-15791 has no known resolution
+
+# CVE-2019-15792 has no known resolution
+
+# CVE-2019-15793 has no known resolution
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2019-15794"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2019-15807"
+
+# CVE-2019-15902 has no known resolution
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15916"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-15917"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15918"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15919"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-15920"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-15921"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15922"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15923"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-15924"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15925"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-15926"
+
+# fixed-version: Fixed after version 5.0rc2
+CVE_CHECK_IGNORE += "CVE-2019-15927"
+
+# CVE-2019-16089 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16229"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16230"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-16231"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-16232"
+
+# fixed-version: Fixed after version 5.4rc5
+CVE_CHECK_IGNORE += "CVE-2019-16233"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-16234"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-16413"
+
+# fixed-version: Fixed after version 5.3rc7
+CVE_CHECK_IGNORE += "CVE-2019-16714"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-16746"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2019-16921"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-16994"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-16995"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17052"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17053"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17054"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17055"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-17056"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-17075"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-17133"
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-17351"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-17666"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-18198"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-18282"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18660"
+
+# fixed-version: Fixed after version 4.17rc5
+CVE_CHECK_IGNORE += "CVE-2019-18675"
+
+# CVE-2019-18680 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18683"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18786"
+
+# fixed-version: Fixed after version 5.1rc7
+CVE_CHECK_IGNORE += "CVE-2019-18805"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18806"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18807"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18808"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-18809"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-18810"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-18811"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-18812"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-18813"
+
+# fixed-version: Fixed after version 5.7rc7
+CVE_CHECK_IGNORE += "CVE-2019-18814"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-18885"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19036"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-19037"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2019-19039"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19043"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19044"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19045"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19046"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19047"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19048"
+
+# fixed-version: Fixed after version 5.4rc5
+CVE_CHECK_IGNORE += "CVE-2019-19049"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19050"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19051"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19052"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19053"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19054"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19055"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19056"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19057"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19058"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19059"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19060"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19061"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19062"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19063"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19064"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19065"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19066"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19067"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19068"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19069"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19070"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19071"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19072"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19073"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19074"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19075"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19076"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19077"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19078"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-19079"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19080"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19081"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19082"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19083"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-19227"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19241"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19252"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19318"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19319"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19332"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19338"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2019-19377"
+
+# CVE-2019-19378 has no known resolution
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19447"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2019-19448"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2019-19449"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2019-19462"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19523"
+
+# fixed-version: Fixed after version 5.4rc8
+CVE_CHECK_IGNORE += "CVE-2019-19524"
+
+# fixed-version: Fixed after version 5.4rc2
+CVE_CHECK_IGNORE += "CVE-2019-19525"
+
+# fixed-version: Fixed after version 5.4rc4
+CVE_CHECK_IGNORE += "CVE-2019-19526"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19527"
+
+# fixed-version: Fixed after version 5.4rc3
+CVE_CHECK_IGNORE += "CVE-2019-19528"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19529"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-19530"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19531"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2019-19532"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19533"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19534"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19535"
+
+# fixed-version: Fixed after version 5.3rc4
+CVE_CHECK_IGNORE += "CVE-2019-19536"
+
+# fixed-version: Fixed after version 5.3rc5
+CVE_CHECK_IGNORE += "CVE-2019-19537"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19543"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19602"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2019-19767"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2019-19768"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2019-19769"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2019-19770"
+
+# fixed-version: Fixed after version 5.4rc7
+CVE_CHECK_IGNORE += "CVE-2019-19807"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19813"
+
+# CVE-2019-19814 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2019-19815"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19816"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-19922"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-19927"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-19947"
+
+# fixed-version: Fixed after version 5.5rc2
+CVE_CHECK_IGNORE += "CVE-2019-19965"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-19966"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-1999"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-20054"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-20095"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-20096"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2019-2024"
+
+# fixed-version: Fixed after version 4.20rc5
+CVE_CHECK_IGNORE += "CVE-2019-2025"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-20422"
+
+# fixed-version: Fixed after version 4.8rc1
+CVE_CHECK_IGNORE += "CVE-2019-2054"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2019-20636"
+
+# CVE-2019-20794 has no known resolution
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-20806"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2019-20810"
+
+# fixed-version: Fixed after version 5.1rc3
+CVE_CHECK_IGNORE += "CVE-2019-20811"
+
+# fixed-version: Fixed after version 5.5rc3
+CVE_CHECK_IGNORE += "CVE-2019-20812"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2019-20908"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-20934"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-2101"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-2181"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2019-2182"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-2213"
+
+# fixed-version: Fixed after version 5.3rc2
+CVE_CHECK_IGNORE += "CVE-2019-2214"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2019-2215"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-25044"
+
+# fixed-version: Fixed after version 5.1
+CVE_CHECK_IGNORE += "CVE-2019-25045"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2019-3016"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-3459"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-3460"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-3701"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-3819"
+
+# fixed-version: Fixed after version 3.18rc1
+CVE_CHECK_IGNORE += "CVE-2019-3837"
+
+# fixed-version: Fixed after version 5.2rc6
+CVE_CHECK_IGNORE += "CVE-2019-3846"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-3874"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-3882"
+
+# fixed-version: Fixed after version 5.1rc4
+CVE_CHECK_IGNORE += "CVE-2019-3887"
+
+# fixed-version: Fixed after version 5.1rc6
+CVE_CHECK_IGNORE += "CVE-2019-3892"
+
+# fixed-version: Fixed after version 2.6.35rc1
+CVE_CHECK_IGNORE += "CVE-2019-3896"
+
+# fixed-version: Fixed after version 5.2rc4
+CVE_CHECK_IGNORE += "CVE-2019-3900"
+
+# fixed-version: Fixed after version 4.6rc6
+CVE_CHECK_IGNORE += "CVE-2019-3901"
+
+# fixed-version: Fixed after version 5.3
+CVE_CHECK_IGNORE += "CVE-2019-5108"
+
+# Skipping CVE-2019-5489, no affected_versions
+
+# fixed-version: Fixed after version 5.0rc2
+CVE_CHECK_IGNORE += "CVE-2019-6133"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-6974"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-7221"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-7222"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2019-7308"
+
+# fixed-version: Fixed after version 5.0rc8
+CVE_CHECK_IGNORE += "CVE-2019-8912"
+
+# fixed-version: Fixed after version 5.0rc6
+CVE_CHECK_IGNORE += "CVE-2019-8956"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-8980"
+
+# fixed-version: Fixed after version 5.0rc4
+CVE_CHECK_IGNORE += "CVE-2019-9003"
+
+# fixed-version: Fixed after version 5.0rc7
+CVE_CHECK_IGNORE += "CVE-2019-9162"
+
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-9213"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-9245"
+
+# fixed-version: Fixed after version 4.15rc2
+CVE_CHECK_IGNORE += "CVE-2019-9444"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9445"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2019-9453"
+
+# fixed-version: Fixed after version 4.15rc9
+CVE_CHECK_IGNORE += "CVE-2019-9454"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-9455"
+
+# fixed-version: Fixed after version 4.16rc6
+CVE_CHECK_IGNORE += "CVE-2019-9456"
+
+# fixed-version: Fixed after version 4.13rc1
+CVE_CHECK_IGNORE += "CVE-2019-9457"
+
+# fixed-version: Fixed after version 4.19rc7
+CVE_CHECK_IGNORE += "CVE-2019-9458"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9466"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9500"
+
+# fixed-version: Fixed after version 5.1rc1
+CVE_CHECK_IGNORE += "CVE-2019-9503"
+
+# fixed-version: Fixed after version 5.2
+CVE_CHECK_IGNORE += "CVE-2019-9506"
+
+# fixed-version: Fixed after version 5.1rc2
+CVE_CHECK_IGNORE += "CVE-2019-9857"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-0009"
+
+# fixed-version: Fixed after version 4.16rc3
+CVE_CHECK_IGNORE += "CVE-2020-0030"
+
+# fixed-version: Fixed after version 5.5rc2
+CVE_CHECK_IGNORE += "CVE-2020-0041"
+
+# fixed-version: Fixed after version 4.3rc7
+CVE_CHECK_IGNORE += "CVE-2020-0066"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-0067"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-0110"
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-0255"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-0305"
+
+# CVE-2020-0347 has no known resolution
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-0404"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-0423"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-0427"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2020-0429"
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2020-0430"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-0431"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-0432"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2020-0433"
+
+# fixed-version: Fixed after version 4.19rc1
+CVE_CHECK_IGNORE += "CVE-2020-0435"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-0444"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-0465"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-0466"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-0543"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10135"
+
+# fixed-version: Fixed after version 5.5rc5
+CVE_CHECK_IGNORE += "CVE-2020-10690"
+
+# CVE-2020-10708 has no known resolution
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-10711"
+
+# fixed-version: Fixed after version 5.2rc3
+CVE_CHECK_IGNORE += "CVE-2020-10720"
+
+# fixed-version: Fixed after version 5.7
+CVE_CHECK_IGNORE += "CVE-2020-10732"
+
+# fixed-version: Fixed after version 3.16rc1
+CVE_CHECK_IGNORE += "CVE-2020-10742"
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-10751"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10757"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10766"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10767"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-10768"
+
+# fixed-version: Fixed after version 5.0rc3
+CVE_CHECK_IGNORE += "CVE-2020-10769"
+
+# fixed-version: Fixed after version 5.4rc6
+CVE_CHECK_IGNORE += "CVE-2020-10773"
+
+# CVE-2020-10774 has no known resolution
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2020-10781"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-10942"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11494"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11565"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11608"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11609"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-11668"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2020-11669"
+
+# CVE-2020-11725 has no known resolution
+
+# fixed-version: Fixed after version 5.7rc4
+CVE_CHECK_IGNORE += "CVE-2020-11884"
+
+# CVE-2020-11935 has no known resolution
+
+# fixed-version: Fixed after version 5.3rc1
+CVE_CHECK_IGNORE += "CVE-2020-12114"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-12351"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-12352"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12362"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12363"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-12364"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-12464"
+
+# fixed-version: Fixed after version 5.6rc6
+CVE_CHECK_IGNORE += "CVE-2020-12465"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2020-12652"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-12653"
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2020-12654"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12655"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-12656"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12657"
+
+# fixed-version: Fixed after version 5.7rc2
+CVE_CHECK_IGNORE += "CVE-2020-12659"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-12768"
+
+# fixed-version: Fixed after version 5.5rc6
+CVE_CHECK_IGNORE += "CVE-2020-12769"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-12770"
+
+# fixed-version: Fixed after version 5.8rc2
+CVE_CHECK_IGNORE += "CVE-2020-12771"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-12826"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-12888"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2020-12912"
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-13143"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-13974"
+
+# CVE-2020-14304 has no known resolution
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-14305"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-14314"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-14331"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-14351"
+
+# fixed-version: Fixed after version 4.14rc3
+CVE_CHECK_IGNORE += "CVE-2020-14353"
+
+# fixed-version: Fixed after version 5.8rc5
+CVE_CHECK_IGNORE += "CVE-2020-14356"
+
+# fixed-version: Fixed after version 5.6rc6
+CVE_CHECK_IGNORE += "CVE-2020-14381"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-14385"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-14386"
+
+# fixed-version: Fixed after version 5.9rc6
+CVE_CHECK_IGNORE += "CVE-2020-14390"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2020-14416"
+
+# fixed-version: Fixed after version 5.8rc3
+CVE_CHECK_IGNORE += "CVE-2020-15393"
+
+# fixed-version: Fixed after version 5.8rc2
+CVE_CHECK_IGNORE += "CVE-2020-15436"
+
+# fixed-version: Fixed after version 5.8rc7
+CVE_CHECK_IGNORE += "CVE-2020-15437"
+
+# fixed-version: Fixed after version 5.8rc3
+CVE_CHECK_IGNORE += "CVE-2020-15780"
+
+# CVE-2020-15802 has no known resolution
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2020-15852"
+
+# fixed-version: Fixed after version 5.15rc2
+CVE_CHECK_IGNORE += "CVE-2020-16119"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-16120"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2020-16166"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2020-1749"
+
+# fixed-version: Fixed after version 5.8rc4
+CVE_CHECK_IGNORE += "CVE-2020-24394"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2020-24490"
+
+# CVE-2020-24502 has no known resolution
+
+# CVE-2020-24503 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-24504"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24586"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24587"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-24588"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25211"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-25212"
+
+# CVE-2020-25220 has no known resolution
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25221"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-25284"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25285"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-25639"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2020-25641"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25643"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2020-25645"
+
+# fixed-version: Fixed after version 5.10rc2
+CVE_CHECK_IGNORE += "CVE-2020-25656"
+
+# CVE-2020-25661 has no known resolution
+
+# CVE-2020-25662 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-25668"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-25669"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25670"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25671"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25672"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2020-25673"
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-25704"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-25705"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-26088"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26139"
+
+# CVE-2020-26140 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26141"
+
+# CVE-2020-26142 has no known resolution
+
+# CVE-2020-26143 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26145"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2020-26147"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26541"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26555"
+
+# CVE-2020-26556 has no known resolution
+
+# CVE-2020-26557 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-26558"
+
+# CVE-2020-26559 has no known resolution
+
+# CVE-2020-26560 has no known resolution
+
+# fixed-version: Fixed after version 5.6
+CVE_CHECK_IGNORE += "CVE-2020-27066"
+
+# fixed-version: Fixed after version 4.14rc4
+CVE_CHECK_IGNORE += "CVE-2020-27067"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-27068"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27152"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2020-27170"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2020-27171"
+
+# fixed-version: Fixed after version 5.9
+CVE_CHECK_IGNORE += "CVE-2020-27194"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-2732"
+
+# CVE-2020-27418 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27673"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27675"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27777"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27784"
+
+# fixed-version: Fixed after version 5.7rc6
+CVE_CHECK_IGNORE += "CVE-2020-27786"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-27815"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2020-27820"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-27825"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-27830"
+
+# fixed-version: Fixed after version 5.10rc6
+CVE_CHECK_IGNORE += "CVE-2020-27835"
+
+# fixed-version: Fixed after version 5.9rc6
+CVE_CHECK_IGNORE += "CVE-2020-28097"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2020-28374"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-28588"
+
+# fixed-version: Fixed after version 5.9
+CVE_CHECK_IGNORE += "CVE-2020-28915"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-28941"
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-28974"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-29368"
+
+# fixed-version: Fixed after version 5.8rc7
+CVE_CHECK_IGNORE += "CVE-2020-29369"
+
+# fixed-version: Fixed after version 5.6rc7
+CVE_CHECK_IGNORE += "CVE-2020-29370"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2020-29371"
+
+# fixed-version: Fixed after version 5.7rc3
+CVE_CHECK_IGNORE += "CVE-2020-29372"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-29373"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-29374"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-29534"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-29568"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-29569"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-29660"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-29661"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-35499"
+
+# CVE-2020-35501 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc3
+CVE_CHECK_IGNORE += "CVE-2020-35508"
+
+# fixed-version: Fixed after version 4.17rc1
+CVE_CHECK_IGNORE += "CVE-2020-35513"
+
+# fixed-version: Fixed after version 5.10rc7
+CVE_CHECK_IGNORE += "CVE-2020-35519"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-36158"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-36310"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-36311"
+
+# fixed-version: Fixed after version 5.9rc5
+CVE_CHECK_IGNORE += "CVE-2020-36312"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36313"
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2020-36322"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2020-36385"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-36386"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2020-36387"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2020-36516"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36557"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-36558"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2020-36691"
+
+# fixed-version: Fixed after version 5.10
+CVE_CHECK_IGNORE += "CVE-2020-36694"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2020-3702"
+
+# fixed-version: Fixed after version 5.10rc5
+CVE_CHECK_IGNORE += "CVE-2020-4788"
+
+# fixed-version: Fixed after version 5.2rc1
+CVE_CHECK_IGNORE += "CVE-2020-7053"
+
+# fixed-version: Fixed after version 5.5
+CVE_CHECK_IGNORE += "CVE-2020-8428"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2020-8647"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-8648"
+
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2020-8649"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2020-8694"
+
+# CVE-2020-8832 has no known resolution
+
+# fixed-version: Fixed after version 4.18rc1
+CVE_CHECK_IGNORE += "CVE-2020-8834"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-8835"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2020-8992"
+
+# fixed-version: Fixed after version 5.6rc4
+CVE_CHECK_IGNORE += "CVE-2020-9383"
+
+# fixed-version: Fixed after version 5.6rc3
+CVE_CHECK_IGNORE += "CVE-2020-9391"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-0129"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2021-0342"
+
+# CVE-2021-0399 has no known resolution
+
+# fixed-version: Fixed after version 4.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-0447"
+
+# fixed-version: Fixed after version 5.9rc7
+CVE_CHECK_IGNORE += "CVE-2021-0448"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-0512"
+
+# fixed-version: Fixed after version 5.8
+CVE_CHECK_IGNORE += "CVE-2021-0605"
+
+# CVE-2021-0606 has no known resolution
+
+# CVE-2021-0695 has no known resolution
+
+# fixed-version: Fixed after version 5.11rc3
+CVE_CHECK_IGNORE += "CVE-2021-0707"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-0920"
+
+# CVE-2021-0924 has no known resolution
+
+# fixed-version: Fixed after version 5.6rc1
+CVE_CHECK_IGNORE += "CVE-2021-0929"
+
+# fixed-version: Fixed after version 4.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-0935"
+
+# CVE-2021-0936 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-0937"
+
+# fixed-version: Fixed after version 5.10rc4
+CVE_CHECK_IGNORE += "CVE-2021-0938"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-0941"
+
+# CVE-2021-0961 has no known resolution
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2021-1048"
+
+# fixed-version: Fixed after version 5.5rc1
+CVE_CHECK_IGNORE += "CVE-2021-20177"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2021-20194"
+
+# CVE-2021-20219 has no known resolution
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2021-20226"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2021-20239"
+
+# fixed-version: Fixed after version 4.5rc5
+CVE_CHECK_IGNORE += "CVE-2021-20261"
+
+# fixed-version: Fixed after version 4.5rc3
+CVE_CHECK_IGNORE += "CVE-2021-20265"
+
+# fixed-version: Fixed after version 5.11rc5
+CVE_CHECK_IGNORE += "CVE-2021-20268"
+
+# fixed-version: Fixed after version 5.9rc1
+CVE_CHECK_IGNORE += "CVE-2021-20292"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2021-20317"
+
+# fixed-version: Fixed after version 5.15rc3
+CVE_CHECK_IGNORE += "CVE-2021-20320"
+
+# fixed-version: Fixed after version 5.15rc5
+CVE_CHECK_IGNORE += "CVE-2021-20321"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-20322"
+
+# fixed-version: Fixed after version 5.11rc7
+CVE_CHECK_IGNORE += "CVE-2021-21781"
+
+# fixed-version: Fixed after version 5.13
+CVE_CHECK_IGNORE += "CVE-2021-22543"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-22555"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2021-22600"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-23133"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-23134"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2021-26401"
+
+# fixed-version: Fixed after version 5.11rc7
+CVE_CHECK_IGNORE += "CVE-2021-26708"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26930"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26931"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-26932"
+
+# CVE-2021-26934 has no known resolution
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27363"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27364"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-27365"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28038"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28039"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-28375"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-28660"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-28688"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-28691"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-28711"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-28712"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-28713"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-28714"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-28715"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28950"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-28951"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28952"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28964"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28971"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-28972"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-29154"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-29155"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-29264"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-29265"
+
+# fixed-version: Fixed after version 5.12rc4
+CVE_CHECK_IGNORE += "CVE-2021-29266"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29646"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29647"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29648"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29649"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-29650"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-29657"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-30002"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2021-30178"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-31440"
+
+# fixed-version: Fixed after version 5.11rc5
+CVE_CHECK_IGNORE += "CVE-2021-3178"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-31829"
+
+# fixed-version: Fixed after version 5.12rc5
+CVE_CHECK_IGNORE += "CVE-2021-31916"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-32078"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-32399"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-32606"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-33033"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-33034"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2021-33061"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-33098"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2021-33135"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-33200"
+
+# fixed-version: Fixed after version 5.11rc6
+CVE_CHECK_IGNORE += "CVE-2021-3347"
+
+# fixed-version: Fixed after version 5.11rc6
+CVE_CHECK_IGNORE += "CVE-2021-3348"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-33624"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2021-33655"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-33656"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-33909"
+
+# fixed-version: Fixed after version 5.10
+CVE_CHECK_IGNORE += "CVE-2021-3411"
+
+# fixed-version: Fixed after version 5.9rc2
+CVE_CHECK_IGNORE += "CVE-2021-3428"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-3444"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-34556"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-34693"
+
+# fixed-version: Fixed after version 5.12rc6
+CVE_CHECK_IGNORE += "CVE-2021-3483"
+
+# fixed-version: Fixed after version 5.14
+CVE_CHECK_IGNORE += "CVE-2021-34866"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-3489"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-3490"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3491"
+
+# CVE-2021-3492 has no known resolution
+
+# fixed-version: Fixed after version 5.11rc1
+CVE_CHECK_IGNORE += "CVE-2021-3493"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-34981"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-3501"
+
+# fixed-version: Fixed after version 5.13
+CVE_CHECK_IGNORE += "CVE-2021-35039"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3506"
+
+# CVE-2021-3542 has no known resolution
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-3543"
+
+# fixed-version: Fixed after version 5.14rc4
+CVE_CHECK_IGNORE += "CVE-2021-35477"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3564"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3573"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-3587"
+
+# fixed-version: Fixed after version 5.11
+CVE_CHECK_IGNORE += "CVE-2021-3600"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-3609"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-3612"
+
+# fixed-version: Fixed after version 5.5rc7
+CVE_CHECK_IGNORE += "CVE-2021-3635"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-3640"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-3653"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-3655"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-3656"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-3659"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3669"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-3679"
+
+# CVE-2021-3714 has no known resolution
+
+# fixed-version: Fixed after version 5.6
+CVE_CHECK_IGNORE += "CVE-2021-3715"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-37159"
+
+# fixed-version: Fixed after version 5.14rc6
+CVE_CHECK_IGNORE += "CVE-2021-3732"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3736"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3739"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-3743"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-3744"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-3752"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3753"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-37576"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-3759"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3760"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-3764"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-3772"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38160"
+
+# fixed-version: Fixed after version 5.14rc6
+CVE_CHECK_IGNORE += "CVE-2021-38166"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-38198"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38199"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38200"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38201"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38202"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2021-38203"
+
+# fixed-version: Fixed after version 5.14rc3
+CVE_CHECK_IGNORE += "CVE-2021-38204"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-38205"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38206"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-38207"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-38208"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-38209"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-38300"
+
+# CVE-2021-3847 has no known resolution
+
+# CVE-2021-3864 has no known resolution
+
+# CVE-2021-3892 has no known resolution
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3894"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-3896"
+
+# fixed-version: Fixed after version 5.16
+CVE_CHECK_IGNORE += "CVE-2021-3923"
+
+# fixed-version: Fixed after version 5.14
+CVE_CHECK_IGNORE += "CVE-2021-39633"
+
+# fixed-version: Fixed after version 5.9rc8
+CVE_CHECK_IGNORE += "CVE-2021-39634"
+
+# fixed-version: Fixed after version 4.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-39636"
+
+# fixed-version: Fixed after version 5.11rc3
+CVE_CHECK_IGNORE += "CVE-2021-39648"
+
+# fixed-version: Fixed after version 5.12rc3
+CVE_CHECK_IGNORE += "CVE-2021-39656"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2021-39657"
+
+# fixed-version: Fixed after version 5.16rc5
+CVE_CHECK_IGNORE += "CVE-2021-39685"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-39686"
+
+# fixed-version: Fixed after version 5.16rc5
+CVE_CHECK_IGNORE += "CVE-2021-39698"
+
+# fixed-version: Fixed after version 4.18rc6
+CVE_CHECK_IGNORE += "CVE-2021-39711"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2021-39713"
+
+# fixed-version: Fixed after version 4.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-39714"
+
+# CVE-2021-39800 has no known resolution
+
+# CVE-2021-39801 has no known resolution
+
+# CVE-2021-39802 has no known resolution
+
+# fixed-version: Fixed after version 5.16rc2
+CVE_CHECK_IGNORE += "CVE-2021-4001"
+
+# fixed-version: Fixed after version 5.16rc3
+CVE_CHECK_IGNORE += "CVE-2021-4002"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-4023"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-4028"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4032"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2021-4037"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-40490"
+
+# fixed-version: Fixed after version 5.16rc4
+CVE_CHECK_IGNORE += "CVE-2021-4083"
+
+# fixed-version: Fixed after version 5.16rc2
+CVE_CHECK_IGNORE += "CVE-2021-4090"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4093"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2021-4095"
+
+# fixed-version: Fixed after version 5.15rc2
+CVE_CHECK_IGNORE += "CVE-2021-41073"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2021-4135"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-4148"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-4149"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2021-4150"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2021-4154"
+
+# fixed-version: Fixed after version 5.16
+CVE_CHECK_IGNORE += "CVE-2021-4155"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-4157"
+
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2021-4159"
+
+# fixed-version: Fixed after version 5.15rc5
+CVE_CHECK_IGNORE += "CVE-2021-41864"
+
+# fixed-version: Fixed after version 5.16
+CVE_CHECK_IGNORE += "CVE-2021-4197"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2021-42008"
+
+# fixed-version: Fixed after version 5.16rc2
+CVE_CHECK_IGNORE += "CVE-2021-4202"
+
+# fixed-version: Fixed after version 5.15rc4
+CVE_CHECK_IGNORE += "CVE-2021-4203"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2021-4204"
+
+# fixed-version: Fixed after version 5.8rc1
+CVE_CHECK_IGNORE += "CVE-2021-4218"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2021-42252"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-42327"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-42739"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-43056"
+
+# fixed-version: Fixed after version 5.15rc3
+CVE_CHECK_IGNORE += "CVE-2021-43057"
+
+# fixed-version: Fixed after version 5.15
+CVE_CHECK_IGNORE += "CVE-2021-43267"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2021-43389"
+
+# fixed-version: Fixed after version 5.16rc2
+CVE_CHECK_IGNORE += "CVE-2021-43975"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2021-43976"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-44733"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2021-44879"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2021-45095"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-45100"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2021-45402"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2021-45469"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2021-45480"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2021-45485"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-45486"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2021-45868"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-46283"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-0001"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-0002"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-0168"
+
+# fixed-version: Fixed after version 5.18rc4
+CVE_CHECK_IGNORE += "CVE-2022-0171"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-0185"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2022-0264"
+
+# fixed-version: Fixed after version 5.14rc2
+CVE_CHECK_IGNORE += "CVE-2022-0286"
+
+# fixed-version: Fixed after version 5.15rc6
+CVE_CHECK_IGNORE += "CVE-2022-0322"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-0330"
+
+# fixed-version: Fixed after version 5.16
+CVE_CHECK_IGNORE += "CVE-2022-0382"
+
+# CVE-2022-0400 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-0433"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-0435"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-0480"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-0487"
+
+# fixed-version: Fixed after version 5.17rc3
+CVE_CHECK_IGNORE += "CVE-2022-0492"
+
+# fixed-version: Fixed after version 5.17rc5
+CVE_CHECK_IGNORE += "CVE-2022-0494"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-0500"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-0516"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-0617"
+
+# fixed-version: Fixed after version 5.15rc7
+CVE_CHECK_IGNORE += "CVE-2022-0644"
+
+# fixed-version: Fixed after version 5.17rc5
+CVE_CHECK_IGNORE += "CVE-2022-0646"
+
+# fixed-version: Fixed after version 5.17rc7
+CVE_CHECK_IGNORE += "CVE-2022-0742"
+
+# fixed-version: Fixed after version 5.8rc6
+CVE_CHECK_IGNORE += "CVE-2022-0812"
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-0847"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2022-0850"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-0854"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-0995"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-0998"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-1011"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-1012"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1015"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1016"
+
+# fixed-version: Fixed after version 5.14rc7
+CVE_CHECK_IGNORE += "CVE-2022-1043"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1048"
+
+# fixed-version: Fixed after version 5.17rc3
+CVE_CHECK_IGNORE += "CVE-2022-1055"
+
+# CVE-2022-1116 has no known resolution
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1158"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1184"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2022-1195"
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-1198"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-1199"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1204"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1205"
+
+# CVE-2022-1247 has no known resolution
+
+# fixed-version: Fixed after version 5.18rc3
+CVE_CHECK_IGNORE += "CVE-2022-1263"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-1280"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-1353"
+
+# fixed-version: Fixed after version 5.6rc2
+CVE_CHECK_IGNORE += "CVE-2022-1419"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-1462"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-1508"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1516"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1651"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-1652"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-1671"
+
+# fixed-version: Fixed after version 4.20rc1
+CVE_CHECK_IGNORE += "CVE-2022-1678"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-1679"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2022-1729"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-1734"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-1786"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2022-1789"
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2022-1836"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1852"
+
+# fixed-version: Fixed after version 5.19rc8
+CVE_CHECK_IGNORE += "CVE-2022-1882"
+
+# fixed-version: Fixed after version 5.18rc7
+CVE_CHECK_IGNORE += "CVE-2022-1943"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1966"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1972"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1973"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-1974"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-1975"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-1976"
+
+# fixed-version: Fixed after version 5.17rc3
+CVE_CHECK_IGNORE += "CVE-2022-1998"
+
+# fixed-version: Fixed after version 5.17rc5
+CVE_CHECK_IGNORE += "CVE-2022-20008"
+
+# fixed-version: Fixed after version 5.16rc5
+CVE_CHECK_IGNORE += "CVE-2022-20132"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-20141"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2022-20148"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2022-20153"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2022-20154"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-20158"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2022-20166"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-20368"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-20369"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20409"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-20421"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-20422"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-20423"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20424"
+
+# fixed-version: Fixed after version 5.9rc4
+CVE_CHECK_IGNORE += "CVE-2022-20565"
+
+# fixed-version: Fixed after version 5.19
+CVE_CHECK_IGNORE += "CVE-2022-20566"
+
+# fixed-version: Fixed after version 4.16rc5
+CVE_CHECK_IGNORE += "CVE-2022-20567"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-20568"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-20572"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-2078"
+
+# fixed-version: Fixed after version 5.19rc3
+CVE_CHECK_IGNORE += "CVE-2022-21123"
+
+# fixed-version: Fixed after version 5.19rc3
+CVE_CHECK_IGNORE += "CVE-2022-21125"
+
+# fixed-version: Fixed after version 5.19rc3
+CVE_CHECK_IGNORE += "CVE-2022-21166"
+
+# fixed-version: Fixed after version 4.20
+CVE_CHECK_IGNORE += "CVE-2022-21385"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-21499"
+
+# fixed-version: Fixed after version 5.19rc8
+CVE_CHECK_IGNORE += "CVE-2022-21505"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-2153"
+
+# cpe-stable-backport: Backported in 6.1.14
+CVE_CHECK_IGNORE += "CVE-2022-2196"
+
+# CVE-2022-2209 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-22942"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23036"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23037"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23038"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23039"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23040"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23041"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23042"
+
+# fixed-version: Fixed after version 6.0
+CVE_CHECK_IGNORE += "CVE-2022-2308"
+
+# fixed-version: Fixed after version 5.19rc5
+CVE_CHECK_IGNORE += "CVE-2022-2318"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-23222"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-2327"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-2380"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-23816"
+
+# CVE-2022-23825 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-23960"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-24122"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-24448"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-24958"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-24959"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-2503"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-25258"
+
+# CVE-2022-25265 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-25375"
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-25636"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-2585"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-2586"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-2588"
+
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2022-2590"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-2602"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-26365"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-26373"
+
+# fixed-version: Fixed after version 5.18rc4
+CVE_CHECK_IGNORE += "CVE-2022-2639"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-26490"
+
+# fixed-version: Fixed after version 6.0rc5
+CVE_CHECK_IGNORE += "CVE-2022-2663"
+
+# CVE-2022-26878 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-26966"
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-27223"
+
+# fixed-version: Fixed after version 5.17rc8
+CVE_CHECK_IGNORE += "CVE-2022-27666"
+
+# cpe-stable-backport: Backported in 6.1.12
+CVE_CHECK_IGNORE += "CVE-2022-27672"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-2785"
+
+# fixed-version: Fixed after version 5.17rc5
+CVE_CHECK_IGNORE += "CVE-2022-27950"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-28356"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-28388"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-28389"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-28390"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-2873"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-28796"
+
+# fixed-version: Fixed after version 5.18rc2
+CVE_CHECK_IGNORE += "CVE-2022-28893"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-2905"
+
+# fixed-version: Fixed after version 5.17rc6
+CVE_CHECK_IGNORE += "CVE-2022-29156"
+
+# fixed-version: Fixed after version 5.17rc2
+CVE_CHECK_IGNORE += "CVE-2022-2938"
+
+# fixed-version: Fixed after version 5.18rc4
+CVE_CHECK_IGNORE += "CVE-2022-29581"
+
+# fixed-version: Fixed after version 5.18rc2
+CVE_CHECK_IGNORE += "CVE-2022-29582"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-2959"
+
+# CVE-2022-2961 has no known resolution
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-2964"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-2977"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-2978"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-29900"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-29901"
+
+# fixed-version: Fixed after version 5.15rc1
+CVE_CHECK_IGNORE += "CVE-2022-2991"
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2022-29968"
+
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2022-3028"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-30594"
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2022-3061"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3077"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3078"
+
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2022-3103"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3104"
+
+# fixed-version: Fixed after version 5.16
+CVE_CHECK_IGNORE += "CVE-2022-3105"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2022-3106"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-3107"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-3108"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3110"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3111"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3112"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3113"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3114"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3115"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3169"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-3170"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2022-3176"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3202"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-32250"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2022-32296"
+
+# CVE-2022-3238 has no known resolution
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-3239"
+
+# fixed-version: Fixed after version 5.19rc2
+CVE_CHECK_IGNORE += "CVE-2022-32981"
+
+# fixed-version: Fixed after version 6.0rc5
+CVE_CHECK_IGNORE += "CVE-2022-3303"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2022-3344"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-33740"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-33741"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-33742"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-33743"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-33744"
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2022-33981"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2022-3424"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3435"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-34494"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-34495"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-34918"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3521"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3522"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3523"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3524"
+
+# fixed-version: Fixed after version 5.18rc3
+CVE_CHECK_IGNORE += "CVE-2022-3526"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2022-3531"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2022-3532"
+
+# CVE-2022-3533 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2022-3534"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3535"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3541"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3542"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3543"
+
+# CVE-2022-3544 has no known resolution
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3545"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2022-3564"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3565"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3566"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3567"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3577"
+
+# fixed-version: Fixed after version 6.0rc5
+CVE_CHECK_IGNORE += "CVE-2022-3586"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3594"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3595"
+
+# CVE-2022-3606 has no known resolution
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-36123"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2022-3619"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3621"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3623"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3624"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3625"
+
+# fixed-version: Fixed after version 6.1rc5
+CVE_CHECK_IGNORE += "CVE-2022-3628"
+
+# cpe-stable-backport: Backported in 6.1.4
+CVE_CHECK_IGNORE += "CVE-2022-36280"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3629"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3630"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3633"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-3635"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-3636"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2022-3640"
+
+# CVE-2022-36402 has no known resolution
+
+# CVE-2022-3642 has no known resolution
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2022-3643"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3646"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3649"
+
+# fixed-version: Fixed after version 5.19rc8
+CVE_CHECK_IGNORE += "CVE-2022-36879"
+
+# fixed-version: Fixed after version 5.19
+CVE_CHECK_IGNORE += "CVE-2022-36946"
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2022-3707"
+
+# CVE-2022-38096 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.7
+CVE_CHECK_IGNORE += "CVE-2022-38457"
+
+# fixed-version: Fixed after version 6.1rc2
+CVE_CHECK_IGNORE += "CVE-2022-3903"
+
+# fixed-version: Fixed after version 6.0rc6
+CVE_CHECK_IGNORE += "CVE-2022-3910"
+
+# fixed-version: Fixed after version 5.19rc8
+CVE_CHECK_IGNORE += "CVE-2022-39188"
+
+# fixed-version: Fixed after version 5.19rc2
+CVE_CHECK_IGNORE += "CVE-2022-39189"
+
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2022-39190"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-3977"
+
+# fixed-version: Fixed after version 5.19rc4
+CVE_CHECK_IGNORE += "CVE-2022-39842"
+
+# cpe-stable-backport: Backported in 6.1.7
+CVE_CHECK_IGNORE += "CVE-2022-40133"
+
+# fixed-version: Fixed after version 6.0rc5
+CVE_CHECK_IGNORE += "CVE-2022-40307"
+
+# fixed-version: Fixed after version 5.19rc4
+CVE_CHECK_IGNORE += "CVE-2022-40476"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-40768"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-4095"
+
+# cpe-stable-backport: Backported in 6.1.44
+CVE_CHECK_IGNORE += "CVE-2022-40982"
+
+# cpe-stable-backport: Backported in 6.1.4
+CVE_CHECK_IGNORE += "CVE-2022-41218"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2022-41222"
+
+# fixed-version: Fixed after version 5.19rc6
+CVE_CHECK_IGNORE += "CVE-2022-4127"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-4128"
+
+# fixed-version: Fixed after version 6.1rc6
+CVE_CHECK_IGNORE += "CVE-2022-4129"
+
+# fixed-version: Fixed after version 6.1rc8
+CVE_CHECK_IGNORE += "CVE-2022-4139"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-41674"
+
+# CVE-2022-41848 has no known resolution
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-41849"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-41850"
+
+# fixed-version: Fixed after version 5.18rc2
+CVE_CHECK_IGNORE += "CVE-2022-41858"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2022-42328"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2022-42329"
+
+# fixed-version: Fixed after version 6.0rc7
+CVE_CHECK_IGNORE += "CVE-2022-42432"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2022-4269"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-42703"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-42719"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-42720"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-42721"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-42722"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2022-42895"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2022-42896"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-43750"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2022-4378"
+
+# cpe-stable-backport: Backported in 6.1.3
+CVE_CHECK_IGNORE += "CVE-2022-4379"
+
+# cpe-stable-backport: Backported in 6.1.8
+CVE_CHECK_IGNORE += "CVE-2022-4382"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2022-43945"
+
+# CVE-2022-44032 needs backporting (fixed from 6.4rc1)
+
+# CVE-2022-44033 needs backporting (fixed from 6.4rc1)
+
+# CVE-2022-44034 has no known resolution
+
+# CVE-2022-4543 has no known resolution
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2022-45869"
+
+# CVE-2022-45884 has no known resolution
+
+# CVE-2022-45885 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2022-45886"
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2022-45887"
+
+# CVE-2022-45888 needs backporting (fixed from 6.2rc1)
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2022-45919"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2022-45934"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2022-4662"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2022-4696"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2022-4744"
+
+# fixed-version: Fixed after version 6.1rc8
+CVE_CHECK_IGNORE += "CVE-2022-47518"
+
+# fixed-version: Fixed after version 6.1rc8
+CVE_CHECK_IGNORE += "CVE-2022-47519"
+
+# fixed-version: Fixed after version 6.1rc8
+CVE_CHECK_IGNORE += "CVE-2022-47520"
+
+# fixed-version: Fixed after version 6.1rc8
+CVE_CHECK_IGNORE += "CVE-2022-47521"
+
+# cpe-stable-backport: Backported in 6.1.6
+CVE_CHECK_IGNORE += "CVE-2022-47929"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-47938"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-47939"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2022-47940"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-47941"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-47942"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2022-47943"
+
+# fixed-version: Fixed after version 5.12rc2
+CVE_CHECK_IGNORE += "CVE-2022-47946"
+
+# cpe-stable-backport: Backported in 6.1.8
+CVE_CHECK_IGNORE += "CVE-2022-4842"
+
+# cpe-stable-backport: Backported in 6.1.3
+CVE_CHECK_IGNORE += "CVE-2022-48423"
+
+# cpe-stable-backport: Backported in 6.1.3
+CVE_CHECK_IGNORE += "CVE-2022-48424"
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2022-48425"
+
+# cpe-stable-backport: Backported in 6.1.40
+CVE_CHECK_IGNORE += "CVE-2022-48502"
+
+# fixed-version: Fixed after version 5.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-0030"
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2023-0045"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2023-0047"
+
+# fixed-version: Fixed after version 6.0rc4
+CVE_CHECK_IGNORE += "CVE-2023-0122"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-0160"
+
+# cpe-stable-backport: Backported in 6.1.7
+CVE_CHECK_IGNORE += "CVE-2023-0179"
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2023-0210"
+
+# fixed-version: Fixed after version 5.10rc1
+CVE_CHECK_IGNORE += "CVE-2023-0240"
+
+# cpe-stable-backport: Backported in 6.1.6
+CVE_CHECK_IGNORE += "CVE-2023-0266"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-0386"
+
+# cpe-stable-backport: Backported in 6.1.7
+CVE_CHECK_IGNORE += "CVE-2023-0394"
+
+# cpe-stable-backport: Backported in 6.1.8
+CVE_CHECK_IGNORE += "CVE-2023-0458"
+
+# cpe-stable-backport: Backported in 6.1.14
+CVE_CHECK_IGNORE += "CVE-2023-0459"
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2023-0461"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-0468"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-0469"
+
+# fixed-version: Fixed after version 6.1rc2
+CVE_CHECK_IGNORE += "CVE-2023-0590"
+
+# CVE-2023-0597 needs backporting (fixed from 6.2rc1)
+
+# fixed-version: Fixed after version 6.1rc3
+CVE_CHECK_IGNORE += "CVE-2023-0615"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1032"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-1073"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-1074"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-1075"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1076"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1077"
+
+# cpe-stable-backport: Backported in 6.1.12
+CVE_CHECK_IGNORE += "CVE-2023-1078"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1079"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-1095"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1118"
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2023-1192"
+
+# CVE-2023-1193 has no known resolution
+
+# CVE-2023-1194 has no known resolution
+
+# fixed-version: Fixed after version 6.1rc3
+CVE_CHECK_IGNORE += "CVE-2023-1195"
+
+# cpe-stable-backport: Backported in 6.1.43
+CVE_CHECK_IGNORE += "CVE-2023-1206"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2023-1249"
+
+# fixed-version: Fixed after version 5.16rc1
+CVE_CHECK_IGNORE += "CVE-2023-1252"
+
+# cpe-stable-backport: Backported in 6.1.13
+CVE_CHECK_IGNORE += "CVE-2023-1281"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2023-1295"
+
+# cpe-stable-backport: Backported in 6.1.27
+CVE_CHECK_IGNORE += "CVE-2023-1380"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-1382"
+
+# fixed-version: Fixed after version 5.11rc4
+CVE_CHECK_IGNORE += "CVE-2023-1390"
+
+# cpe-stable-backport: Backported in 6.1.13
+CVE_CHECK_IGNORE += "CVE-2023-1513"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2023-1582"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-1583"
+
+# cpe-stable-backport: Backported in 6.1.23
+CVE_CHECK_IGNORE += "CVE-2023-1611"
+
+# fixed-version: Fixed after version 5.18rc2
+CVE_CHECK_IGNORE += "CVE-2023-1637"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-1652"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-1670"
+
+# cpe-stable-backport: Backported in 6.1.18
+CVE_CHECK_IGNORE += "CVE-2023-1829"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2023-1838"
+
+# cpe-stable-backport: Backported in 6.1.21
+CVE_CHECK_IGNORE += "CVE-2023-1855"
+
+# cpe-stable-backport: Backported in 6.1.25
+CVE_CHECK_IGNORE += "CVE-2023-1859"
+
+# fixed-version: Fixed after version 5.18rc2
+CVE_CHECK_IGNORE += "CVE-2023-1872"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-1989"
+
+# cpe-stable-backport: Backported in 6.1.21
+CVE_CHECK_IGNORE += "CVE-2023-1990"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-1998"
+
+# cpe-stable-backport: Backported in 6.1.27
+CVE_CHECK_IGNORE += "CVE-2023-2002"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-2006"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-2007"
+
+# fixed-version: Fixed after version 5.19rc4
+CVE_CHECK_IGNORE += "CVE-2023-2008"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-2019"
+
+# cpe-stable-backport: Backported in 6.1.44
+CVE_CHECK_IGNORE += "CVE-2023-20569"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-20588"
+
+# cpe-stable-backport: Backported in 6.1.41
+CVE_CHECK_IGNORE += "CVE-2023-20593"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-20928"
+
+# CVE-2023-20937 has no known resolution
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2023-20938"
+
+# CVE-2023-20941 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.8
+CVE_CHECK_IGNORE += "CVE-2023-21102"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-21106"
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2023-2124"
+
+# cpe-stable-backport: Backported in 6.1.31
+CVE_CHECK_IGNORE += "CVE-2023-21255"
+
+# CVE-2023-21264 needs backporting (fixed from 6.4rc5)
+
+# CVE-2023-21400 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.26
+CVE_CHECK_IGNORE += "CVE-2023-2156"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-2162"
+
+# cpe-stable-backport: Backported in 6.1.26
+CVE_CHECK_IGNORE += "CVE-2023-2163"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2023-2166"
+
+# CVE-2023-2176 needs backporting (fixed from 6.3rc1)
+
+# fixed-version: Fixed after version 5.19
+CVE_CHECK_IGNORE += "CVE-2023-2177"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-2194"
+
+# cpe-stable-backport: Backported in 6.1.21
+CVE_CHECK_IGNORE += "CVE-2023-2235"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-2236"
+
+# cpe-stable-backport: Backported in 6.1.26
+CVE_CHECK_IGNORE += "CVE-2023-2248"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-2269"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2023-22995"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2023-22996"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2023-22997"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-22998"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2023-22999"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2023-23000"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2023-23001"
+
+# fixed-version: Fixed after version 5.17rc1
+CVE_CHECK_IGNORE += "CVE-2023-23002"
+
+# fixed-version: Fixed after version 5.16rc6
+CVE_CHECK_IGNORE += "CVE-2023-23003"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2023-23004"
+
+# CVE-2023-23005 needs backporting (fixed from 6.2rc1)
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2023-23006"
+
+# CVE-2023-23039 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2023-23454"
+
+# cpe-stable-backport: Backported in 6.1.5
+CVE_CHECK_IGNORE += "CVE-2023-23455"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-23559"
+
+# fixed-version: Fixed after version 5.12rc1
+CVE_CHECK_IGNORE += "CVE-2023-23586"
+
+# CVE-2023-2430 needs backporting (fixed from 6.1.50)
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-2483"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-25012"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-2513"
+
+# CVE-2023-25775 has no known resolution
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-2598"
+
+# CVE-2023-26242 has no known resolution
+
+# CVE-2023-2640 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.3
+CVE_CHECK_IGNORE += "CVE-2023-26544"
+
+# cpe-stable-backport: Backported in 6.1.13
+CVE_CHECK_IGNORE += "CVE-2023-26545"
+
+# fixed-version: Fixed after version 6.1rc7
+CVE_CHECK_IGNORE += "CVE-2023-26605"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2023-26606"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2023-26607"
+
+# fixed-version: Fixed after version 6.1
+CVE_CHECK_IGNORE += "CVE-2023-28327"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2023-28328"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2023-28410"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-28464"
+
+# cpe-stable-backport: Backported in 6.1.20
+CVE_CHECK_IGNORE += "CVE-2023-28466"
+
+# fixed-version: Fixed after version 6.0rc5
+CVE_CHECK_IGNORE += "CVE-2023-2860"
+
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2023-28772"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-28866"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-2898"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-2985"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2023-3006"
+
+# Skipping CVE-2023-3022, no affected_versions
+
+# cpe-stable-backport: Backported in 6.1.21
+CVE_CHECK_IGNORE += "CVE-2023-30456"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-30772"
+
+# cpe-stable-backport: Backported in 6.1.30
+CVE_CHECK_IGNORE += "CVE-2023-3090"
+
+# fixed-version: Fixed after version 4.8rc7
+CVE_CHECK_IGNORE += "CVE-2023-3106"
+
+# Skipping CVE-2023-3108, no affected_versions
+
+# CVE-2023-31081 has no known resolution
+
+# CVE-2023-31082 has no known resolution
+
+# CVE-2023-31083 has no known resolution
+
+# CVE-2023-31084 needs backporting (fixed from 6.4rc3)
+
+# CVE-2023-31085 has no known resolution
+
+# fixed-version: Fixed after version 6.0rc2
+CVE_CHECK_IGNORE += "CVE-2023-3111"
+
+# cpe-stable-backport: Backported in 6.1.35
+CVE_CHECK_IGNORE += "CVE-2023-3117"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-31248"
+
+# cpe-stable-backport: Backported in 6.1.30
+CVE_CHECK_IGNORE += "CVE-2023-3141"
+
+# cpe-stable-backport: Backported in 6.1.26
+CVE_CHECK_IGNORE += "CVE-2023-31436"
+
+# fixed-version: Fixed after version 5.18rc6
+CVE_CHECK_IGNORE += "CVE-2023-3159"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-3161"
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2023-3212"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-3220"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-32233"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-32247"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-32248"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-32250"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-32252"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-32254"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-32257"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-32258"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-32269"
+
+# CVE-2023-32629 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-3268"
+
+# cpe-stable-backport: Backported in 6.1.37
+CVE_CHECK_IGNORE += "CVE-2023-3269"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3312"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-3317"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-33203"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-33250"
+
+# cpe-stable-backport: Backported in 6.1.22
+CVE_CHECK_IGNORE += "CVE-2023-33288"
+
+# fixed-version: Fixed after version 6.1rc1
+CVE_CHECK_IGNORE += "CVE-2023-3338"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-3355"
+
+# cpe-stable-backport: Backported in 6.1.2
+CVE_CHECK_IGNORE += "CVE-2023-3357"
+
+# cpe-stable-backport: Backported in 6.1.9
+CVE_CHECK_IGNORE += "CVE-2023-3358"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-3359"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2023-3389"
+
+# cpe-stable-backport: Backported in 6.1.35
+CVE_CHECK_IGNORE += "CVE-2023-3390"
+
+# cpe-stable-backport: Backported in 6.1.13
+CVE_CHECK_IGNORE += "CVE-2023-33951"
+
+# cpe-stable-backport: Backported in 6.1.13
+CVE_CHECK_IGNORE += "CVE-2023-33952"
+
+# CVE-2023-3397 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2023-34255"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2023-34256"
+
+# cpe-stable-backport: Backported in 6.1.44
+CVE_CHECK_IGNORE += "CVE-2023-34319"
+
+# fixed-version: Fixed after version 5.18rc5
+CVE_CHECK_IGNORE += "CVE-2023-3439"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-35001"
+
+# cpe-stable-backport: Backported in 6.1.11
+CVE_CHECK_IGNORE += "CVE-2023-3567"
+
+# CVE-2023-35693 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.33
+CVE_CHECK_IGNORE += "CVE-2023-35788"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-35823"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-35824"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-35826"
+
+# CVE-2023-35827 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-35828"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-35829"
+
+# cpe-stable-backport: Backported in 6.1.35
+CVE_CHECK_IGNORE += "CVE-2023-3609"
+
+# cpe-stable-backport: Backported in 6.1.36
+CVE_CHECK_IGNORE += "CVE-2023-3610"
+
+# cpe-stable-backport: Backported in 6.1.40
+CVE_CHECK_IGNORE += "CVE-2023-3611"
+
+# CVE-2023-3640 has no known resolution
+
+# CVE-2023-37453 has no known resolution
+
+# CVE-2023-37454 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-3772"
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-3773"
+
+# cpe-stable-backport: Backported in 6.1.40
+CVE_CHECK_IGNORE += "CVE-2023-3776"
+
+# cpe-stable-backport: Backported in 6.1.42
+CVE_CHECK_IGNORE += "CVE-2023-3777"
+
+# fixed-version: Fixed after version 6.1rc4
+CVE_CHECK_IGNORE += "CVE-2023-3812"
+
+# cpe-stable-backport: Backported in 6.1.25
+CVE_CHECK_IGNORE += "CVE-2023-38409"
+
+# cpe-stable-backport: Backported in 6.1.30
+CVE_CHECK_IGNORE += "CVE-2023-38426"
+
+# cpe-stable-backport: Backported in 6.1.34
+CVE_CHECK_IGNORE += "CVE-2023-38427"
+
+# cpe-stable-backport: Backported in 6.1.30
+CVE_CHECK_IGNORE += "CVE-2023-38428"
+
+# cpe-stable-backport: Backported in 6.1.30
+CVE_CHECK_IGNORE += "CVE-2023-38429"
+
+# cpe-stable-backport: Backported in 6.1.35
+CVE_CHECK_IGNORE += "CVE-2023-38430"
+
+# cpe-stable-backport: Backported in 6.1.34
+CVE_CHECK_IGNORE += "CVE-2023-38431"
+
+# cpe-stable-backport: Backported in 6.1.36
+CVE_CHECK_IGNORE += "CVE-2023-38432"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-3863"
+
+# cpe-stable-backport: Backported in 6.1.42
+CVE_CHECK_IGNORE += "CVE-2023-4004"
+
+# CVE-2023-4010 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.43
+CVE_CHECK_IGNORE += "CVE-2023-4015"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-40283"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-4128"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-4132"
+
+# CVE-2023-4133 needs backporting (fixed from 6.3)
+
+# CVE-2023-4134 needs backporting (fixed from 6.5rc1)
+
+# cpe-stable-backport: Backported in 6.1.43
+CVE_CHECK_IGNORE += "CVE-2023-4147"
+
+# cpe-stable-backport: Backported in 6.1.46
+CVE_CHECK_IGNORE += "CVE-2023-4155"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4194"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-4206"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-4207"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-4208"
+
+# cpe-stable-backport: Backported in 6.1.45
+CVE_CHECK_IGNORE += "CVE-2023-4273"
+
+# fixed-version: Fixed after version 5.19rc1
+CVE_CHECK_IGNORE += "CVE-2023-4385"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2023-4387"
+
+# fixed-version: Fixed after version 5.18rc3
+CVE_CHECK_IGNORE += "CVE-2023-4389"
+
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2023-4394"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2023-4459"
+
+# CVE-2023-4563 needs backporting (fixed from 6.5rc6)
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-4569"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4611"
+
+# CVE-2023-4622 needs backporting (fixed from 6.5rc1)
+
+# CVE-2023-4623 has no known resolution
+

--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -1,6 +1,7 @@
 KBRANCH ?= "linux-5.15.y"
 
 require linux-yocto-onl.inc
+include cve-exclusion_5.15.inc
 
 KCONF_BSP_AUDIT_LEVEL = "1"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -1,6 +1,7 @@
 KBRANCH ?= "linux-6.1.y"
 
 require linux-yocto-onl.inc
+include cve-exclusion_6.1.inc
 
 KCONF_BSP_AUDIT_LEVEL = "1"
 


### PR DESCRIPTION
Add and include generated lists of known fixed CVEs so cve_check won't
warn about them.

Mitre is not particularly good at keeping the list of affected and fixed linux verions up to date. The linux kernel CVEs project [1] tries to take care of that. Therefore add a list of fixed CVEs for each kernel, so the list of CVEs being warned about become more meaningful.

For obvious reasons the list needs to be re-generated on every kernel update.

Generated with generate-cve-exclusions.py from poky [2]

[1] https://github.com/nluedtke/linux_kernel_cves
[2] https://git.yoctoproject.org/poky/tree/meta/recipes-kernel/linux/generate-cve-exclusions.py?h=kirkstone&id=f17c07ff4b979e45e967fab6e0ba9faf83290115