### PR TITLE
accton-as4610: fix disconnect-on-idle for i2 mux

### DIFF
--- a/recipes-kernel/generic-armel-iproc-dtbs/files/arm-accton-as4610-54.dts
+++ b/recipes-kernel/generic-armel-iproc-dtbs/files/arm-accton-as4610-54.dts
@@ -10,6 +10,9 @@
  *
  */
 /dts-v1/;
+
+#include <dt-bindings/mux/mux.h>
+
 #include "bcm-helix4.dtsi"
 
 / {
@@ -87,7 +90,7 @@
             reg = <0x70>;
             #address-cells = <1>;
             #size-cells = <0>;
-            deselect-on-exit;
+            idle-state = <MUX_IDLE_DISCONNECT>;
 
         // SFP+ 1
         i2c@0 {

--- a/recipes-kernel/generic-armel-iproc-dtbs/files/arm-accton-as4610.dtsi
+++ b/recipes-kernel/generic-armel-iproc-dtbs/files/arm-accton-as4610.dtsi
@@ -9,6 +9,9 @@
  * option) any later version.
  *
  */
+
+#include <dt-bindings/mux/mux.h>
+
 #include "bcm-helix4.dtsi"
 
 / {
@@ -79,7 +82,7 @@
             reg = <0x70>;
             #address-cells = <1>;
             #size-cells = <0>;
-            deselect-on-exit;
+            idle-state = <MUX_IDLE_DISCONNECT>;
 
         // SFP+ 1
         i2c@0 {


### PR DESCRIPTION
The appropriate generic property for setting the mux to disconnect on idle according to [1] is

    idle-state = <MUX_IDLE_DISCONNECT>;

"deselect-on-exit" was a custom ONIE/ONL[2] property that was never upstream, so it never did anything for our kernels. ONL kernels also only ever supported it up to 3.16, so even ONL was missing it.

[1] https://elixir.bootlin.com/linux/v6.7.6/source/Documentation/devicetree/bindings/mux/mux-controller.yaml#L85
[2] https://github.com/opencomputeproject/onie/blob/master/patches/kernel/3.2.69/driver-pca954x-i2c-mux-deselect-on-exit-dtb-property.patch