### PR TITLE
onl: optoe: fix race in sysfs registration on probe

### DIFF
--- a/recipes-extended/onl/files/onl/0001-file_uds-silence-unused-result-warnings.patch
+++ b/recipes-extended/onl/files/onl/0001-file_uds-silence-unused-result-warnings.patch
@@ -1,7 +1,7 @@
 From f6851f93820bb0cf7b586534e123cc5874e3326a Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 19 Mar 2021 12:00:28 +0100
-Subject: [PATCH 01/16] file_uds: silence unused result warnings
+Subject: [PATCH 01/17] file_uds: silence unused result warnings
 
 We don't seem to care if these fail, so silence them in a way that works
 with GCC.

--- a/recipes-extended/onl/files/onl/0002-platform_manager-do-not-ignore-write-return-value.patch
+++ b/recipes-extended/onl/files/onl/0002-platform_manager-do-not-ignore-write-return-value.patch
@@ -1,7 +1,7 @@
 From 19a0c4e9d37a58bf39765a10def62256263143d8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 19 Mar 2021 12:07:35 +0100
-Subject: [PATCH 02/16] platform_manager: do not ignore write return value
+Subject: [PATCH 02/17] platform_manager: do not ignore write return value
 
 If the write fails, the other thread will not be notified, so we should
 not try to wait for it.

--- a/recipes-extended/onl/files/onl/0003-file-check-unix-socket-path-is-short-enough.patch
+++ b/recipes-extended/onl/files/onl/0003-file-check-unix-socket-path-is-short-enough.patch
@@ -1,7 +1,7 @@
 From bf0e7acf7bc12292b8a57b74e1b6f2e87dde57c0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 19 Apr 2021 16:23:26 +0200
-Subject: [PATCH 03/16] file: check unix socket path is short enough
+Subject: [PATCH 03/17] file: check unix socket path is short enough
 
 Add a length check for path before attempting to copy it. And because
 gcc is not smart enough, move strncpy to the check, else it will fail to

--- a/recipes-extended/onl/files/onl/0004-ym2651y-fix-update-when-MFR_MODEL_OPTION-is-uninmple.patch
+++ b/recipes-extended/onl/files/onl/0004-ym2651y-fix-update-when-MFR_MODEL_OPTION-is-uninmple.patch
@@ -1,7 +1,7 @@
 From 57868d941546cbe28a0db9d7d4d3db60fa29fa2b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 13 May 2022 12:24:11 +0200
-Subject: [PATCH 04/16] ym2651y: fix update when MFR_MODEL_OPTION is
+Subject: [PATCH 04/17] ym2651y: fix update when MFR_MODEL_OPTION is
  uninmplemented
 
 Not every PSU implements the MFR_MODEL_OPTION register. If it does not

--- a/recipes-extended/onl/files/onl/0005-WIP-tools-convert-to-python3.patch
+++ b/recipes-extended/onl/files/onl/0005-WIP-tools-convert-to-python3.patch
@@ -1,7 +1,7 @@
 From df6d99bf26a8e8cca41633b9af00b6c84ce10607 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 16 Jun 2022 10:30:25 +0200
-Subject: [PATCH 05/16] WIP: tools: convert to python3
+Subject: [PATCH 05/17] WIP: tools: convert to python3
 
 Convert the build code from python2 to python3:
 

--- a/recipes-extended/onl/files/onl/0006-dynamically-determine-location-of-python3.patch
+++ b/recipes-extended/onl/files/onl/0006-dynamically-determine-location-of-python3.patch
@@ -1,7 +1,7 @@
 From 996cf13c0506b88549bb30f43d2bf52f8d91dc37 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 16 Jun 2022 10:32:16 +0200
-Subject: [PATCH 06/16] dynamically determine location of python3
+Subject: [PATCH 06/17] dynamically determine location of python3
 
 To allow running the scripts within a distro context with custom python
 search paths, replace the hardcoded location of the python3 binary with

