### PR TITLE
onl: always build all platforms

### DIFF
--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -29,9 +29,6 @@ ONL_PLATFORM_SUPPORT = " \
     x86_64-cel_questone_2a-r0 \
 "
 
-# delta-ag5648's i2c-cpld is part of delta's common vendor modules
-ONL_MODULE_VENDORS = "delta"
-
 MACHINE_EXTRA_RDEPENDS += " \
     accton-as4630-54pe-poe-mcu-mod \
     ipmitool \

--- a/conf/machine/include/onl.inc
+++ b/conf/machine/include/onl.inc
@@ -13,6 +13,3 @@ ONL_PLATFORM="${@'${ONIE_ARCH}-${ONIE_MACHINE}'.replace('_', '-')}"
 
 # list of platforms in ONIE format for which to include support
 ONL_PLATFORM_SUPPORT ?= "${ONIE_PLATFORM}"
-
-# some platforms require common vendor modules
-ONL_MODULE_VENDORS ?= ""

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -130,10 +130,7 @@ do_compile() {
   ${S}/tools/scripts/kmodbuild.sh "${STAGING_KERNEL_BUILDDIR}" "$mods" "onl/onl/common"
   cd -
 
-  for onie_platform in ${ONL_PLATFORMS_BUILD}; do
-      # onl uses dashes instead of undescores for platforms
-      platform="$(echo $onie_platform | tr '_' '-')"
-
+  for platform in ${ONL_PLATFORMS_BUILD}; do
       # get the path to the platform
       ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${platform}:${ONL_BUILD_ARCH})
 
@@ -182,9 +179,7 @@ do_install() {
   mkdir -p ${D}${nonarch_base_libdir}/modules
   cp -r onl-modules/lib/modules ${D}${nonarch_base_libdir}
 
-  for onie_platform in ${ONL_PLATFORMS_BUILD}; do
-      # onl uses dashes instead of undescores for platforms
-      platform="$(echo $onie_platform | tr '_' '-')"
+  for platform in ${ONL_PLATFORMS_BUILD}; do
       # get the path to the platform
       ONLP_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onlp-${platform}:${ONL_BUILD_ARCH})
 

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -80,9 +80,6 @@ def onl_arch_map(arch, tune):
 ONL_BUILD_ARCH = "${@onl_arch_map(d.getVar('TARGET_ARCH'), d.getVar('TUNE_FEATURES'))}"
 ONL_DEBIAN_SUITE = "buster"
 
-ONL_PLATFORMS_BUILD = "${ONL_PLATFORM_SUPPORT}"
-ONL_PLATFORMS_BUILD:remove = "${ONL_PLATFORMS_IGNORE}"
-
 ###
 # TODO CFLAGS?
 EXTRA_OEMAKE = "\
@@ -149,7 +146,7 @@ do_compile() {
       V=1 VERBOSE=1 oe_runmake -C ${MODULES_DIR}/builds modules ARCH=${ARCH} KERNELS=${STAGING_KERNEL_BUILDDIR}
   done
 
-  for vendor in ${ONL_MODULE_VENDORS}; do
+  for vendor in ${ONL_MODULE_VENDORS_BUILD}; do
       MODULES_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onl-vendor-${vendor}-modules:${ONL_BUILD_ARCH})
       V=1 VERBOSE=1 oe_runmake -C ${MODULES_DIR}/builds modules ARCH=${ARCH} KERNELS=${STAGING_KERNEL_BUILDDIR}
   done
@@ -203,7 +200,7 @@ do_install() {
   done
 
   # install vendor modules
-  for vendor in ${ONL_MODULE_VENDORS}; do
+  for vendor in ${ONL_MODULE_VENDORS_BUILD}; do
       MODULES_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onl-vendor-${vendor}-modules:${ONL_BUILD_ARCH})
       cp -r ${MODULES_DIR}/builds/${nonarch_base_libdir}/modules ${D}${nonarch_base_libdir}
   done

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -94,18 +94,18 @@ FILES:${PN} = " \
 "
 
 ONL_PLATFORMS_BUILD:arm = " \
-    arm-accton_as4610_30-r0 \
-    arm-accton_as4610_54-r0 \
+    arm-accton-as4610-30-r0 \
+    arm-accton-as4610-54-r0 \
 "
 
 ONL_PLATFORMS_BUILD:x86-64 = " \
-    x86_64-accton_as4630_54pe-r0 \
-    x86_64-accton_as4630_54te-r0 \
-    x86_64-accton_as7726_32x-r0 \
-    x86_64-accton_as5835_54x-r0 \
-    x86_64-delta_ag5648-r0 \
-    x86_64-delta_ag7648-r0 \
-    x86_64-cel_questone_2a-r0 \
+    x86-64-accton-as4630-54pe-r0 \
+    x86-64-accton-as4630-54te-r0 \
+    x86-64-accton-as7726-32x-r0 \
+    x86-64-accton-as5835-54x-r0 \
+    x86-64-delta-ag5648-r0 \
+    x86-64-delta-ag7648-r0 \
+    x86-64-cel-questone-2a-r0 \
 "
 
 # delta-ag5648's i2c-cpld is part of delta's common vendor modules

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -93,8 +93,20 @@ FILES:${PN} = " \
   ${libdir}/libonlp*.so.1 \
 "
 
-# ONIE platforms that should not be built
-ONL_PLATFORMS_IGNORE = ""
+ONL_PLATFORMS_BUILD:arm = " \
+    arm-accton_as4610_30-r0 \
+    arm-accton_as4610_54-r0 \
+"
 
-# delta_ag5648v1 is an alias for delta_ag5648
-ONL_PLATFORMS_IGNORE += "x86_64-delta_ag5648v1-r0"
+ONL_PLATFORMS_BUILD:x86-64 = " \
+    x86_64-accton_as4630_54pe-r0 \
+    x86_64-accton_as4630_54te-r0 \
+    x86_64-accton_as7726_32x-r0 \
+    x86_64-accton_as5835_54x-r0 \
+    x86_64-delta_ag5648-r0 \
+    x86_64-delta_ag7648-r0 \
+    x86_64-cel_questone_2a-r0 \
+"
+
+# delta-ag5648's i2c-cpld is part of delta's common vendor modules
+ONL_MODULE_VENDORS_BUILD:x86-64 = "delta"


### PR DESCRIPTION
Since we now do not have single-device machines anymore, there is no reason to support dynamically limited ONL builds. So let's reduce complexity and always build all supported platforms.

This also let us drop the need for ignoring unknown platforms, as we
now do not use the ONL_PLATFORM_SUPPORT contents anymore. And since the list is ONL-recipe local, there is no need anymore to have it in ONIE format, and change it to ONL format directly.