### PR TITLE
onl: add packagegroups and split out platform libraries into own packages

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -46,12 +46,7 @@ ONL_PLATFORM_SUPPORT = " \
 
 MACHINE_EXTRA_RDEPENDS += " \
     accton-as4610-poe-mcu-mod \
-    kernel-module-accton-as4610-cpld \
-    kernel-module-accton-as4610-fan \
-    kernel-module-accton-as4610-leds \
-    kernel-module-accton-as4610-psu \
-    kernel-module-optoe \
-    kernel-module-ym2651y \
+    packagegroup-onl-platform-arm-accton-as4610 \
     platform-onl-init \
 "
 

--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -31,33 +31,12 @@ ONL_PLATFORM_SUPPORT = " \
 
 MACHINE_EXTRA_RDEPENDS += " \
     accton-as4630-54pe-poe-mcu-mod \
-    ipmitool \
-    kernel-module-optoe \
-    kernel-module-x86-64-accton-as4630-54pe-cpld \
-    kernel-module-x86-64-accton-as4630-54pe-leds \
-    kernel-module-x86-64-accton-as4630-54pe-psu \
-    kernel-module-x86-64-accton-as4630-54te-cpld \
-    kernel-module-x86-64-accton-as4630-54te-leds \
-    kernel-module-x86-64-accton-as4630-54te-psu \
-    kernel-module-x86-64-accton-as7726-32x-cpld \
-    kernel-module-x86-64-accton-as7726-32x-fan \
-    kernel-module-x86-64-accton-as7726-32x-leds \
-    kernel-module-x86-64-accton-as7726-32x-psu \
-    kernel-module-x86-64-accton-as5835-54x-cpld \
-    kernel-module-x86-64-accton-as5835-54x-fan \
-    kernel-module-x86-64-accton-as5835-54x-leds \
-    kernel-module-x86-64-accton-as5835-54x-psu \
-    kernel-module-x86-64-delta-ag7648-cpld-mux-1 \
-    kernel-module-x86-64-delta-ag7648-cpld-mux-2 \
-    kernel-module-x86-64-delta-ag7648-i2c-mux-setting \
-    kernel-module-dni-ag5648-psu \
-    kernel-module-dni-ag5648-sfp \
-    kernel-module-dni-emc2305 \
-    kernel-module-i2c-cpld \
-    kernel-module-mc24lc64t \
-    kernel-module-optoe \
-    kernel-module-questone2a-baseboard-cpld \
-    kernel-module-questone2a-switchboard \
-    kernel-module-ym2651y \
+    packagegroup-onl-platform-x86-64-accton-as4630-54pe \
+    packagegroup-onl-platform-x86-64-accton-as4630-54te \
+    packagegroup-onl-platform-x86-64-accton-as5835-54x \
+    packagegroup-onl-platform-x86-64-accton-as7726-32x \
+    packagegroup-onl-platform-x86-64-cel-questone-2a \
+    packagegroup-onl-platform-x86-64-delta-ag5648 \
+    packagegroup-onl-platform-x86-64-delta-ag7648 \
     platform-onl-init \
 "

--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -36,6 +36,30 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 PROVIDES += "libonlp libonlp-platform libonlp-platform-defaults"
 INSANE_SKIP:${PN} = "file-rdeps"
 
+PACKAGES_DYNAMIC = "^libonlp-.*"
+
+python populate_packages:prepend () {
+    # ONL uses dashes in the ARCH name
+    arch=d.getVar('TRANSLATED_TARGET_ARCH')
+    name_prefix='libonlp-' + arch
+
+    # prevent Yocto from being "helpful" and renaming packages based on the
+    # included lib's filename
+    def debian_noautoname(file, pkg, pattern, format, basename):
+        d.setVar('DEBIAN_NOAUTONAME:%s' % pkg, "1")
+
+    # only split out platform libraries (having arch in their name)
+    do_split_packages(
+        d, '${libdir}', name_prefix + '-(.*).so.1', name_prefix + '-%s',
+        'libonlp (' + arch + '-%s)', prepend=True, hook=debian_noautoname)
+    # create -dev packages as well for the .so symlink, else onl-dev will depend
+    # on everything
+    do_split_packages(
+        d, '${libdir}', name_prefix + '-(.*).so$', name_prefix + '-%s-dev',
+        'libonlp (' + arch + '-%s) - Development files', prepend=True,
+        allow_links=True)
+}
+
 #### TODO onl.bbclass?
 ONL = "${S}"
 

--- a/recipes-extended/onl/packagegroup-onl-platform-arm.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-arm.bb
@@ -16,4 +16,6 @@ RDEPENDS:${PN}-accton-as4610 = "\
     kernel-module-accton-as4610-psu \
     kernel-module-optoe \
     kernel-module-ym2651y \
+    libonlp-arm-accton-as4610-30 \
+    libonlp-arm-accton-as4610-54 \
 "

--- a/recipes-extended/onl/packagegroup-onl-platform-arm.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-arm.bb
@@ -1,0 +1,19 @@
+SUMMARY = "packagroups for ONL arm platform support"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit packagegroup
+
+# arm platform support
+PACKAGES = "\
+    ${PN}-accton-as4610 \
+"
+
+RDEPENDS:${PN}-accton-as4610 = "\
+    kernel-module-accton-as4610-cpld \
+    kernel-module-accton-as4610-fan \
+    kernel-module-accton-as4610-leds \
+    kernel-module-accton-as4610-psu \
+    kernel-module-optoe \
+    kernel-module-ym2651y \
+"

