### PR TITLE
switch to kernel 6.6

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for generic armel iProc ONL image
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
-PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
+PREFERRED_VERSION_linux-yocto-onl ?= "6.6%"
 
 KMACHINE:generic-armel-iproc = "armel-iproc"
 KERNEL_FEATURES += "bsp/armel-iproc"

--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for generic x86-64 ONL image
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto-onl"
-PREFERRED_VERSION_linux-yocto-onl ?= "6.1%"
+PREFERRED_VERSION_linux-yocto-onl ?= "6.6%"
 
 KMACHINE:generic-x86-64 = "x86_64-intel"
 KERNEL_FEATURES += "bsp/x86_64-intel"

--- a/recipes-extended/onl/files/cel-questone-2a/0001-add-celestica-questone-2a.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0001-add-celestica-questone-2a.patch
@@ -1,7 +1,7 @@
 From 20c41467cb9446b73d349c4903c4498e4160ae77 Mon Sep 17 00:00:00 2001
 From: Peerapong Jaipakdee <pjaipakdee@celestica.com>
 Date: Mon, 14 Sep 2020 17:51:55 +0700
-Subject: [PATCH 1/7] add celestica questone 2a
+Subject: [PATCH 1/8] add celestica questone 2a
 
 Add Celestica Questone-2a taken from [1], all commits squashed into one
 for easier addition.

--- a/recipes-extended/onl/files/cel-questone-2a/0002-questone-2a-fix-ignoring-unused-result-warnings.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0002-questone-2a-fix-ignoring-unused-result-warnings.patch
@@ -1,7 +1,7 @@
 From 692acdbf4a993151288ce806b1b2bf1f4a1c82de Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 23 Mar 2021 11:20:55 +0100
-Subject: [PATCH 2/7] questone-2a: fix ignoring unused result warnings
+Subject: [PATCH 2/8] questone-2a: fix ignoring unused result warnings
 
 |     Compiling[ release ]: x86_64_cel_questone_2a::platform.c
 | ../../../../../../../../../questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/platform.c: In function 'is_cache_exist':

--- a/recipes-extended/onl/files/cel-questone-2a/0003-cel-questone-2a-delete-unused-global-variables.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0003-cel-questone-2a-delete-unused-global-variables.patch
@@ -1,7 +1,7 @@
 From b6fc4dab5010566ca09ba77b526d4504bd3edffa Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 1 Jul 2022 16:01:24 +0200
-Subject: [PATCH 3/7] cel-questone-2a: delete unused global variables
+Subject: [PATCH 3/8] cel-questone-2a: delete unused global variables
 
 Delete unused global variables to avoid the following build error:
 

--- a/recipes-extended/onl/files/cel-questone-2a/0004-cel-questone-2a-fix-various-issues-in-questone-2a_sw.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0004-cel-questone-2a-fix-various-issues-in-questone-2a_sw.patch
@@ -1,7 +1,7 @@
 From 9c741e5b9793dbf529cda24b1023249e2f0099d3 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 5 Aug 2022 10:43:37 +0000
-Subject: [PATCH 4/7] cel-questone-2a: fix various issues in
+Subject: [PATCH 4/8] cel-questone-2a: fix various issues in
  questone-2a_switchboard
 
 Update the code to compile against newer kernels and fix various issues:

--- a/recipes-extended/onl/files/cel-questone-2a/0005-cel-questone-2a-do-not-build-optoe.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0005-cel-questone-2a-do-not-build-optoe.patch
@@ -1,7 +1,7 @@
 From dfca372096505a9aa1b34044a4dc882d76431f1b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 5 Aug 2022 11:34:17 +0000
-Subject: [PATCH 5/7] cel-questone-2a: do not build optoe
+Subject: [PATCH 5/8] cel-questone-2a: do not build optoe
 
 No reason to use the local copy, just use the onl one that is more
 recent.

--- a/recipes-extended/onl/files/cel-questone-2a/0006-cel-questone-2a-update-i2c_drivers-with-6.1-compatib.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0006-cel-questone-2a-update-i2c_drivers-with-6.1-compatib.patch
@@ -1,7 +1,7 @@
 From df72009cc00f3a10aed0e23d653bdaff67da8029 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 22 Nov 2022 13:07:46 +0100
-Subject: [PATCH 6/7] cel-questone-2a: update i2c_drivers with 6.1
+Subject: [PATCH 6/8] cel-questone-2a: update i2c_drivers with 6.1
  compatibility
 
 i2c_remove changes its return type from int to void, so we need to

--- a/recipes-extended/onl/files/cel-questone-2a/0007-cel-questone-2a-update-i2c_drivers-with-6.3-compatib.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0007-cel-questone-2a-update-i2c_drivers-with-6.3-compatib.patch
@@ -1,7 +1,7 @@
 From 1be6ea265034a85992562842891f57b7a81df433 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 21 Nov 2023 14:40:09 +0100
-Subject: [PATCH 7/7] cel-questone-2a: update i2c_drivers with 6.3
+Subject: [PATCH 7/8] cel-questone-2a: update i2c_drivers with 6.3
  compatibility
 
 i2c_probe() dropped its i2c_device_id* argument, so we need to provide

--- a/recipes-extended/onl/files/cel-questone-2a/0007-cel-questone-2a-update-i2c_drivers-with-6.3-compatib.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0007-cel-questone-2a-update-i2c_drivers-with-6.3-compatib.patch
@@ -1,4 +1,4 @@
-From eb85a682cf7c099c6bbc51988d2711f35f2f90db Mon Sep 17 00:00:00 2001
+From 1be6ea265034a85992562842891f57b7a81df433 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 21 Nov 2023 14:40:09 +0100
 Subject: [PATCH 7/7] cel-questone-2a: update i2c_drivers with 6.3
