### PR TITLE
linux-yocto-onl/6.1: update to 6.1.60

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.1.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.1.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2023-10-13 08:58:32.432556 for version 6.1.57
+# Generated at 2023-10-30 08:37:04.527071 for version 6.1.60
 
 python check_kernel_cve_status_version() {
-    this_version = "6.1.57"
+    this_version = "6.1.60"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -4839,7 +4839,8 @@ CVE_CHECK_IGNORE += "CVE-2020-27194"
 # fixed-version: Fixed after version 5.6rc4
 CVE_CHECK_IGNORE += "CVE-2020-2732"
 
-# CVE-2020-27418 has no known resolution
+# fixed-version: Fixed after version 5.6rc5
+CVE_CHECK_IGNORE += "CVE-2020-27418"
 
 # fixed-version: Fixed after version 5.10rc1
 CVE_CHECK_IGNORE += "CVE-2020-27673"
@@ -7032,7 +7033,8 @@ CVE_CHECK_IGNORE += "CVE-2023-3106"
 
 # CVE-2023-31084 needs backporting (fixed from 6.4rc3)
 
-# CVE-2023-31085 has no known resolution
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-31085"
 
 # fixed-version: Fixed after version 6.0rc2
 CVE_CHECK_IGNORE += "CVE-2023-3111"
@@ -7149,6 +7151,9 @@ CVE_CHECK_IGNORE += "CVE-2023-34256"
 # cpe-stable-backport: Backported in 6.1.44
 CVE_CHECK_IGNORE += "CVE-2023-34319"
 
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-34324"
+
 # fixed-version: Fixed after version 5.18rc5
 CVE_CHECK_IGNORE += "CVE-2023-3439"
 
@@ -7247,6 +7252,20 @@ CVE_CHECK_IGNORE += "CVE-2023-3866"
 # cpe-stable-backport: Backported in 6.1.40
 CVE_CHECK_IGNORE += "CVE-2023-3867"
 
+# cpe-stable-backport: Backported in 6.1.54
+CVE_CHECK_IGNORE += "CVE-2023-39189"
+
+# CVE-2023-39191 needs backporting (fixed from 6.3rc1)
+
+# cpe-stable-backport: Backported in 6.1.53
+CVE_CHECK_IGNORE += "CVE-2023-39192"
+
+# cpe-stable-backport: Backported in 6.1.53
+CVE_CHECK_IGNORE += "CVE-2023-39193"
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-39194"
+
 # cpe-stable-backport: Backported in 6.1.42
 CVE_CHECK_IGNORE += "CVE-2023-4004"
 
@@ -7257,6 +7276,8 @@ CVE_CHECK_IGNORE += "CVE-2023-4015"
 
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-40283"
+
+# CVE-2023-40791 needs backporting (fixed from 6.5rc6)
 
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-4128"
@@ -7286,7 +7307,8 @@ CVE_CHECK_IGNORE += "CVE-2023-4207"
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-4208"
 
-# CVE-2023-4244 needs backporting (fixed from 6.5rc7)
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-4244"
 
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-4273"
@@ -7297,8 +7319,14 @@ CVE_CHECK_IGNORE += "CVE-2023-42752"
 # cpe-stable-backport: Backported in 6.1.53
 CVE_CHECK_IGNORE += "CVE-2023-42753"
 
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-42754"
+
 # cpe-stable-backport: Backported in 6.1.55
 CVE_CHECK_IGNORE += "CVE-2023-42755"
+
+# fixed-version: only affects 6.4rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2023-42756"
 
 # fixed-version: Fixed after version 5.19rc1
 CVE_CHECK_IGNORE += "CVE-2023-4385"
@@ -7312,13 +7340,30 @@ CVE_CHECK_IGNORE += "CVE-2023-4389"
 # fixed-version: Fixed after version 6.0rc3
 CVE_CHECK_IGNORE += "CVE-2023-4394"
 
+# cpe-stable-backport: Backported in 6.1.40
+CVE_CHECK_IGNORE += "CVE-2023-44466"
+
 # fixed-version: Fixed after version 5.18
 CVE_CHECK_IGNORE += "CVE-2023-4459"
 
-# CVE-2023-4563 needs backporting (fixed from 6.5rc6)
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-4563"
 
 # cpe-stable-backport: Backported in 6.1.47
 CVE_CHECK_IGNORE += "CVE-2023-4569"
+
+# cpe-stable-backport: Backported in 6.1.18
+CVE_CHECK_IGNORE += "CVE-2023-45862"
+
+# cpe-stable-backport: Backported in 6.1.16
+CVE_CHECK_IGNORE += "CVE-2023-45863"
+
+# cpe-stable-backport: Backported in 6.1.53
+CVE_CHECK_IGNORE += "CVE-2023-45871"
+
+# CVE-2023-45898 needs backporting (fixed from 6.6rc1)
+
+# CVE-2023-4610 has no known resolution
 
 # fixed-version: only affects 6.4rc1 onwards
 CVE_CHECK_IGNORE += "CVE-2023-4611"
@@ -7328,6 +7373,9 @@ CVE_CHECK_IGNORE += "CVE-2023-4611"
 # cpe-stable-backport: Backported in 6.1.53
 CVE_CHECK_IGNORE += "CVE-2023-4623"
 
+# fixed-version: Fixed after version 5.14rc1
+CVE_CHECK_IGNORE += "CVE-2023-4732"
+
 # cpe-stable-backport: Backported in 6.1.54
 CVE_CHECK_IGNORE += "CVE-2023-4881"
 
@@ -7336,5 +7384,9 @@ CVE_CHECK_IGNORE += "CVE-2023-4921"
 
 # CVE-2023-5158 has no known resolution
 
-# CVE-2023-5197 needs backporting (fixed from 6.6rc3)
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-5197"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-5345"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.57"
+LINUX_VERSION ?= "6.1.60"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "082280fe94a09462c727fb6e7b0c982efb36dede"
+SRCREV_machine ?= "32c9cdbe383c153af23cfa1df0a352b97ab3df7a"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "8aa5efbc5e5361efc8b11c5aec9b967085613a0b"
+SRCREV_meta ?= "0553e01ca003e82d32d9b85c0275568e8ce67274"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel 6.1 to 6.1.60 and kernel-meta accordingly.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.60
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.59
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.58