--- a/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN}-accton-as4630-54pe = "\
     kernel-module-x86-64-accton-as4630-54pe-leds \
     kernel-module-x86-64-accton-as4630-54pe-psu \
     kernel-module-ym2651y \
+    libonlp-x86-64-accton-as4630-54pe \
 "
 
 RDEPENDS:${PN}-accton-as4630-54te = "\
@@ -29,6 +30,7 @@ RDEPENDS:${PN}-accton-as4630-54te = "\
     kernel-module-x86-64-accton-as4630-54te-leds \
     kernel-module-x86-64-accton-as4630-54te-psu \
     kernel-module-ym2651y \
+    libonlp-x86-64-accton-as4630-54te \
 "
 
 RDEPENDS:${PN}-accton-as7726-32x = " \
@@ -38,6 +40,7 @@ RDEPENDS:${PN}-accton-as7726-32x = " \
     kernel-module-x86-64-accton-as7726-32x-leds \
     kernel-module-x86-64-accton-as7726-32x-psu \
     kernel-module-ym2651y \
+    libonlp-x86-64-accton-as7726-32x \
 "
 
 RDEPENDS:${PN}-accton-as5835-54x = " \
@@ -47,6 +50,7 @@ RDEPENDS:${PN}-accton-as5835-54x = " \
     kernel-module-x86-64-accton-as5835-54x-leds \
     kernel-module-x86-64-accton-as5835-54x-psu \
     kernel-module-ym2651y \
+    libonlp-x86-64-accton-as5835-54x \
 "
 
 RDEPENDS:${PN}-delta-ag5648 = " \
@@ -54,12 +58,14 @@ RDEPENDS:${PN}-delta-ag5648 = " \
     kernel-module-dni-ag5648-sfp \
     kernel-module-dni-emc2305 \
     kernel-module-i2c-cpld \
+    libonlp-x86-64-delta-ag5648 \
 "
 
 RDEPENDS:${PN}-delta-ag7648 = " \
     kernel-module-x86-64-delta-ag7648-cpld-mux-1 \
     kernel-module-x86-64-delta-ag7648-cpld-mux-2 \
     kernel-module-x86-64-delta-ag7648-i2c-mux-setting \
+    libonlp-x86-64-delta-ag7648 \
 "
 
 RDEPENDS:${PN}-cel-questone-2a = " \
@@ -68,4 +74,5 @@ RDEPENDS:${PN}-cel-questone-2a = " \
     kernel-module-mc24lc64t \
     kernel-module-questone2a-baseboard-cpld \
     kernel-module-questone2a-switchboard \
+    libonlp-x86-64-cel-questone-2a \
 "

--- a/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
@@ -1,0 +1,71 @@
+SUMMARY = "packagroups for ONL x86-64 platform support"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit packagegroup
+
+# x86-64 platform support
+PACKAGES = "\
+    ${PN}-accton-as4630-54pe \
+    ${PN}-accton-as4630-54te \
+    ${PN}-accton-as5835-54x \
+    ${PN}-accton-as7726-32x \
+    ${PN}-cel-questone-2a \
+    ${PN}-delta-ag5648 \
+    ${PN}-delta-ag7648 \
+"
+
+RDEPENDS:${PN}-accton-as4630-54pe = "\
+    kernel-module-optoe \
+    kernel-module-x86-64-accton-as4630-54pe-cpld \
+    kernel-module-x86-64-accton-as4630-54pe-leds \
+    kernel-module-x86-64-accton-as4630-54pe-psu \
+    kernel-module-ym2651y \
+"
+
+RDEPENDS:${PN}-accton-as4630-54te = "\
+    kernel-module-optoe \
+    kernel-module-x86-64-accton-as4630-54te-cpld \
+    kernel-module-x86-64-accton-as4630-54te-leds \
+    kernel-module-x86-64-accton-as4630-54te-psu \
+    kernel-module-ym2651y \
+"
+
+RDEPENDS:${PN}-accton-as7726-32x = " \
+    kernel-module-optoe \
+    kernel-module-x86-64-accton-as7726-32x-cpld \
+    kernel-module-x86-64-accton-as7726-32x-fan \
+    kernel-module-x86-64-accton-as7726-32x-leds \
+    kernel-module-x86-64-accton-as7726-32x-psu \
+    kernel-module-ym2651y \
+"
+
+RDEPENDS:${PN}-accton-as5835-54x = " \
+    kernel-module-optoe \
+    kernel-module-x86-64-accton-as5835-54x-cpld \
+    kernel-module-x86-64-accton-as5835-54x-fan \
+    kernel-module-x86-64-accton-as5835-54x-leds \
+    kernel-module-x86-64-accton-as5835-54x-psu \
+    kernel-module-ym2651y \
+"
+
+RDEPENDS:${PN}-delta-ag5648 = " \
+    kernel-module-dni-ag5648-psu \
+    kernel-module-dni-ag5648-sfp \
+    kernel-module-dni-emc2305 \
+    kernel-module-i2c-cpld \
+"
+
+RDEPENDS:${PN}-delta-ag7648 = " \
+    kernel-module-x86-64-delta-ag7648-cpld-mux-1 \
+    kernel-module-x86-64-delta-ag7648-cpld-mux-2 \
+    kernel-module-x86-64-delta-ag7648-i2c-mux-setting \
+"
+
+RDEPENDS:${PN}-cel-questone-2a = " \
+    ipmitool \
+    kernel-module-optoe \
+    kernel-module-mc24lc64t \
+    kernel-module-questone2a-baseboard-cpld \
+    kernel-module-questone2a-switchboard \
+"


### PR DESCRIPTION
To better compartmentalize the ONL platform support parts, add packagegroups for each supported platform, and split out the platform libraries from the main onl package.

This will allow adding more platforms to build, but not include in the image to make it easier to lay groundwork for adding new platform support in the future.