### PR TITLE
linux-yocto-onl/6.1: update to 6.1.75

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.1.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.1.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2023-10-30 08:37:04.527071 for version 6.1.60
+# Generated at 2024-01-29 10:27:20.474080 for version 6.1.75
 
 python check_kernel_cve_status_version() {
-    this_version = "6.1.60"
+    this_version = "6.1.75"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -6557,7 +6557,7 @@ CVE_CHECK_IGNORE += "CVE-2022-43945"
 
 # CVE-2022-44033 needs backporting (fixed from 6.4rc1)
 
-# CVE-2022-44034 has no known resolution
+# CVE-2022-44034 needs backporting (fixed from 6.4rc1)
 
 # CVE-2022-4543 has no known resolution
 
@@ -6641,6 +6641,9 @@ CVE_CHECK_IGNORE += "CVE-2022-48425"
 
 # cpe-stable-backport: Backported in 6.1.40
 CVE_CHECK_IGNORE += "CVE-2022-48502"
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2022-48619"
 
 # fixed-version: Fixed after version 5.0rc1
 CVE_CHECK_IGNORE += "CVE-2023-0030"
@@ -6731,7 +6734,8 @@ CVE_CHECK_IGNORE += "CVE-2023-1118"
 # cpe-stable-backport: Backported in 6.1.33
 CVE_CHECK_IGNORE += "CVE-2023-1192"
 
-# CVE-2023-1193 has no known resolution
+# cpe-stable-backport: Backported in 6.1.71
+CVE_CHECK_IGNORE += "CVE-2023-1193"
 
 # cpe-stable-backport: Backported in 6.1.34
 CVE_CHECK_IGNORE += "CVE-2023-1194"
@@ -6762,6 +6766,8 @@ CVE_CHECK_IGNORE += "CVE-2023-1382"
 
 # fixed-version: Fixed after version 5.11rc4
 CVE_CHECK_IGNORE += "CVE-2023-1390"
+
+# CVE-2023-1476 has no known resolution
 
 # cpe-stable-backport: Backported in 6.1.13
 CVE_CHECK_IGNORE += "CVE-2023-1513"
@@ -7177,7 +7183,8 @@ CVE_CHECK_IGNORE += "CVE-2023-35824"
 # cpe-stable-backport: Backported in 6.1.28
 CVE_CHECK_IGNORE += "CVE-2023-35826"
 
-# CVE-2023-35827 has no known resolution
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-35827"
 
 # cpe-stable-backport: Backported in 6.1.28
 CVE_CHECK_IGNORE += "CVE-2023-35828"
@@ -7266,6 +7273,12 @@ CVE_CHECK_IGNORE += "CVE-2023-39193"
 # cpe-stable-backport: Backported in 6.1.47
 CVE_CHECK_IGNORE += "CVE-2023-39194"
 
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2023-39197"
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-39198"
+
 # cpe-stable-backport: Backported in 6.1.42
 CVE_CHECK_IGNORE += "CVE-2023-4004"
 
@@ -7277,7 +7290,8 @@ CVE_CHECK_IGNORE += "CVE-2023-4015"
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-40283"
 
-# CVE-2023-40791 needs backporting (fixed from 6.5rc6)
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-40791"
 
 # cpe-stable-backport: Backported in 6.1.45
 CVE_CHECK_IGNORE += "CVE-2023-4128"
@@ -7361,9 +7375,11 @@ CVE_CHECK_IGNORE += "CVE-2023-45863"
 # cpe-stable-backport: Backported in 6.1.53
 CVE_CHECK_IGNORE += "CVE-2023-45871"
 
-# CVE-2023-45898 needs backporting (fixed from 6.6rc1)
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-45898"
 
-# CVE-2023-4610 has no known resolution
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-4610"
 
 # fixed-version: only affects 6.4rc1 onwards
 CVE_CHECK_IGNORE += "CVE-2023-4611"
@@ -7372,6 +7388,14 @@ CVE_CHECK_IGNORE += "CVE-2023-4611"
 
 # cpe-stable-backport: Backported in 6.1.53
 CVE_CHECK_IGNORE += "CVE-2023-4623"
+
+# cpe-stable-backport: Backported in 6.1.60
+CVE_CHECK_IGNORE += "CVE-2023-46813"
+
+# cpe-stable-backport: Backported in 6.1.61
+CVE_CHECK_IGNORE += "CVE-2023-46862"
+
+# CVE-2023-47233 has no known resolution
 
 # fixed-version: Fixed after version 5.14rc1
 CVE_CHECK_IGNORE += "CVE-2023-4732"
@@ -7382,11 +7406,108 @@ CVE_CHECK_IGNORE += "CVE-2023-4881"
 # cpe-stable-backport: Backported in 6.1.54
 CVE_CHECK_IGNORE += "CVE-2023-4921"
 
-# CVE-2023-5158 has no known resolution
+# CVE-2023-50431 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.62
+CVE_CHECK_IGNORE += "CVE-2023-5090"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-5158"
+
+# cpe-stable-backport: Backported in 6.1.70
+CVE_CHECK_IGNORE += "CVE-2023-51779"
+
+# cpe-stable-backport: Backported in 6.1.60
+CVE_CHECK_IGNORE += "CVE-2023-5178"
+
+# cpe-stable-backport: Backported in 6.1.69
+CVE_CHECK_IGNORE += "CVE-2023-51780"
+
+# cpe-stable-backport: Backported in 6.1.69
+CVE_CHECK_IGNORE += "CVE-2023-51781"
+
+# cpe-stable-backport: Backported in 6.1.69
+CVE_CHECK_IGNORE += "CVE-2023-51782"
 
 # cpe-stable-backport: Backported in 6.1.56
 CVE_CHECK_IGNORE += "CVE-2023-5197"
 
 # cpe-stable-backport: Backported in 6.1.56
 CVE_CHECK_IGNORE += "CVE-2023-5345"
+
+# fixed-version: only affects 6.2 onwards
+CVE_CHECK_IGNORE += "CVE-2023-5633"
+
+# cpe-stable-backport: Backported in 6.1.60
+CVE_CHECK_IGNORE += "CVE-2023-5717"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-5972"
+
+# CVE-2023-6039 needs backporting (fixed from 6.5rc5)
+
+# fixed-version: Fixed after version 5.18rc1
+CVE_CHECK_IGNORE += "CVE-2023-6040"
+
+# fixed-version: only affects 6.6rc3 onwards
+CVE_CHECK_IGNORE += "CVE-2023-6111"
+
+# cpe-stable-backport: Backported in 6.1.65
+CVE_CHECK_IGNORE += "CVE-2023-6121"
+
+# cpe-stable-backport: Backported in 6.1.54
+CVE_CHECK_IGNORE += "CVE-2023-6176"
+
+# CVE-2023-6238 has no known resolution
+
+# CVE-2023-6270 has no known resolution
+
+# CVE-2023-6356 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.68
+CVE_CHECK_IGNORE += "CVE-2023-6531"
+
+# CVE-2023-6535 has no known resolution
+
+# CVE-2023-6536 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-6546"
+
+# CVE-2023-6560 needs backporting (fixed from 6.7rc4)
+
+# cpe-stable-backport: Backported in 6.1.70
+CVE_CHECK_IGNORE += "CVE-2023-6606"
+
+# CVE-2023-6610 needs backporting (fixed from 6.7rc7)
+
+# cpe-stable-backport: Backported in 6.1.68
+CVE_CHECK_IGNORE += "CVE-2023-6622"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-6679"
+
+# cpe-stable-backport: Backported in 6.1.68
+CVE_CHECK_IGNORE += "CVE-2023-6817"
+
+# cpe-stable-backport: Backported in 6.1.68
+CVE_CHECK_IGNORE += "CVE-2023-6931"
+
+# cpe-stable-backport: Backported in 6.1.66
+CVE_CHECK_IGNORE += "CVE-2023-6932"
+
+# CVE-2023-7042 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.18
+CVE_CHECK_IGNORE += "CVE-2023-7192"
+
+# fixed-version: only affects 6.5rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-0193"
+
+# CVE-2024-0340 needs backporting (fixed from 6.4rc6)
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-0443"
+
+# Skipping dd=CVE-2023-1476, no affected_versions
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.60"
+LINUX_VERSION ?= "6.1.75"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "32c9cdbe383c153af23cfa1df0a352b97ab3df7a"
+SRCREV_machine ?= "883d1a9562083922c6d293e9adad8cca4626adf3"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "0553e01ca003e82d32d9b85c0275568e8ce67274"
+SRCREV_meta ?= "7ca3655cbccce6330c6f947abf667b5e3ae5350b"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
We haven't update the kernel in a while so let's update it to 6.1.75 and
kernel-meta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.75
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.74
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.73
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.72
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.71
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.70
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.69
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.68
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.67
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.66
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.65
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.64
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.63
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.62
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.61