--- a/recipes-extended/onl/files/onl/0007-onlpm-hardcode-supported-arches.patch
+++ b/recipes-extended/onl/files/onl/0007-onlpm-hardcode-supported-arches.patch
@@ -1,7 +1,7 @@
 From 6f7181c0f752418627790dca797b1fad1c56302f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 18 May 2022 16:21:02 +0200
-Subject: [PATCH 07/16] onlpm: hardcode supported arches
+Subject: [PATCH 07/17] onlpm: hardcode supported arches
 
 For yocto we don't provide a dpkg, so we need to hardcode the supported
 arches.

--- a/recipes-extended/onl/files/onl/0008-onlpm-add-an-argument-for-just-printing-the-builddir.patch
+++ b/recipes-extended/onl/files/onl/0008-onlpm-add-an-argument-for-just-printing-the-builddir.patch
@@ -1,7 +1,7 @@
 From 5abd34f18352748a1dcd5bcb2144bacd931f59a8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 18 May 2022 15:49:13 +0200
-Subject: [PATCH 08/16] onlpm: add an argument for just printing the builddirs
+Subject: [PATCH 08/17] onlpm: add an argument for just printing the builddirs
 
 To allow building without packaging, we need to know the appropriate
 build dir for passing to make.

--- a/recipes-extended/onl/files/onl/0009-onlpm-allow-overriding-the-dist-codename-from-enviro.patch
+++ b/recipes-extended/onl/files/onl/0009-onlpm-allow-overriding-the-dist-codename-from-enviro.patch
@@ -1,7 +1,7 @@
 From 509f7a7325348408e6b2b1d92ece1224c19e1056 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 23 Jun 2022 11:13:22 +0200
-Subject: [PATCH 09/16] onlpm: allow overriding the dist codename from
+Subject: [PATCH 09/17] onlpm: allow overriding the dist codename from
  environment
 
 Yocto does not provide a lsb_release module, so add support for

--- a/recipes-extended/onl/files/onl/0010-tools-replace-yaml.load-with-yaml.full_load.patch
+++ b/recipes-extended/onl/files/onl/0010-tools-replace-yaml.load-with-yaml.full_load.patch
@@ -1,7 +1,7 @@
 From 9013e00f506f73b45a560c161881c98c05a6bd78 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 28 Jun 2022 11:00:16 +0200
-Subject: [PATCH 10/16] tools: replace yaml.load with yaml.full_load
+Subject: [PATCH 10/17] tools: replace yaml.load with yaml.full_load
 
 yaml.load without loader is deprecated and unsafe [1], and was removed
 with PyYAML 6.0.

--- a/recipes-extended/onl/files/onl/0011-optoe-allow-compilation-with-linux-5.5-and-newer.patch
+++ b/recipes-extended/onl/files/onl/0011-optoe-allow-compilation-with-linux-5.5-and-newer.patch
@@ -1,7 +1,7 @@
 From 7cf9dead170ea3269903a131e503b9aea2b376c2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 20 May 2022 10:44:58 +0200
-Subject: [PATCH 11/16] optoe: allow compilation with linux 5.5 and newer
+Subject: [PATCH 11/17] optoe: allow compilation with linux 5.5 and newer
 
 i2c_new_dummy was dropped in linux in favour of i2c_new_dummy_device,
 which was introduced in 5.3.

--- a/recipes-extended/onl/files/onl/0012-kmodbuild.sh-don-t-treat-undefined-symbols-as-errors.patch
+++ b/recipes-extended/onl/files/onl/0012-kmodbuild.sh-don-t-treat-undefined-symbols-as-errors.patch
@@ -1,7 +1,7 @@
 From 998766c329dc8b387d6bd7208c1283876e320506 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@gmail.com>
 Date: Thu, 19 May 2022 10:09:04 +0200
-Subject: [PATCH 12/16] kmodbuild.sh: don't treat undefined symbols as errors
+Subject: [PATCH 12/17] kmodbuild.sh: don't treat undefined symbols as errors
 
 Modern kernels treat undefined symbols as errors, but when building
 modules individually, inter-module dependencies cannot be properly

