### PR TITLE
packagegroup-onl-platform-*: set arch

### DIFF
--- a/recipes-extended/onl/packagegroup-onl-platform-arm.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-arm.bb
@@ -2,6 +2,8 @@ SUMMARY = "packagroups for ONL arm platform support"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit packagegroup
 
 # arm platform support

--- a/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
+++ b/recipes-extended/onl/packagegroup-onl-platform-x86-64.bb
@@ -2,6 +2,8 @@ SUMMARY = "packagroups for ONL x86-64 platform support"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit packagegroup
 
 # x86-64 platform support


### PR DESCRIPTION
All referenced packages are arch-specific, so it does not make sense for the packagegroups themselves to be generic.