@@ -26,10 +26,10 @@ struct i2c_driver DRIVER@p = {
 
 @i depends on r@
 @@
-#include <linux/version.h>
+ #include <linux/version.h>
 @depends on r && !i@
 @@
-#include <...>
+ #include <...>
 +#include <linux/version.h>
 @depends on r@
 identifier r.probe_fn;
@@ -46,14 +46,19 @@ int probe_fn(...) {...}
 
 applied with
 
-  spatch --smpl-spacing --sp-file 6.3-i2c_probe_sig.cocci --in-place --dir packages/
+  spatch --allow-inconsistent-paths --smpl-spacing --sp-file 6.3-i2c_probe_sig.cocci --in-place --dir packages/
+
+(not sure where the inconsistent paths come from, but they get triggered
+in optoe.c and sff_8436_eeprom.c)
 
 Result taken as is, without any code style fixes.
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  .../x86-64/questone-2a/modules/builds/src/mc24lc64t.c  | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ .../x86-64/questone-2a/modules/builds/src/optoe.c      | 10 ++++++++++
+ .../questone-2a/modules/builds/src/sff_8436_eeprom.c   | 10 ++++++++++
+ 3 files changed, 30 insertions(+)
 
 diff --git a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/mc24lc64t.c b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/mc24lc64t.c
 index 7901297137f4..4d0b461c2800 100644
@@ -84,6 +89,64 @@ index 7901297137f4..4d0b461c2800 100644
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
          .remove = mc24lc64t_remove_6_1,
  #else
+diff --git a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/optoe.c b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/optoe.c
+index 76ee8aee17db..e26b512294f5 100644
+--- a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/optoe.c
++++ b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/optoe.c
+@@ -1117,6 +1117,12 @@ exit:
+ 
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int optoe_probe_6_3(struct i2c_client *client)
++{
++	return optoe_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /*-------------------------------------------------------------------------*/
+ 
+@@ -1125,7 +1131,11 @@ static struct i2c_driver optoe_driver = {
+ 		.name = "optoe",
+ 		.owner = THIS_MODULE,
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = optoe_probe_6_3,
++#else
+ 	.probe = optoe_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = optoe_remove_6_1,
+ #else
+diff --git a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/sff_8436_eeprom.c b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/sff_8436_eeprom.c
+index 191cc65e6755..216ee4e639f2 100644
+--- a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/sff_8436_eeprom.c
++++ b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/sff_8436_eeprom.c
+@@ -953,6 +953,12 @@ exit:
+ 
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int sff_8436_eeprom_probe_6_3(struct i2c_client *client)
++{
++	return sff_8436_eeprom_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /*-------------------------------------------------------------------------*/
+ 
+@@ -961,7 +967,11 @@ static struct i2c_driver sff_8436_driver = {
+ 		.name = "sff8436",
+ 		.owner = THIS_MODULE,
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = sff_8436_eeprom_probe_6_3,
++#else
+ 	.probe = sff_8436_eeprom_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = sff_8436_remove_6_1,
+ #else
 -- 
-2.42.1
+2.43.0
 

--- a/recipes-extended/onl/files/cel-questone-2a/0008-cel-questone-2a-update-class_create-usage-for-6.4.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0008-cel-questone-2a-update-class_create-usage-for-6.4.patch
@@ -1,0 +1,69 @@
+From 526182fa397a7b8df5ee42debac4b9e84c08c613 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 7 Feb 2024 17:25:24 +0100
+Subject: [PATCH 8/8] cel-questone-2a: update class_create() usage for 6.4
+
+Update class_create() usage for 6.4 which lost its first parameter.
+
+// <smpl>
+@r@
+expression ret;
+expression E1,E2;
+@@
+ret = class_create(E1, E2);
+@depends on r@
+expression ret;
+expression E1,E2;
+@@
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++ret = class_create(E2);
++#else
+ ret = class_create(E1, E2);
++#endif
+@i depends on r@
+@@
+ #include <linux/version.h>
+@depends on r && !i@
+@@
+ #include <...>
++#include <linux/version.h>
+// </smpl>
+
+applied with
+
+  spatch --sp-file 6.4-class_create.cocci --in-place --dir packages/
+
+Result taken as is, without any code style fixes.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../questone-2a/modules/builds/src/questone2a_switchboard.c  | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/questone2a_switchboard.c b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/questone2a_switchboard.c
+index cbe1dd0735ee..e867c980aa18 100644
+--- a/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/questone2a_switchboard.c
++++ b/packages/platforms/celestica/x86-64/questone-2a/modules/builds/src/questone2a_switchboard.c
+@@ -50,6 +50,7 @@
+ #include <linux/fs.h>
+ #include <linux/uaccess.h>
+ #include <linux/jiffies.h>
++#include <linux/version.h>
+ 
+ 
+ 
+@@ -2024,7 +2025,11 @@ static int fpgafw_init(void){
+    printk(KERN_INFO "Device registered correctly with major number %d\n", majorNumber);
+ 
+    // Register the device class
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++   fpgafwclass = class_create(CLASS_NAME);
++#else
+    fpgafwclass = class_create(THIS_MODULE, CLASS_NAME);
++#endif
+    if (IS_ERR(fpgafwclass)){                // Check for error and clean up if there is
+       unregister_chrdev(majorNumber, DEVICE_NAME);
+       printk(KERN_ALERT "Failed to register device class\n");
+-- 
+2.43.0
+

--- a/recipes-extended/onl/files/onl/0001-platform_manager-do-not-ignore-write-return-value.patch
+++ b/recipes-extended/onl/files/onl/0001-platform_manager-do-not-ignore-write-return-value.patch
@@ -1,7 +1,7 @@
 From 19a0c4e9d37a58bf39765a10def62256263143d8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 19 Mar 2021 12:07:35 +0100
-Subject: [PATCH 01/17] platform_manager: do not ignore write return value
+Subject: [PATCH 01/18] platform_manager: do not ignore write return value
 
 If the write fails, the other thread will not be notified, so we should
 not try to wait for it.

--- a/recipes-extended/onl/files/onl/0002-file-check-unix-socket-path-is-short-enough.patch
+++ b/recipes-extended/onl/files/onl/0002-file-check-unix-socket-path-is-short-enough.patch
@@ -1,7 +1,7 @@
 From bf0e7acf7bc12292b8a57b74e1b6f2e87dde57c0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 19 Apr 2021 16:23:26 +0200
-Subject: [PATCH 02/17] file: check unix socket path is short enough
+Subject: [PATCH 02/18] file: check unix socket path is short enough
 
 Add a length check for path before attempting to copy it. And because
 gcc is not smart enough, move strncpy to the check, else it will fail to

--- a/recipes-extended/onl/files/onl/0003-ym2651y-fix-update-when-MFR_MODEL_OPTION-is-uninmple.patch
+++ b/recipes-extended/onl/files/onl/0003-ym2651y-fix-update-when-MFR_MODEL_OPTION-is-uninmple.patch
@@ -1,7 +1,7 @@
 From 57868d941546cbe28a0db9d7d4d3db60fa29fa2b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 13 May 2022 12:24:11 +0200
-Subject: [PATCH 03/17] ym2651y: fix update when MFR_MODEL_OPTION is
+Subject: [PATCH 03/18] ym2651y: fix update when MFR_MODEL_OPTION is
  uninmplemented
 
 Not every PSU implements the MFR_MODEL_OPTION register. If it does not

--- a/recipes-extended/onl/files/onl/0004-WIP-tools-convert-to-python3.patch
+++ b/recipes-extended/onl/files/onl/0004-WIP-tools-convert-to-python3.patch
@@ -1,7 +1,7 @@
 From df6d99bf26a8e8cca41633b9af00b6c84ce10607 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 16 Jun 2022 10:30:25 +0200
-Subject: [PATCH 04/17] WIP: tools: convert to python3
+Subject: [PATCH 04/18] WIP: tools: convert to python3
 
 Convert the build code from python2 to python3:
 

--- a/recipes-extended/onl/files/onl/0005-dynamically-determine-location-of-python3.patch
+++ b/recipes-extended/onl/files/onl/0005-dynamically-determine-location-of-python3.patch
@@ -1,7 +1,7 @@
 From 996cf13c0506b88549bb30f43d2bf52f8d91dc37 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 16 Jun 2022 10:32:16 +0200
-Subject: [PATCH 05/17] dynamically determine location of python3
+Subject: [PATCH 05/18] dynamically determine location of python3
 
 To allow running the scripts within a distro context with custom python
 search paths, replace the hardcoded location of the python3 binary with

--- a/recipes-extended/onl/files/onl/0006-onlpm-hardcode-supported-arches.patch
+++ b/recipes-extended/onl/files/onl/0006-onlpm-hardcode-supported-arches.patch
@@ -1,7 +1,7 @@
 From 6f7181c0f752418627790dca797b1fad1c56302f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 18 May 2022 16:21:02 +0200
-Subject: [PATCH 06/17] onlpm: hardcode supported arches
+Subject: [PATCH 06/18] onlpm: hardcode supported arches
 
 For yocto we don't provide a dpkg, so we need to hardcode the supported
 arches.

--- a/recipes-extended/onl/files/onl/0007-onlpm-add-an-argument-for-just-printing-the-builddir.patch
+++ b/recipes-extended/onl/files/onl/0007-onlpm-add-an-argument-for-just-printing-the-builddir.patch
@@ -1,7 +1,7 @@
 From 5abd34f18352748a1dcd5bcb2144bacd931f59a8 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 18 May 2022 15:49:13 +0200
-Subject: [PATCH 07/17] onlpm: add an argument for just printing the builddirs
+Subject: [PATCH 07/18] onlpm: add an argument for just printing the builddirs
 
 To allow building without packaging, we need to know the appropriate
 build dir for passing to make.

--- a/recipes-extended/onl/files/onl/0008-onlpm-allow-overriding-the-dist-codename-from-enviro.patch
+++ b/recipes-extended/onl/files/onl/0008-onlpm-allow-overriding-the-dist-codename-from-enviro.patch
@@ -1,7 +1,7 @@
 From 509f7a7325348408e6b2b1d92ece1224c19e1056 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Thu, 23 Jun 2022 11:13:22 +0200
-Subject: [PATCH 08/17] onlpm: allow overriding the dist codename from
+Subject: [PATCH 08/18] onlpm: allow overriding the dist codename from
  environment
 
 Yocto does not provide a lsb_release module, so add support for

--- a/recipes-extended/onl/files/onl/0009-tools-replace-yaml.load-with-yaml.full_load.patch
+++ b/recipes-extended/onl/files/onl/0009-tools-replace-yaml.load-with-yaml.full_load.patch
@@ -1,7 +1,7 @@
 From 9013e00f506f73b45a560c161881c98c05a6bd78 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 28 Jun 2022 11:00:16 +0200
-Subject: [PATCH 9/17] tools: replace yaml.load with yaml.full_load
+Subject: [PATCH 9/18] tools: replace yaml.load with yaml.full_load
 
 yaml.load without loader is deprecated and unsafe [1], and was removed
 with PyYAML 6.0.

--- a/recipes-extended/onl/files/onl/0010-optoe-allow-compilation-with-linux-5.5-and-newer.patch
+++ b/recipes-extended/onl/files/onl/0010-optoe-allow-compilation-with-linux-5.5-and-newer.patch
@@ -1,7 +1,7 @@
 From 7cf9dead170ea3269903a131e503b9aea2b376c2 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 20 May 2022 10:44:58 +0200
-Subject: [PATCH 10/17] optoe: allow compilation with linux 5.5 and newer
+Subject: [PATCH 10/18] optoe: allow compilation with linux 5.5 and newer
 
 i2c_new_dummy was dropped in linux in favour of i2c_new_dummy_device,
 which was introduced in 5.3.

--- a/recipes-extended/onl/files/onl/0011-kmodbuild.sh-don-t-treat-undefined-symbols-as-errors.patch
+++ b/recipes-extended/onl/files/onl/0011-kmodbuild.sh-don-t-treat-undefined-symbols-as-errors.patch
@@ -1,7 +1,7 @@
 From 998766c329dc8b387d6bd7208c1283876e320506 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@gmail.com>
 Date: Thu, 19 May 2022 10:09:04 +0200
-Subject: [PATCH 11/17] kmodbuild.sh: don't treat undefined symbols as errors
+Subject: [PATCH 11/18] kmodbuild.sh: don't treat undefined symbols as errors
 
 Modern kernels treat undefined symbols as errors, but when building
 modules individually, inter-module dependencies cannot be properly

--- a/recipes-extended/onl/files/onl/0012-optoe-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0012-optoe-add-of-device-match-table.patch
@@ -1,7 +1,7 @@
 From 4f5ccc51b8b0f893351349c55b40c57be7bd29be Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 26 Aug 2022 11:43:30 +0200
-Subject: [PATCH 12/17] optoe: add of device match table
+Subject: [PATCH 12/18] optoe: add of device match table
 
 For on-demand loading to work the kernel needs to know which compatibles
 are handled by the driver, so add an appropriate table.

--- a/recipes-extended/onl/files/onl/0013-ym2561y-add-of-device-match-table.patch
+++ b/recipes-extended/onl/files/onl/0013-ym2561y-add-of-device-match-table.patch
@@ -1,7 +1,7 @@
 From e7ce73b790ce3044501632b30054d436213861b0 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 26 Aug 2022 11:49:20 +0200
-Subject: [PATCH 13/17] ym2561y: add of device match table
+Subject: [PATCH 13/18] ym2561y: add of device match table
 
 For on-demand loading to work the kernel needs to know which compatibles
 are handled by the driver, so add an appropriate table.

--- a/recipes-extended/onl/files/onl/0014-modules-do-not-call-hwmon_device_register_with_info-.patch
+++ b/recipes-extended/onl/files/onl/0014-modules-do-not-call-hwmon_device_register_with_info-.patch
@@ -1,7 +1,7 @@
 From 31b24beb4569542800638b74ca9b91dc0d17a4b5 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 31 Oct 2023 14:35:01 +0100
-Subject: [PATCH 14/17] modules: do not call  hwmon_device_register_with_info()
+Subject: [PATCH 14/18] modules: do not call  hwmon_device_register_with_info()
  with NULL chip
 
 hwmon_device_register_with_info() is supposed to require hwmon_chip_info

--- a/recipes-extended/onl/files/onl/0015-modules-update-i2c_drivers-with-6.1.patch
+++ b/recipes-extended/onl/files/onl/0015-modules-update-i2c_drivers-with-6.1.patch
@@ -1,7 +1,7 @@
 From 953ea306ffe57fa5623da4c93e536415773574b7 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 31 Oct 2023 14:31:26 +0100
-Subject: [PATCH 15/17] modules: update i2c_drivers with 6.1
+Subject: [PATCH 15/18] modules: update i2c_drivers with 6.1
 
 i2c_remove changes its return type from int to void, so we need to
 provide different versions based on kernel version.

--- a/recipes-extended/onl/files/onl/0016-optoe-fix-race-in-sysfs-registraton-on-probe.patch
+++ b/recipes-extended/onl/files/onl/0016-optoe-fix-race-in-sysfs-registraton-on-probe.patch
@@ -1,7 +1,7 @@
 From 21c1dbb7292fa4db62a91fdffb1b6ffcc4d0dacb Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 29 Sep 2023 11:26:41 +0200
-Subject: [PATCH 16/17] optoe: fix race in sysfs registration on probe
+Subject: [PATCH 16/18] optoe: fix race in sysfs registration on probe
 
 The optoe first creates the sysfs entries and then calls
 i2c_set_clientdata(), but a very fast userspace may already try to

--- a/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
+++ b/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
@@ -194,7 +194,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../silverstone/modules/builds/src/mc24lc64t.c    | 10 ++++++++++
  .../x86-64/ag5648/modules/builds/dni_ag5648_psu.c | 10 ++++++++++
  .../x86-64/ag5648/modules/builds/dni_ag5648_sfp.c | 10 ++++++++++
- .../x86-64/ag5648/modules/builds/dni_emc2305.c    | 10 ++++++++++
+ .../x86-64/ag5648/modules/builds/dni_emc2305.c    | 13 +++++++++++++
  .../ag9032v1/modules/builds/dni_ag9032v1_psu.c    | 10 ++++++++++
  .../ag9032v1/modules/builds/dni_ag9032v1_sfp.c    | 10 ++++++++++
  .../x86-64/ag9032v1/modules/builds/dni_emc2305.c  | 10 ++++++++++
@@ -273,7 +273,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../modules/builds/rseb-w1-32-system_cpld.c       | 10 ++++++++++
  .../modules/builds/rseb-w1-32_psu.c               | 10 ++++++++++
  .../modules/builds/tps53681.c                     | 10 ++++++++++
- 222 files changed, 2290 insertions(+), 46 deletions(-)
+ 222 files changed, 2293 insertions(+), 46 deletions(-)
 
 diff --git a/packages/base/any/kernels/modules/accton_i2c_psu.c b/packages/base/any/kernels/modules/accton_i2c_psu.c
 index 1550ac1381ee..79ba285a5502 100755
@@ -4527,10 +4527,20 @@ index 6dc38ec6d1d5..849f4b7044c0 100755
  	.remove = ag5648_sfp_remove_6_1,
  #else
 diff --git a/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_emc2305.c b/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_emc2305.c
-index edd46a60421f..b4dfd38cb36d 100755
+index edd46a60421f..7dbb73d2d62c 100755
 --- a/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_emc2305.c
 +++ b/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_emc2305.c
-@@ -91,7 +91,11 @@ static struct i2c_driver emc2305_driver =
+@@ -77,6 +77,9 @@ static int emc2305_remove(struct i2c_client *client);
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ static void emc2305_remove_6_1(struct i2c_client *client);
+ #endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int emc2305_probe_6_3(struct i2c_client *client);
++#endif
+ 
+ static const struct i2c_device_id emc2305_id[] =
+ {
+@@ -91,7 +94,11 @@ static struct i2c_driver emc2305_driver =
    .driver = {
      .name = "emc2305",
    },
@@ -4542,7 +4552,7 @@ index edd46a60421f..b4dfd38cb36d 100755
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
    .remove = emc2305_remove_6_1,
  #else
-@@ -375,6 +379,12 @@ exit_remove:
+@@ -375,6 +382,12 @@ exit_remove:
    sysfs_remove_group(&client->dev.kobj, &data->attrs);
    return err;
  }

--- a/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
+++ b/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
@@ -1,7 +1,7 @@
 From 8d7cc76d9261ea82d0b9ed1f007dc4092588a03d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 21 Nov 2023 14:41:16 +0100
-Subject: [PATCH 17/17] modules: update i2c_drivers with 6.3 compatibility
+Subject: [PATCH 17/18] modules: update i2c_drivers with 6.3 compatibility
 
 i2c_probe() dropped its i2c_device_id* argument, so we need to provide
 different versions based on kernel version.

--- a/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
+++ b/recipes-extended/onl/files/onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch
@@ -1,4 +1,4 @@
-From 794bb8bb89a5e1fbfe7e8a9b21629ed2ca4d5dd6 Mon Sep 17 00:00:00 2001
+From 8d7cc76d9261ea82d0b9ed1f007dc4092588a03d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 21 Nov 2023 14:41:16 +0100
 Subject: [PATCH 17/17] modules: update i2c_drivers with 6.3 compatibility
@@ -25,10 +25,10 @@ struct i2c_driver DRIVER@p = {
 
 @i depends on r@
 @@
-#include <linux/version.h>
+ #include <linux/version.h>
 @depends on r && !i@
 @@
-#include <...>
+ #include <...>
 +#include <linux/version.h>
 @depends on r@
 identifier r.probe_fn;
@@ -45,7 +45,10 @@ int probe_fn(...) {...}
 
 applied with
 
-  spatch --smpl-spacing --sp-file 6.3-i2c_probe_sig.cocci --in-place --dir packages/
+    spatch --allow-inconsistent-paths --smpl-spacing --sp-file 6.3-i2c_probe.cocci --in-place --dir packages/
+
+(not sure where the inconsistent paths come from, but they get triggered
+in multiple modules)
 
 Result taken as is, without any code style fixes.
 
@@ -192,6 +195,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../belgite/modules/builds/src/platform_fan.c     | 10 ++++++++++
  .../belgite/modules/builds/src/platform_psu.c     | 10 ++++++++++
  .../silverstone/modules/builds/src/mc24lc64t.c    | 10 ++++++++++
+ .../x86-64/silverstone/modules/builds/src/optoe.c | 10 ++++++++++
  .../x86-64/ag5648/modules/builds/dni_ag5648_psu.c | 10 ++++++++++
  .../x86-64/ag5648/modules/builds/dni_ag5648_sfp.c | 10 ++++++++++
  .../x86-64/ag5648/modules/builds/dni_emc2305.c    | 13 +++++++++++++
@@ -212,6 +216,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../delta/x86-64/modules/builds/i2c_cpld.c        | 10 ++++++++++
  .../ingrasys/x86-64/modules/builds/eeprom_mb.c    | 10 ++++++++++
  .../modules/builds/ingrasys_s9230_64x_i2c_cpld.c  | 10 ++++++++++
+ .../modules/builds/ingrasys_s9230_64x_psu.c       | 10 ++++++++++
  .../modules/builds/ingrasys_s9280_64x_i2c_cpld.c  | 10 ++++++++++
  .../modules/builds/ingrasys_s9280_64x_psu.c       | 10 ++++++++++
  .../x86-64/d10056/modules/builds/src/inv_cpld.c   | 10 ++++++++++
@@ -262,6 +267,9 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../powerpc/ly2/modules/builds/quanta-ly-hwmon.c  | 10 ++++++++++
  .../ly2/modules/builds/quanta-ly2-i2c-mux.c       | 10 ++++++++++
  .../modules/builds/quanta-ly6-i2c-mux.c           | 10 ++++++++++
+ .../quanta/x86-64/modules/builds/qci_cpld.c       | 10 ++++++++++
+ .../quanta/x86-64/modules/builds/qci_cpld_led.c   | 10 ++++++++++
+ .../quanta/x86-64/modules/builds/qci_cpld_sfp28.c | 10 ++++++++++
  .../quanta/x86-64/modules/builds/qci_pmbus.c      | 10 ++++++++++
  .../modules/builds/quanta_hwmon_ix_series.c       | 10 ++++++++++
  .../modules/builds/quanta_hwmon_ly_series.c       | 10 ++++++++++
@@ -273,7 +281,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  .../modules/builds/rseb-w1-32-system_cpld.c       | 10 ++++++++++
  .../modules/builds/rseb-w1-32_psu.c               | 10 ++++++++++
  .../modules/builds/tps53681.c                     | 10 ++++++++++
- 222 files changed, 2293 insertions(+), 46 deletions(-)
+ 227 files changed, 2343 insertions(+), 46 deletions(-)
 
 diff --git a/packages/base/any/kernels/modules/accton_i2c_psu.c b/packages/base/any/kernels/modules/accton_i2c_psu.c
 index 1550ac1381ee..79ba285a5502 100755
@@ -4468,6 +4476,35 @@ index 9fcfcb531cb7..32f05ba7a51b 100644
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
          .remove = mc24lc64t_remove_6_1,
  #else
+diff --git a/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/optoe.c b/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/optoe.c
+index a699a7e16cd6..5ba179ea94c8 100644
+--- a/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/optoe.c
++++ b/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/optoe.c
+@@ -1168,6 +1168,12 @@ exit:
+ 
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int optoe_probe_6_3(struct i2c_client *client)
++{
++	return optoe_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /*-------------------------------------------------------------------------*/
+ 
+@@ -1176,7 +1182,11 @@ static struct i2c_driver optoe_driver = {
+ 		.name = "optoe",
+ 		.owner = THIS_MODULE,
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = optoe_probe_6_3,
++#else
+ 	.probe = optoe_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = optoe_remove_6_1,
+ #else
 diff --git a/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_ag5648_psu.c b/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_ag5648_psu.c
 index 9c4287e94a90..5be3f38171a7 100755
 --- a/packages/platforms/delta/x86-64/ag5648/modules/builds/dni_ag5648_psu.c
@@ -5057,6 +5094,35 @@ index a5c0a2362434..4ca29cdbbc0b 100644
 +#endif
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
      .remove = ingrasys_i2c_cpld_remove_6_1,
+ #else
+diff --git a/packages/platforms/ingrasys/x86-64/s9230-64x/modules/builds/ingrasys_s9230_64x_psu.c b/packages/platforms/ingrasys/x86-64/s9230-64x/modules/builds/ingrasys_s9230_64x_psu.c
+index b1db59aa75db..05cc72439308 100644
+--- a/packages/platforms/ingrasys/x86-64/s9230-64x/modules/builds/ingrasys_s9230_64x_psu.c
++++ b/packages/platforms/ingrasys/x86-64/s9230-64x/modules/builds/ingrasys_s9230_64x_psu.c
+@@ -369,6 +369,12 @@ exit:
+     
+     return status;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int s9230_psu_probe_6_3(struct i2c_client *client)
++{
++    return s9230_psu_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ static int 
+ s9230_psu_remove(struct i2c_client *client)
+@@ -519,7 +525,11 @@ static struct i2c_driver s9230_psu_driver = {
+     .driver = {
+         .name     = DRIVER_NAME,
+     },
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++    .probe = s9230_psu_probe_6_3,
++#else
+     .probe        = s9230_psu_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+     .remove = s9230_psu_remove_6_1,
  #else
 diff --git a/packages/platforms/ingrasys/x86-64/s9280-64x/modules/builds/ingrasys_s9280_64x_i2c_cpld.c b/packages/platforms/ingrasys/x86-64/s9280-64x/modules/builds/ingrasys_s9280_64x_i2c_cpld.c
 index a6ca5403b600..6010bc7e03a4 100644
@@ -6510,6 +6576,93 @@ index 22b6ecff1be9..2c0324741660 100644
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
  	.remove = quanta_ly6_i2c_mux_remove_6_1,
  #else
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
+index db12eed1d051..92737e3098d5 100755
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
+@@ -82,7 +82,11 @@ static struct i2c_driver cpld_driver = {
+ 	.driver = {
+ 		.name	= "qci_cpld",
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = cpld_probe_6_3,
++#else
+ 	.probe		= cpld_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = cpld_remove_6_1,
+ #else
+@@ -560,6 +564,12 @@ static int cpld_probe(struct i2c_client *client,
+ //	sysfs_remove_group(&client->dev.kobj, &data->attrs);
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int cpld_probe_6_3(struct i2c_client *client)
++{
++	return cpld_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */
+ #if 1
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
+index 3474d0507fd3..61c78a7c04bf 100644
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
+@@ -76,7 +76,11 @@ static struct i2c_driver cpld_led_driver = {
+ 	.driver = {
+ 		.name	= "qci_cpld_led",
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = cpld_led_probe_6_3,
++#else
+ 	.probe		= cpld_led_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = cpld_led_remove_6_1,
+ #else
+@@ -247,6 +251,12 @@ exit_remove:
+ //	sysfs_remove_group(&client->dev.kobj, &data->attrs);
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int cpld_led_probe_6_3(struct i2c_client *client)
++{
++	return cpld_led_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */
+ static int idr_has_entry(int id, void *p, void *data)
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
+index 03e84a79bbb4..54bf79bfb697 100755
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
+@@ -80,7 +80,11 @@ static struct i2c_driver cpld_driver = {
+ 	.driver = {
+ 		.name	= "qci_cpld_sfp28",
+ 	},
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++	.probe = cpld_probe_6_3,
++#else
+ 	.probe		= cpld_probe,
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+ 	.remove = cpld_remove_6_1,
+ #else
+@@ -363,6 +367,12 @@ static int cpld_probe(struct i2c_client *client,
+ //	sysfs_remove_group(&client->dev.kobj, &data->attrs);
+ 	return err;
+ }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
++static int cpld_probe_6_3(struct i2c_client *client)
++{
++	return cpld_probe(client, i2c_client_get_device_id(client));
++}
++#endif
+ 
+ /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */
+ #if 1
 diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_pmbus.c b/packages/platforms/quanta/x86-64/modules/builds/qci_pmbus.c
 index 675f579676c1..6f4aca8ee089 100644
 --- a/packages/platforms/quanta/x86-64/modules/builds/qci_pmbus.c

--- a/recipes-extended/onl/files/onl/0018-modules-update-class_create-usage-for-6.4.patch
+++ b/recipes-extended/onl/files/onl/0018-modules-update-class_create-usage-for-6.4.patch
@@ -1,0 +1,614 @@
+From 7831a272c10984b39a3805a2306024bd548f39c4 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 7 Feb 2024 17:27:23 +0100
+Subject: [PATCH 18/18] modules: update class_create() usage for 6.4
+
+Update class_create() usage for 6.4 which lost its first parameter.
+
+// <smpl>
+@@
+expression ret;
+expression E1,E2;
+@@
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++ret = class_create(E2);
++#else
+ ret = class_create(E1, E2);
++#endif
+// </smpl>
+
+applied with
+
+  spatch --sp-file 6.4-class_create.cocci --in-place --dir packages/
+
+Result taken as is, without any code style fixes.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../x86-64/as9516-32d/modules/builds/src/bf_fpga_main.c    | 4 ++++
+ .../x86-64/belgite/modules/builds/src/platform_cpld.c      | 4 ++++
+ .../silverstone/modules/builds/src/switchboard-diag.c      | 4 ++++
+ .../inventec/x86-64/d10056/modules/builds/src/inv_swps.c   | 4 ++++
+ .../inventec/x86-64/d10056/modules/builds/src/inv_vpd.c    | 4 ++++
+ .../inventec/x86-64/d3352/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d5052/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d5052/modules/builds/src/inv_vpd.c     | 4 ++++
+ .../inventec/x86-64/d5254/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d5254/modules/builds/src/inv_vpd.c     | 4 ++++
+ .../x86-64/d5264q28b/modules/builds/src/inv_swps.c         | 4 ++++
+ .../inventec/x86-64/d6254qs/modules/builds/src/inv_swps.c  | 4 ++++
+ .../inventec/x86-64/d6254qs/modules/builds/src/inv_vpd.c   | 4 ++++
+ .../inventec/x86-64/d6332/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d6356/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d6356/modules/builds/src/inv_vpd.c     | 4 ++++
+ .../inventec/x86-64/d6556/modules/builds/src/inv_swps.c    | 4 ++++
+ .../inventec/x86-64/d6556/modules/builds/src/inv_vpd.c     | 4 ++++
+ .../x86-64/d7032q28b/modules/builds/src/inv_swps.c         | 4 ++++
+ .../inventec/x86-64/d7032q28b/modules/builds/src/inv_vpd.c | 4 ++++
+ .../x86-64/d7054q28b/modules/builds/src/inv_swps.c         | 4 ++++
+ .../inventec/x86-64/d7054q28b/modules/builds/src/inv_vpd.c | 4 ++++
+ .../x86-64/d7264q28b/modules/builds/src/inv_swps.c         | 4 ++++
+ .../inventec/x86-64/d7264q28b/modules/builds/src/inv_vpd.c | 4 ++++
+ .../inventec/x86-64/d7332/modules/builds/src/inv_vpd.c     | 4 ++++
+ .../x86-64/aurora-610/modules/builds/src/net_swps.c        | 7 ++++++-
+ .../netberg/x86-64/aurora-610/modules/builds/src/net_vpd.c | 7 ++++++-
+ .../netberg/x86-64/aurora-820/modules/builds/src/net_vpd.c | 4 ++++
+ packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c | 4 ++++
+ .../platforms/quanta/x86-64/modules/builds/qci_cpld_led.c  | 4 ++++
+ .../quanta/x86-64/modules/builds/qci_cpld_sfp28.c          | 4 ++++
+ .../modules/builds/src/x86-64-ufispace-s9700-23d-vpd.c     | 4 ++++
+ .../modules/builds/src/x86-64-ufispace-s9700-53dx-vpd.c    | 4 ++++
+ .../modules/builds/src/x86-64-ufispace-s9705-48d-vpd.c     | 4 ++++
+ 34 files changed, 140 insertions(+), 2 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as9516-32d/modules/builds/src/bf_fpga_main.c b/packages/platforms/accton/x86-64/as9516-32d/modules/builds/src/bf_fpga_main.c
+index 2cb1ee3b1a7f..8b4195c382f0 100644
+--- a/packages/platforms/accton/x86-64/as9516-32d/modules/builds/src/bf_fpga_main.c
++++ b/packages/platforms/accton/x86-64/as9516-32d/modules/builds/src/bf_fpga_main.c
+@@ -657,7 +657,11 @@ static int bf_init_cdev(struct bf_pci_dev *bfdev, int minor) {
+   ret = bf_major_init(bfdev, minor);
+   if (ret) return ret;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++  bf_class = class_create(BF_CLASS_NAME);
++#else
+   bf_class = class_create(THIS_MODULE, BF_CLASS_NAME);
++#endif
+   if (!bf_class) {
+     printk(KERN_ERR "create_class failed for bf_fpga_dev\n");
+     ret = -ENODEV;
+diff --git a/packages/platforms/celestica/x86-64/belgite/modules/builds/src/platform_cpld.c b/packages/platforms/celestica/x86-64/belgite/modules/builds/src/platform_cpld.c
+index 7a4c5cb6f7fc..c56306dd4d00 100644
+--- a/packages/platforms/celestica/x86-64/belgite/modules/builds/src/platform_cpld.c
++++ b/packages/platforms/celestica/x86-64/belgite/modules/builds/src/platform_cpld.c
+@@ -928,7 +928,11 @@ static int cpld_drv_probe(struct platform_device *pdev)
+         return err;
+     }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    celplatform = class_create("celplatform");
++#else
+     celplatform = class_create(THIS_MODULE, "celplatform");
++#endif
+     if (IS_ERR(celplatform)) {
+         printk(KERN_ERR "Failed to register device class\n");
+         sysfs_remove_group(&pdev->dev.kobj, &cpld_group);
+diff --git a/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/switchboard-diag.c b/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/switchboard-diag.c
+index ee3e6d7be920..ff9fde4f7420 100644
+--- a/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/switchboard-diag.c
++++ b/packages/platforms/celestica/x86-64/silverstone/modules/builds/src/switchboard-diag.c
+@@ -1258,7 +1258,11 @@ static int fpga_pci_probe(struct pci_dev *pdev)
+     fpga_version = ioread32(fpga_dev.data_base_addr);
+     printk(KERN_INFO "FPGA VERSION : %8.8x\n", fpga_version);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    fpgafwclass = class_create(CLASS_NAME);
++#else
+     fpgafwclass = class_create(THIS_MODULE, CLASS_NAME);
++#endif
+     if (IS_ERR(fpgafwclass)) {
+         printk(KERN_ALERT "Failed to register device class\n");
+         err = PTR_ERR(fpgafwclass);
+diff --git a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.c
+index 6686352cf616..cff2b68fd9f4 100644
+--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.c
+@@ -2920,7 +2920,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c
+index b07cb6bbbdc6..92ea920df26d 100644
+--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c
+@@ -259,7 +259,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d3352/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d3352/modules/builds/src/inv_swps.c
+index e5988f2758f1..02c45abd888c 100644
+--- a/packages/platforms/inventec/x86-64/d3352/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d3352/modules/builds/src/inv_swps.c
+@@ -2760,7 +2760,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_swps.c
+index d3fddbc48988..8924a0dec8a5 100644
+--- a/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_swps.c
+@@ -2760,7 +2760,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_vpd.c
+index b6d755e1d6df..569409e648ba 100644
+--- a/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d5052/modules/builds/src/inv_vpd.c
+@@ -264,7 +264,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_swps.c
+index 42e430026263..5400f18c8880 100644
+--- a/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_swps.c
+@@ -2745,7 +2745,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_vpd.c
+index a11ac3309c50..8f91c99d2e6d 100644
+--- a/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d5254/modules/builds/src/inv_vpd.c
+@@ -259,7 +259,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_swps.c
+index cce1bad65884..0ed4c8941cfd 100644
+--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_swps.c
+@@ -2976,7 +2976,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_swps.c
+index 23f6c5247680..d0c10209ac9d 100644
+--- a/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_swps.c
+@@ -2838,7 +2838,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_vpd.c
+index b6d755e1d6df..569409e648ba 100644
+--- a/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d6254qs/modules/builds/src/inv_vpd.c
+@@ -264,7 +264,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d6332/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d6332/modules/builds/src/inv_swps.c
+index cce1bad65884..0ed4c8941cfd 100644
+--- a/packages/platforms/inventec/x86-64/d6332/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d6332/modules/builds/src/inv_swps.c
+@@ -2976,7 +2976,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_swps.c
+index 922515e1fab7..1012a17d2e2d 100644
+--- a/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_swps.c
+@@ -3032,7 +3032,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_vpd.c
+index 2075fd4eea91..51a0bbe93d74 100644
+--- a/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d6356/modules/builds/src/inv_vpd.c
+@@ -258,7 +258,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_swps.c
+index 3d38ec510a00..ae3668097730 100644
+--- a/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_swps.c
+@@ -2855,7 +2855,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_vpd.c
+index 2075fd4eea91..51a0bbe93d74 100644
+--- a/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d6556/modules/builds/src/inv_vpd.c
+@@ -258,7 +258,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_swps.c
+index 015fefc19ef8..1cc53e57df1f 100644
+--- a/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_swps.c
+@@ -2699,7 +2699,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_vpd.c
+index b4b232a4d64e..97bf4cef696e 100644
+--- a/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d7032q28b/modules/builds/src/inv_vpd.c
+@@ -284,7 +284,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_swps.c
+index 9050e59c9b23..f268b5307d9e 100644
+--- a/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_swps.c
+@@ -2743,7 +2743,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_vpd.c
+index 7e81636e9027..9cacf9b049c6 100644
+--- a/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d7054q28b/modules/builds/src/inv_vpd.c
+@@ -280,7 +280,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_swps.c b/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_swps.c
+index 41ee997443af..8363025d98b4 100644
+--- a/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_swps.c
++++ b/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_swps.c
+@@ -2743,7 +2743,11 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
+     swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_vpd.c
+index 2075fd4eea91..51a0bbe93d74 100644
+--- a/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d7264q28b/modules/builds/src/inv_vpd.c
+@@ -258,7 +258,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/inventec/x86-64/d7332/modules/builds/src/inv_vpd.c b/packages/platforms/inventec/x86-64/d7332/modules/builds/src/inv_vpd.c
+index 7e81636e9027..9cacf9b049c6 100644
+--- a/packages/platforms/inventec/x86-64/d7332/modules/builds/src/inv_vpd.c
++++ b/packages/platforms/inventec/x86-64/d7332/modules/builds/src/inv_vpd.c
+@@ -280,7 +280,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_swps.c b/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_swps.c
+index 0d2b06243ad3..25c86326bbcf 100644
+--- a/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_swps.c
++++ b/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_swps.c
+@@ -2709,7 +2709,12 @@ register_swp_module(void){
+     port_major = MAJOR(port_devt);
+ 
+     /* Create class object */
+-    swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    swp_class_p = class_create(SWP_CLS_NAME);
++#else
++    swp_class_p = class_create(THIS_MODULE, SWP_CLS_NAME);
++#endif
++    
+     if (IS_ERR(swp_class_p)) {
+         SWPS_ERR("Create class failure! \n");
+         goto err_register_swp_module_3;
+diff --git a/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_vpd.c b/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_vpd.c
+index 8806ffeb96e6..7a9b2b119749 100644
+--- a/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_vpd.c
++++ b/packages/platforms/netberg/x86-64/aurora-610/modules/builds/src/net_vpd.c
+@@ -259,7 +259,12 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
+-    vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
++    vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
++    
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/netberg/x86-64/aurora-820/modules/builds/src/net_vpd.c b/packages/platforms/netberg/x86-64/aurora-820/modules/builds/src/net_vpd.c
+index 89b86ae3c430..4dde0224a8b5 100644
+--- a/packages/platforms/netberg/x86-64/aurora-820/modules/builds/src/net_vpd.c
++++ b/packages/platforms/netberg/x86-64/aurora-820/modules/builds/src/net_vpd.c
+@@ -264,7 +264,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
+index db12eed1d051..466e4641ef37 100755
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld.c
+@@ -479,7 +479,11 @@ static int cpld_probe(struct i2c_client *client,
+ 
+ 	if (!cpld_class)
+ 	{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++		cpld_class = class_create(name);
++#else
+ 		cpld_class = class_create(THIS_MODULE, name);
++#endif
+ 		if (IS_ERR(cpld_class)) {
+ 			pr_err("couldn't create sysfs class\n");
+ 			return PTR_ERR(cpld_class);
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
+index 3474d0507fd3..15d4a2217917 100644
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_led.c
+@@ -194,7 +194,11 @@ static int cpld_led_probe(struct i2c_client *client,
+ 
+ 	if (!cpld_class)
+ 	{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++		cpld_class = class_create("cpld-led");
++#else
+ 		cpld_class = class_create(THIS_MODULE, "cpld-led");
++#endif
+ 		if (IS_ERR(cpld_class)) {
+ 			pr_err("couldn't create sysfs class\n");
+ 			return PTR_ERR(cpld_class);
+diff --git a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
+index 03e84a79bbb4..bc7912f2a83b 100755
+--- a/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
++++ b/packages/platforms/quanta/x86-64/modules/builds/qci_cpld_sfp28.c
+@@ -303,7 +303,11 @@ static int cpld_probe(struct i2c_client *client,
+ 
+ 	if (!cpld_class)
+ 	{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++		cpld_class = class_create(name);
++#else
+ 		cpld_class = class_create(THIS_MODULE, name);
++#endif
+ 		if (IS_ERR(cpld_class)) {
+ 			pr_err("couldn't create sysfs class\n");
+ 			return PTR_ERR(cpld_class);
+diff --git a/packages/platforms/ufispace/x86-64/s9700-23d/modules/builds/src/x86-64-ufispace-s9700-23d-vpd.c b/packages/platforms/ufispace/x86-64/s9700-23d/modules/builds/src/x86-64-ufispace-s9700-23d-vpd.c
+index 02e4dd446a1e..bb8c812c756e 100644
+--- a/packages/platforms/ufispace/x86-64/s9700-23d/modules/builds/src/x86-64-ufispace-s9700-23d-vpd.c
++++ b/packages/platforms/ufispace/x86-64/s9700-23d/modules/builds/src/x86-64-ufispace-s9700-23d-vpd.c
+@@ -287,7 +287,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/ufispace/x86-64/s9700-53dx/modules/builds/src/x86-64-ufispace-s9700-53dx-vpd.c b/packages/platforms/ufispace/x86-64/s9700-53dx/modules/builds/src/x86-64-ufispace-s9700-53dx-vpd.c
+index 2ef91515fed8..dd703a86969e 100644
+--- a/packages/platforms/ufispace/x86-64/s9700-53dx/modules/builds/src/x86-64-ufispace-s9700-53dx-vpd.c
++++ b/packages/platforms/ufispace/x86-64/s9700-53dx/modules/builds/src/x86-64-ufispace-s9700-53dx-vpd.c
+@@ -287,7 +287,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+diff --git a/packages/platforms/ufispace/x86-64/s9705-48d/modules/builds/src/x86-64-ufispace-s9705-48d-vpd.c b/packages/platforms/ufispace/x86-64/s9705-48d/modules/builds/src/x86-64-ufispace-s9705-48d-vpd.c
+index 0ee93c594f1e..d197f5be336c 100644
+--- a/packages/platforms/ufispace/x86-64/s9705-48d/modules/builds/src/x86-64-ufispace-s9705-48d-vpd.c
++++ b/packages/platforms/ufispace/x86-64/s9705-48d/modules/builds/src/x86-64-ufispace-s9705-48d-vpd.c
+@@ -287,7 +287,11 @@ register_vpd_module(void)
+     vpd_major  = MAJOR(vpd_devt);
+ 
+     /* Create class object */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++    vpd_class_p = class_create(EEPROM_CLASS);
++#else
+     vpd_class_p = class_create(THIS_MODULE, EEPROM_CLASS);
++#endif
+     if (IS_ERR(vpd_class_p)) {
+         VPD_ERR("Create class failure! \n");
+         goto err_register_vpd_module_1;
+-- 
+2.43.0
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -32,6 +32,7 @@ SRC_URI += " \
            file://onl/0015-modules-update-i2c_drivers-with-6.1.patch \
            file://onl/0016-optoe-fix-race-in-sysfs-registraton-on-probe.patch \
            file://onl/0017-modules-update-i2c_drivers-with-6.3-compatibility.patch \
+           file://onl/0018-modules-update-class_create-usage-for-6.4.patch \
            file://bigcode/0001-WIP-convert-to-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0002-dynamically-determine-location-of-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0003-avoid-multiple-global-definitions-for-not_empty.patch;patchdir=${SUBMODULE_BIGCODE} \
@@ -59,6 +60,7 @@ SRC_URI += " \
            file://cel-questone-2a/0005-cel-questone-2a-do-not-build-optoe.patch \
            file://cel-questone-2a/0006-cel-questone-2a-update-i2c_drivers-with-6.1-compatib.patch \
            file://cel-questone-2a/0007-cel-questone-2a-update-i2c_drivers-with-6.3-compatib.patch \
+           file://cel-questone-2a/0008-cel-questone-2a-update-class_create-usage-for-6.4.patch \
            file://delta-ag5648/0001-delta-ag5648-avoid-multiple-definitions-of-mutex-mut.patch \
            file://delta-ag5648/0002-ag5648-update-modules-to-compile-and-work-on-recent-.patch \
            file://delta-ag7648/0001-agema-ag7648-fix-buffer-overflow-while-reading-therm.patch \

--- a/recipes-kernel/accton-as4630-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/accton-as4630-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -474,6 +474,12 @@ static int as4630_poe_pse_probe(struct i2c_client *client, const struct i2c_devi
 
 	return 0;
 }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
+static int as4630_poe_pse_probe_6_3(struct i2c_client *client)
+{
+	return as4630_poe_pse_probe(client, i2c_client_get_device_id(client));
+}
+#endif
 
 static int as4630_poe_pse_remove(struct i2c_client *client)
 {
@@ -508,7 +514,11 @@ static const struct i2c_device_id as4630_54pe_poe_pse_id[] = {
 MODULE_DEVICE_TABLE(i2c, as4630_54pe_poe_pse_id);
 
 static struct i2c_driver as4630_poe_pse_driver = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
+	.probe = as4630_poe_pse_probe_6_3,
+#else
 	.probe = as4630_poe_pse_probe,
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
 	.remove = as4630_poe_pse_remove_6_1,
 #else

--- a/scripts/coccinelle/modules/6.3-i2c_probe.cocci
+++ b/scripts/coccinelle/modules/6.3-i2c_probe.cocci
@@ -8,7 +8,7 @@
 
 @r@
 identifier DRIVER;
-identifier remove_fn;
+identifier probe_fn;
 fresh identifier probe_fn_wrap = probe_fn ## "_6_3";
 position p;
 @@
@@ -19,7 +19,6 @@ struct i2c_driver DRIVER@p = {
 	.probe = probe_fn,
 +#endif
 };
-
 @i depends on r@
 @@
 #include <linux/version.h>
@@ -33,8 +32,8 @@ identifier r.probe_fn_wrap;
 @@
 int probe_fn(...) {...}
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
-+static void probe_fn_wrap(struct i2c_client *client)
++static int probe_fn_wrap(struct i2c_client *client)
 +{
-+	probe_fn(client, i2c_client_get_device_id(client));
++	return probe_fn(client, i2c_client_get_device_id(client));
 +}
 +#endif

--- a/scripts/coccinelle/modules/6.4-class_create.cocci
+++ b/scripts/coccinelle/modules/6.4-class_create.cocci
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Update class_create() callers to the reduced arguments changed in 6.4.
+//
+// Not idempotent!
+//
+// Copyright (c) 2024 Jonas Gorski, BISDN GmbH
+
+@r@
+expression ret;
+expression E1,E2;
+@@
+ret = class_create(E1, E2);
+@depends on r@
+expression ret;
+expression E1,E2;
+@@
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
++ret = class_create(E2);
++#else
+ ret = class_create(E1, E2);
++#endif
+@i depends on r@
+@@
+#include <linux/version.h>
+@depends on r && !i@
+@@
+ #include <...>
++#include <linux/version.h>


### PR DESCRIPTION
After testing it showed that the update for ONL's module was incomplete, so add the missing changes required for building in 6.6. While doing so AS4630's PoE-MCU module also needed adaption.

With these fixes applied, and a base kernel 6.6 recipe added, we switch to it.