--- a/recipes-extended/onl/files/onl/0013-optoe-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0013-optoe-add-of-device-match-table.patch
@@ -1,7 +1,7 @@
 From 4f5ccc51b8b0f893351349c55b40c57be7bd29be Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 26 Aug 2022 11:43:30 +0200
-Subject: [PATCH 13/16] optoe: add of device match table
+Subject: [PATCH 13/17] optoe: add of device match table
 
 For on-demand loading to work the kernel needs to know which compatibles
 are handled by the driver, so add an appropriate table.

--- a/recipes-extended/onl/files/onl/0014-ym2561y-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0014-ym2561y-add-of-device-match-table.patch
@@ -1,7 +1,7 @@
 From e7ce73b790ce3044501632b30054d436213861b0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 26 Aug 2022 11:49:20 +0200
-Subject: [PATCH 14/16] ym2561y: add of device match table
+Subject: [PATCH 14/17] ym2561y: add of device match table
 
 For on-demand loading to work the kernel needs to know which compatibles
 are handled by the driver, so add an appropriate table.

--- a/recipes-extended/onl/files/onl/0015-modules-do-not-call-hwmon_device_register_with_info-.patch
+++ b/recipes-extended/onl/files/onl/0015-modules-do-not-call-hwmon_device_register_with_info-.patch
@@ -1,7 +1,7 @@
 From 4e4dfb701e7f1473cc6c8cecbd3e8eab49369fd8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 22 Nov 2022 13:48:48 +0100
-Subject: [PATCH 15/16] modules: do not call hwmon_device_register_with_info()
+Subject: [PATCH 15/17] modules: do not call hwmon_device_register_with_info()
  with NULL chip
 
 hwmon_device_register_with_info() is supposed to require hwmon_chip_info

--- a/recipes-extended/onl/files/onl/0016-modules-update-i2c_driver-with-6.1-compatibility.patch
+++ b/recipes-extended/onl/files/onl/0016-modules-update-i2c_driver-with-6.1-compatibility.patch
@@ -1,7 +1,7 @@
 From ec80a0578cb99389104cf02dfa7b98511ded5c40 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 15 Nov 2022 14:48:11 +0100
-Subject: [PATCH 16/16] modules: update i2c_driver with 6.1 compatibility
+Subject: [PATCH 16/17] modules: update i2c_driver with 6.1 compatibility
 
 i2c_remove changes its return type from int to void, so we need to
 provide different versions based on kernel version.

--- a/recipes-extended/onl/files/onl/0017-optoe-fix-race-in-sysfs-registraton-on-probe.patch
+++ b/recipes-extended/onl/files/onl/0017-optoe-fix-race-in-sysfs-registraton-on-probe.patch
@@ -1,0 +1,141 @@
+From 21c1dbb7292fa4db62a91fdffb1b6ffcc4d0dacb Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 29 Sep 2023 11:26:41 +0200
+Subject: [PATCH 17/17] optoe: fix race in sysfs registration on probe
+
+The optoe first creates the sysfs entries and then calls
+i2c_set_clientdata(), but a very fast userspace may already try to
+access the sysfs entries before the clientdata was set. This then leads
+to a NULL pointer access, crashing the kernel.
+
+Fix this by ensuring the sysfs entries are only registered after
+clientdata is populated.
+
+Fixes the following crash observed on boot:
+Sep 28 18:59:33 accton-as4630-54pe kernel: i2c i2c-18: new_device: Instantiated device optoe2 at 0x50
+Sep 28 18:59:33 accton-as4630-54pe kernel: BUG: kernel NULL pointer dereference, address: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: optoe 18-0050: 33152 byte optoe2 EEPROM, read/write
+Sep 28 18:59:33 accton-as4630-54pe kernel: #PF: supervisor write access in kernel mode
+Sep 28 18:59:33 accton-as4630-54pe kernel: #PF: error_code(0x0002) - not-present page
+Sep 28 18:59:33 accton-as4630-54pe kernel: PGD 0 P4D 0
+Sep 28 18:59:33 accton-as4630-54pe kernel: Oops: 0002 [#1] PREEMPT SMP NOPTI
+Sep 28 18:59:33 accton-as4630-54pe kernel: CPU: 1 PID: 1733 Comm: platform-onl-in Tainted: G           O       6.1.47-yocto-standard-onl #1
+Sep 28 18:59:33 accton-as4630-54pe kernel: Hardware name: Accton AS4630-54PE/AS4630-54PE, BIOS v47.01.01.00 03/14/2021
+Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0010:mutex_lock+0x19/0x30
+Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 00 0f 1f 44 00 00 be 02 00 00 00 e9 e1 f7 ff ff 90 0f 1f 44 00 00 55 48 89 fd e8 e2 de ff ff 31 c0 65 48 8b 14 25 00 ad 01 00 <f0> 48 0f b1 55 00 75 02 5d c3 48 89 ef 5d eb c7 0f 1f 80 00 00 00
+Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 0018:ffffc900002a7df0 EFLAGS: 00010246
+Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff888102e11d93
+Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: ffff888102c26e40 RSI: ffffffffa02c339f RDI: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 0000000000000048 R08: 0000000000000013 R09: 0000000000000001
+Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000001 R11: 0000000000000000 R12: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: R13: fffffffffffffff2 R14: ffff888104406540 R15: ffff888104406560
+Sep 28 18:59:33 accton-as4630-54pe kernel: FS:  00007f7346004740(0000) GS:ffff88846fc80000(0000) knlGS:0000000000000000
+Sep 28 18:59:33 accton-as4630-54pe kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048 CR3: 000000010113c000 CR4: 00000000003506e0
+Sep 28 18:59:33 accton-as4630-54pe kernel: Call Trace:
+Sep 28 18:59:33 accton-as4630-54pe kernel:  <TASK>
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? __die_body.cold+0x1a/0x1f
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? page_fault_oops+0xae/0x260
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? do_truncate+0x93/0xd0
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? do_user_addr_fault+0x61/0x570
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? exc_page_fault+0x5d/0x120
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? asm_exc_page_fault+0x22/0x30
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ? mutex_lock+0x19/0x30
+Sep 28 18:59:33 accton-as4630-54pe kernel:  set_port_name+0x4c/0x90 [optoe]
+Sep 28 18:59:33 accton-as4630-54pe kernel:  kernfs_fop_write_iter+0x10c/0x1a0
+Sep 28 18:59:33 accton-as4630-54pe kernel:  vfs_write+0x2b4/0x3b0
+Sep 28 18:59:33 accton-as4630-54pe kernel:  ksys_write+0x5f/0xe0
+Sep 28 18:59:33 accton-as4630-54pe kernel:  do_syscall_64+0x35/0x80
+Sep 28 18:59:33 accton-as4630-54pe kernel:  entry_SYSCALL_64_after_hwframe+0x63/0xcd
+Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0033:0x7f7346103377
+Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 0f 00 f7 d8 64 89 02 48 c7 c0 ff ff ff ff eb b7 0f 1f 00 f3 0f 1e fa 64 8b 04 25 18 00 00 00 85 c0 75 10 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 51 c3 48 83 ec 28 48 89 54 24 18 48 89 74 24
+Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 002b:00007ffe849c05b8 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
+Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: ffffffffffffffda RBX: 0000000000000007 RCX: 00007f7346103377
+Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: 0000000000000007 RSI: 000055e3a50ca6b0 RDI: 0000000000000001
+Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 000055e3a50ca6b0 R08: 00007f73461b23e0 R09: 0000000000000000
+Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000007
+Sep 28 18:59:33 accton-as4630-54pe kernel: R13: 00007f73461f85a0 R14: 0000000000000007 R15: 00007f73461f87a0
+Sep 28 18:59:33 accton-as4630-54pe kernel:  </TASK>
+Sep 28 18:59:33 accton-as4630-54pe kernel: Modules linked in: optoe(O) ym2651y(O) x86_64_accton_as4630_54pe_leds(O) x86_64_accton_as4630_54pe_psu(O) x86_64_accton_as4630_54pe_cpld(O) i2c_ismt i2c_i801 i2c_smbus iptable_filter linux_user_bde(O) linux_bcm_knet(O) linux_kernel_bde(O) openvswitch nsh nf_nat
+Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: ---[ end trace 0000000000000000 ]---
+Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0010:mutex_lock+0x19/0x30
+Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 00 0f 1f 44 00 00 be 02 00 00 00 e9 e1 f7 ff ff 90 0f 1f 44 00 00 55 48 89 fd e8 e2 de ff ff 31 c0 65 48 8b 14 25 00 ad 01 00 <f0> 48 0f b1 55 00 75 02 5d c3 48 89 ef 5d eb c7 0f 1f 80 00 00 00
+Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 0018:ffffc900002a7df0 EFLAGS: 00010246
+Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff888102e11d93
+Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: ffff888102c26e40 RSI: ffffffffa02c339f RDI: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 0000000000000048 R08: 0000000000000013 R09: 0000000000000001
+Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000001 R11: 0000000000000000 R12: 0000000000000048
+Sep 28 18:59:33 accton-as4630-54pe kernel: R13: fffffffffffffff2 R14: ffff888104406540 R15: ffff888104406560
+Sep 28 18:59:33 accton-as4630-54pe kernel: FS:  00007f7346004740(0000) GS:ffff88846fc80000(0000) knlGS:0000000000000000
+Sep 28 18:59:33 accton-as4630-54pe kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048 CR3: 000000010113c000 CR4: 00000000003506e0
+Sep 28 18:59:33 accton-as4630-54pe kernel: note: platform-onl-in[1733] exited with irqs disabled
+
+Upstream-Status: Submitted [https://github.com/opencomputeproject/OpenNetworkLinux/pull/956]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ packages/base/any/kernels/modules/optoe.c | 31 ++++++++++++-----------
+ 1 file changed, 16 insertions(+), 15 deletions(-)
+
+diff --git a/packages/base/any/kernels/modules/optoe.c b/packages/base/any/kernels/modules/optoe.c
+index 869b7eff887b..f5bcc6a91b46 100644
+--- a/packages/base/any/kernels/modules/optoe.c
++++ b/packages/base/any/kernels/modules/optoe.c
+@@ -1133,19 +1133,6 @@ static int optoe_probe(struct i2c_client *client,
+ 		}
+ 	}
+ 
+-	/* create the sysfs eeprom file */
+-	err = sysfs_create_bin_file(&client->dev.kobj, &optoe->bin);
+-	if (err)
+-		goto err_struct;
+-
+-	optoe->attr_group = optoe_attr_group;
+-
+-	err = sysfs_create_group(&client->dev.kobj, &optoe->attr_group);
+-	if (err) {
+-		dev_err(&client->dev, "failed to create sysfs attribute group.\n");
+-		goto err_struct;
+-	}
+-
+ #ifdef EEPROM_CLASS
+ 	optoe->eeprom_dev = eeprom_device_register(&client->dev,
+ 							chip.eeprom_data);
+@@ -1158,6 +1145,19 @@ static int optoe_probe(struct i2c_client *client,
+ 
+ 	i2c_set_clientdata(client, optoe);
+ 
++	/* create the sysfs eeprom file */
++	err = sysfs_create_bin_file(&client->dev.kobj, &optoe->bin);
++	if (err)
++		goto err_eeprom_cleanup;
++
++	optoe->attr_group = optoe_attr_group;
++
++	err = sysfs_create_group(&client->dev.kobj, &optoe->attr_group);
++	if (err) {
++		dev_err(&client->dev, "failed to create sysfs attribute group.\n");
++		goto err_sysfs_cleanup;
++	}
++
+ 	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
+ 		optoe->bin.size, client->name,
+ 		optoe->bin.write ? "read/write" : "read-only");
+@@ -1171,10 +1171,11 @@ static int optoe_probe(struct i2c_client *client,
+ 
+ 	return 0;
+ 
+-#ifdef EEPROM_CLASS
+ err_sysfs_cleanup:
+-	sysfs_remove_group(&client->dev.kobj, &optoe->attr_group);
+ 	sysfs_remove_bin_file(&client->dev.kobj, &optoe->bin);
++err_eeprom_cleanup:
++#ifdef EEPROM_CLASS
++	eeprom_device_unregister(optoe->eeprom_dev);
+ #endif
+ 
+ err_struct:
+-- 
+2.42.0
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -31,6 +31,7 @@ SRC_URI += " \
            file://onl/0014-ym2561y-add-of-device-match-table.patch \
            file://onl/0015-modules-do-not-call-hwmon_device_register_with_info-.patch \
            file://onl/0016-modules-update-i2c_driver-with-6.1-compatibility.patch \
+           file://onl/0017-optoe-fix-race-in-sysfs-registraton-on-probe.patch \
            file://bigcode/0001-WIP-convert-to-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0002-dynamically-determine-location-of-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0003-avoid-multiple-global-definitions-for-not_empty.patch;patchdir=${SUBMODULE_BIGCODE} \


### PR DESCRIPTION
The optoe driver first creates the sysfs entries and then calls i2c_set_clientdata(), but a very fast userspace may already try to access the sysfs entries before the clientdata was set. This then leads to a NULL pointer access, crashing the kernel.

Fix this by ensuring the sysfs entries are only registered after clientdata is populated.

Fixes the following crash observed on boot:
> Sep 28 18:59:33 accton-as4630-54pe kernel: i2c i2c-18: new_device: Instantiated device optoe2 at 0x50
> Sep 28 18:59:33 accton-as4630-54pe kernel: BUG: kernel NULL pointer dereference, address: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: optoe 18-0050: 33152 byte optoe2 EEPROM, read/write
> Sep 28 18:59:33 accton-as4630-54pe kernel: #PF: supervisor write access in kernel mode
> Sep 28 18:59:33 accton-as4630-54pe kernel: #PF: error_code(0x0002) - not-present page
> Sep 28 18:59:33 accton-as4630-54pe kernel: PGD 0 P4D 0
> Sep 28 18:59:33 accton-as4630-54pe kernel: Oops: 0002 [#1] PREEMPT SMP NOPTI
> Sep 28 18:59:33 accton-as4630-54pe kernel: CPU: 1 PID: 1733 Comm: platform-onl-in Tainted: G           O       6.1.47-yocto-standard-onl #1
> Sep 28 18:59:33 accton-as4630-54pe kernel: Hardware name: Accton AS4630-54PE/AS4630-54PE, BIOS v47.01.01.00 03/14/2021
> Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0010:mutex_lock+0x19/0x30
> Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 00 0f 1f 44 00 00 be 02 00 00 00 e9 e1 f7 ff ff 90 0f 1f 44 00 00 55 48 89 fd e8 e2 de ff ff 31 c0 65 48 8b 14 25 00 ad 01 00 <f0> 48 0f b1 55 00 75 02 5d c3 48 89 ef 5d eb c7 0f 1f 80 00 00 00
> Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 0018:ffffc900002a7df0 EFLAGS: 00010246
> Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff888102e11d93
> Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: ffff888102c26e40 RSI: ffffffffa02c339f RDI: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 0000000000000048 R08: 0000000000000013 R09: 0000000000000001
> Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000001 R11: 0000000000000000 R12: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: R13: fffffffffffffff2 R14: ffff888104406540 R15: ffff888104406560
> Sep 28 18:59:33 accton-as4630-54pe kernel: FS:  00007f7346004740(0000) GS:ffff88846fc80000(0000) knlGS:0000000000000000
> Sep 28 18:59:33 accton-as4630-54pe kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
> Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048 CR3: 000000010113c000 CR4: 00000000003506e0
> Sep 28 18:59:33 accton-as4630-54pe kernel: Call Trace:
> Sep 28 18:59:33 accton-as4630-54pe kernel:  <TASK>
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? __die_body.cold+0x1a/0x1f
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? page_fault_oops+0xae/0x260
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? do_truncate+0x93/0xd0
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? do_user_addr_fault+0x61/0x570
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? exc_page_fault+0x5d/0x120
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? asm_exc_page_fault+0x22/0x30
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ? mutex_lock+0x19/0x30
> Sep 28 18:59:33 accton-as4630-54pe kernel:  set_port_name+0x4c/0x90 [optoe]
> Sep 28 18:59:33 accton-as4630-54pe kernel:  kernfs_fop_write_iter+0x10c/0x1a0
> Sep 28 18:59:33 accton-as4630-54pe kernel:  vfs_write+0x2b4/0x3b0
> Sep 28 18:59:33 accton-as4630-54pe kernel:  ksys_write+0x5f/0xe0
> Sep 28 18:59:33 accton-as4630-54pe kernel:  do_syscall_64+0x35/0x80
> Sep 28 18:59:33 accton-as4630-54pe kernel:  entry_SYSCALL_64_after_hwframe+0x63/0xcd
> Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0033:0x7f7346103377
> Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 0f 00 f7 d8 64 89 02 48 c7 c0 ff ff ff ff eb b7 0f 1f 00 f3 0f 1e fa 64 8b 04 25 18 00 00 00 85 c0 75 10 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 51 c3 48 83 ec 28 48 89 54 24 18 48 89 74 24
> Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 002b:00007ffe849c05b8 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
> Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: ffffffffffffffda RBX: 0000000000000007 RCX: 00007f7346103377
> Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: 0000000000000007 RSI: 000055e3a50ca6b0 RDI: 0000000000000001
> Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 000055e3a50ca6b0 R08: 00007f73461b23e0 R09: 0000000000000000
> Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000007
> Sep 28 18:59:33 accton-as4630-54pe kernel: R13: 00007f73461f85a0 R14: 0000000000000007 R15: 00007f73461f87a0
> Sep 28 18:59:33 accton-as4630-54pe kernel:  </TASK>
> Sep 28 18:59:33 accton-as4630-54pe kernel: Modules linked in: optoe(O) ym2651y(O) x86_64_accton_as4630_54pe_leds(O) x86_64_accton_as4630_54pe_psu(O) x86_64_accton_as4630_54pe_cpld(O) i2c_ismt i2c_i801 i2c_smbus iptable_filter linux_user_bde(O) linux_bcm_knet(O) linux_kernel_bde(O) openvswitch nsh nf_nat
> Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: ---[ end trace 0000000000000000 ]---
> Sep 28 18:59:33 accton-as4630-54pe kernel: RIP: 0010:mutex_lock+0x19/0x30
> Sep 28 18:59:33 accton-as4630-54pe kernel: Code: 00 0f 1f 44 00 00 be 02 00 00 00 e9 e1 f7 ff ff 90 0f 1f 44 00 00 55 48 89 fd e8 e2 de ff ff 31 c0 65 48 8b 14 25 00 ad 01 00 <f0> 48 0f b1 55 00 75 02 5d c3 48 89 ef 5d eb c7 0f 1f 80 00 00 00
> Sep 28 18:59:33 accton-as4630-54pe kernel: RSP: 0018:ffffc900002a7df0 EFLAGS: 00010246
> Sep 28 18:59:33 accton-as4630-54pe kernel: RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffff888102e11d93
> Sep 28 18:59:33 accton-as4630-54pe kernel: RDX: ffff888102c26e40 RSI: ffffffffa02c339f RDI: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: RBP: 0000000000000048 R08: 0000000000000013 R09: 0000000000000001
> Sep 28 18:59:33 accton-as4630-54pe kernel: R10: 0000000000000001 R11: 0000000000000000 R12: 0000000000000048
> Sep 28 18:59:33 accton-as4630-54pe kernel: R13: fffffffffffffff2 R14: ffff888104406540 R15: ffff888104406560
> Sep 28 18:59:33 accton-as4630-54pe kernel: FS:  00007f7346004740(0000) GS:ffff88846fc80000(0000) knlGS:0000000000000000
> Sep 28 18:59:33 accton-as4630-54pe kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
> Sep 28 18:59:33 accton-as4630-54pe kernel: CR2: 0000000000000048 CR3: 000000010113c000 CR4: 00000000003506e0
> Sep 28 18:59:33 accton-as4630-54pe kernel: note: platform-onl-in[1733] exited with irqs disabled

Closes #140