### PR TITLE
linux-yocto-onl/6.6: update to 6.6.29

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2024-02-02 16:22:17.856503 for version 6.6.15
+# Generated at 2024-04-29 07:37:41.973537 for version 6.6.29
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.15"
+    this_version = "6.6.29"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -4298,6 +4298,12 @@ CVE_CHECK_IGNORE += "CVE-2019-25044"
 # fixed-version: Fixed after version 5.1
 CVE_CHECK_IGNORE += "CVE-2019-25045"
 
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-25160"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-25162"
+
 # fixed-version: Fixed after version 5.6rc1
 CVE_CHECK_IGNORE += "CVE-2019-3016"
 
@@ -4985,6 +4991,45 @@ CVE_CHECK_IGNORE += "CVE-2020-36694"
 # fixed-version: Fixed after version 5.9rc1
 CVE_CHECK_IGNORE += "CVE-2020-36766"
 
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36775"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36776"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36777"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36778"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36779"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36780"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36781"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36782"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36783"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36784"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36785"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36786"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36787"
+
 # fixed-version: Fixed after version 5.12rc1
 CVE_CHECK_IGNORE += "CVE-2020-3702"
 
@@ -5299,6 +5344,12 @@ CVE_CHECK_IGNORE += "CVE-2021-3348"
 
 # fixed-version: Fixed after version 5.13rc7
 CVE_CHECK_IGNORE += "CVE-2021-33624"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2021-33630"
+
+# fixed-version: Fixed after version 6.2rc1
+CVE_CHECK_IGNORE += "CVE-2021-33631"
 
 # fixed-version: Fixed after version 5.19rc6
 CVE_CHECK_IGNORE += "CVE-2021-33655"
@@ -5692,6 +5743,807 @@ CVE_CHECK_IGNORE += "CVE-2021-45868"
 
 # fixed-version: Fixed after version 5.13rc7
 CVE_CHECK_IGNORE += "CVE-2021-46283"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-46904"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46905"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-46906"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46908"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46909"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46910"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46911"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46912"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46913"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46914"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46915"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46916"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46917"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46918"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46919"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46920"
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2021-46921"
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2021-46922"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46923"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46924"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46925"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-46926"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46927"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-46928"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46929"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46930"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46931"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46932"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46933"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46934"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46935"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46936"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46937"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46938"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46939"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46940"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46941"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46942"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46943"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46944"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46945"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46947"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46948"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46949"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46950"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46951"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46952"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46953"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46954"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46955"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46956"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46957"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46958"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46959"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46960"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46961"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46962"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46963"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46964"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46965"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46966"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46967"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46968"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46969"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46970"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46971"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46972"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46973"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46974"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46976"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46977"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46978"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46979"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46980"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46981"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46982"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46983"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46984"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46985"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46986"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46987"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46988"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46989"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46990"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46991"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46992"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46993"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46994"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46995"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46996"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46997"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46998"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46999"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47000"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47001"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47002"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47003"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47004"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47005"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47006"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47007"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47008"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47009"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47010"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47011"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47012"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47013"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47014"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47015"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47016"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47017"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47018"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47019"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47020"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47021"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47022"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47023"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47024"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47025"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47026"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47027"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47028"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47029"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47030"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47031"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47032"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47033"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47034"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47035"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47036"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47037"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47038"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47039"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47040"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47041"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47042"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47043"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47044"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47045"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47046"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47047"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47048"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47049"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47050"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47051"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47052"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47053"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47054"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47055"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47056"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47057"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47058"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47059"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47060"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47061"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47062"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47063"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47064"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47065"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47066"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47067"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47068"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47069"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47070"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47071"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47072"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47073"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47074"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47075"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47076"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47077"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47078"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47079"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47080"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47081"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47082"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47083"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47086"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47087"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47088"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47089"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47090"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47091"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47092"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47093"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47094"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47095"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47096"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47097"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47098"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47099"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47100"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47101"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47102"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47103"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47104"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47105"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47106"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47107"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47108"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-47109"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47110"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-47111"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47112"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47113"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47114"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47116"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47117"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47118"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47119"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47120"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47121"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47122"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47123"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47124"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47125"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47126"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47127"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47128"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47129"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47130"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47131"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47132"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47133"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47134"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47135"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47136"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47137"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47138"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47139"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47140"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47141"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47142"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47143"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47144"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47145"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47146"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47147"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47148"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47149"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47150"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47151"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47152"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47153"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47158"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47159"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47160"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47161"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47162"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47163"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47164"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47165"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47166"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47167"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47168"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47169"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47170"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47171"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47172"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47173"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47174"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47175"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47176"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47177"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47178"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47179"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47180"
 
 # fixed-version: Fixed after version 5.17rc8
 CVE_CHECK_IGNORE += "CVE-2022-0001"
@@ -6407,7 +7259,8 @@ CVE_CHECK_IGNORE += "CVE-2022-3636"
 # fixed-version: Fixed after version 6.1rc4
 CVE_CHECK_IGNORE += "CVE-2022-3640"
 
-# CVE-2022-36402 has no known resolution
+# fixed-version: Fixed after version 6.5
+CVE_CHECK_IGNORE += "CVE-2022-36402"
 
 # CVE-2022-3642 has no known resolution
 
@@ -6648,6 +7501,21 @@ CVE_CHECK_IGNORE += "CVE-2022-48502"
 
 # fixed-version: Fixed after version 5.18rc1
 CVE_CHECK_IGNORE += "CVE-2022-48619"
+
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-48626"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-48627"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2022-48628"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-48629"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2022-48630"
 
 # fixed-version: Fixed after version 5.0rc1
 CVE_CHECK_IGNORE += "CVE-2023-0030"
@@ -7007,6 +7875,9 @@ CVE_CHECK_IGNORE += "CVE-2023-28466"
 
 # fixed-version: Fixed after version 6.0rc5
 CVE_CHECK_IGNORE += "CVE-2023-2860"
+
+# cpe-stable-backport: Backported in 6.6.22
+CVE_CHECK_IGNORE += "CVE-2023-28746"
 
 # fixed-version: Fixed after version 5.14rc1
 CVE_CHECK_IGNORE += "CVE-2023-28772"
@@ -7404,12 +8275,19 @@ CVE_CHECK_IGNORE += "CVE-2023-4622"
 CVE_CHECK_IGNORE += "CVE-2023-4623"
 
 # fixed-version: Fixed after version 6.6rc7
+CVE_CHECK_IGNORE += "CVE-2023-46343"
+
+# fixed-version: Fixed after version 6.6rc7
 CVE_CHECK_IGNORE += "CVE-2023-46813"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-46838"
 
 # fixed-version: Fixed after version 6.6
 CVE_CHECK_IGNORE += "CVE-2023-46862"
 
-# CVE-2023-47233 has no known resolution
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2023-47233"
 
 # fixed-version: Fixed after version 5.14rc1
 CVE_CHECK_IGNORE += "CVE-2023-4732"
@@ -7420,10 +8298,17 @@ CVE_CHECK_IGNORE += "CVE-2023-4881"
 # fixed-version: Fixed after version 6.6rc1
 CVE_CHECK_IGNORE += "CVE-2023-4921"
 
-# CVE-2023-50431 has no known resolution
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-50431"
 
 # fixed-version: Fixed after version 6.6rc7
 CVE_CHECK_IGNORE += "CVE-2023-5090"
+
+# fixed-version: Fixed after version 6.5rc1
+CVE_CHECK_IGNORE += "CVE-2023-51042"
+
+# fixed-version: Fixed after version 6.5rc3
+CVE_CHECK_IGNORE += "CVE-2023-51043"
 
 # fixed-version: Fixed after version 6.6rc5
 CVE_CHECK_IGNORE += "CVE-2023-5158"
@@ -7445,6 +8330,530 @@ CVE_CHECK_IGNORE += "CVE-2023-51782"
 
 # fixed-version: Fixed after version 6.6rc3
 CVE_CHECK_IGNORE += "CVE-2023-5197"
+
+# fixed-version: Fixed after version 6.3rc1
+CVE_CHECK_IGNORE += "CVE-2023-52340"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2023-52429"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52433"
+
+# cpe-stable-backport: Backported in 6.6.8
+CVE_CHECK_IGNORE += "CVE-2023-52434"
+
+# cpe-stable-backport: Backported in 6.6.11
+CVE_CHECK_IGNORE += "CVE-2023-52435"
+
+# cpe-stable-backport: Backported in 6.6.13
+CVE_CHECK_IGNORE += "CVE-2023-52436"
+
+# cpe-stable-backport: Backported in 6.6.13
+CVE_CHECK_IGNORE += "CVE-2023-52438"
+
+# cpe-stable-backport: Backported in 6.6.13
+CVE_CHECK_IGNORE += "CVE-2023-52439"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52440"
+
+# fixed-version: Fixed after version 6.5rc4
+CVE_CHECK_IGNORE += "CVE-2023-52441"
+
+# fixed-version: Fixed after version 6.5rc4
+CVE_CHECK_IGNORE += "CVE-2023-52442"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52443"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52444"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52445"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52446"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52447"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52448"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52449"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52450"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52451"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52452"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52453"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52454"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52455"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52456"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52457"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52458"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52459"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52460"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52461"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52462"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52463"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52464"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52465"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52467"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52468"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52469"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52470"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52471"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52472"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52473"
+
+# fixed-version: Fixed after version 6.4rc1
+CVE_CHECK_IGNORE += "CVE-2023-52474"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52475"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52476"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52477"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52478"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52479"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52480"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52481"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52482"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52483"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52484"
+
+# CVE-2023-52485 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52486"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52487"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52488"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52489"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52490"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52491"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52492"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52493"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52494"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52495"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52497"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52498"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52499"
+
+# fixed-version: Fixed after version 6.6rc2
+CVE_CHECK_IGNORE += "CVE-2023-52500"
+
+# fixed-version: Fixed after version 6.6rc2
+CVE_CHECK_IGNORE += "CVE-2023-52501"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52502"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52503"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52504"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52505"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52506"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52507"
+
+# fixed-version: Fixed after version 6.6rc2
+CVE_CHECK_IGNORE += "CVE-2023-52508"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52509"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52510"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52511"
+
+# fixed-version: Fixed after version 6.6rc6
+CVE_CHECK_IGNORE += "CVE-2023-52512"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52513"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52515"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52516"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52517"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52518"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52519"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52520"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52522"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52523"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52524"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52525"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52526"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52527"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52528"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52529"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52530"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52531"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52532"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2023-52559"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52560"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52561"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52562"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52563"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52564"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52565"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52566"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52567"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52568"
+
+# fixed-version: Fixed after version 6.6rc2
+CVE_CHECK_IGNORE += "CVE-2023-52569"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52570"
+
+# fixed-version: Fixed after version 6.6rc4
+CVE_CHECK_IGNORE += "CVE-2023-52571"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52572"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52573"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52574"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52575"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52576"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52577"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52578"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52580"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52581"
+
+# fixed-version: Fixed after version 6.6rc3
+CVE_CHECK_IGNORE += "CVE-2023-52582"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52583"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52584"
+
+# CVE-2023-52585 needs backporting (fixed from 6.8rc1)
+
+# CVE-2023-52586 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52587"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52588"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52589"
+
+# CVE-2023-52590 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52591"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52593"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52594"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52595"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52596"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52597"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52598"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52599"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52600"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52601"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52602"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52603"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52604"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52606"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52607"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52608"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52609"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52610"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52611"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52612"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-52613"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52614"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52615"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52616"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52617"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52618"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52619"
+
+# fixed-version: Fixed after version 6.4
+CVE_CHECK_IGNORE += "CVE-2023-52620"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52621"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52622"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52623"
+
+# CVE-2023-52624 needs backporting (fixed from 6.8rc1)
+
+# CVE-2023-52625 needs backporting (fixed from 6.8rc1)
+
+# fixed-version: only affects 6.7rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52626"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2023-52627"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52628"
+
+# fixed-version: Fixed after version 6.6rc1
+CVE_CHECK_IGNORE += "CVE-2023-52629"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2023-52630"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2023-52631"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52632"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52633"
+
+# CVE-2023-52634 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2023-52635"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2023-52636"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2023-52637"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2023-52638"
+
+# cpe-stable-backport: Backported in 6.6.22
+CVE_CHECK_IGNORE += "CVE-2023-52639"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2023-52640"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2023-52641"
 
 # fixed-version: Fixed after version 6.6rc4
 CVE_CHECK_IGNORE += "CVE-2023-5345"
@@ -7473,18 +8882,26 @@ CVE_CHECK_IGNORE += "CVE-2023-6121"
 # fixed-version: Fixed after version 6.6rc2
 CVE_CHECK_IGNORE += "CVE-2023-6176"
 
+# cpe-stable-backport: Backported in 6.6.9
+CVE_CHECK_IGNORE += "CVE-2023-6200"
+
 # CVE-2023-6238 has no known resolution
 
-# CVE-2023-6270 has no known resolution
+# CVE-2023-6240 has no known resolution
 
-# CVE-2023-6356 has no known resolution
+# cpe-stable-backport: Backported in 6.6.23
+CVE_CHECK_IGNORE += "CVE-2023-6270"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-6356"
 
 # cpe-stable-backport: Backported in 6.6.7
 CVE_CHECK_IGNORE += "CVE-2023-6531"
 
 # CVE-2023-6535 has no known resolution
 
-# CVE-2023-6536 has no known resolution
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2023-6536"
 
 # fixed-version: Fixed after version 6.5rc7
 CVE_CHECK_IGNORE += "CVE-2023-6546"
@@ -7495,7 +8912,8 @@ CVE_CHECK_IGNORE += "CVE-2023-6560"
 # cpe-stable-backport: Backported in 6.6.9
 CVE_CHECK_IGNORE += "CVE-2023-6606"
 
-# CVE-2023-6610 needs backporting (fixed from 6.7rc7)
+# cpe-stable-backport: Backported in 6.6.13
+CVE_CHECK_IGNORE += "CVE-2023-6610"
 
 # cpe-stable-backport: Backported in 6.6.7
 CVE_CHECK_IGNORE += "CVE-2023-6622"
@@ -7506,13 +8924,17 @@ CVE_CHECK_IGNORE += "CVE-2023-6679"
 # cpe-stable-backport: Backported in 6.6.7
 CVE_CHECK_IGNORE += "CVE-2023-6817"
 
+# cpe-stable-backport: Backported in 6.6.13
+CVE_CHECK_IGNORE += "CVE-2023-6915"
+
 # cpe-stable-backport: Backported in 6.6.7
 CVE_CHECK_IGNORE += "CVE-2023-6931"
 
 # cpe-stable-backport: Backported in 6.6.5
 CVE_CHECK_IGNORE += "CVE-2023-6932"
 
-# CVE-2023-7042 has no known resolution
+# cpe-stable-backport: Backported in 6.6.23
+CVE_CHECK_IGNORE += "CVE-2023-7042"
 
 # fixed-version: Fixed after version 6.3rc1
 CVE_CHECK_IGNORE += "CVE-2023-7192"
@@ -7526,5 +8948,761 @@ CVE_CHECK_IGNORE += "CVE-2024-0340"
 # fixed-version: Fixed after version 6.4rc7
 CVE_CHECK_IGNORE += "CVE-2024-0443"
 
-# Skipping dd=CVE-2023-1476, no affected_versions
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2024-0562"
+
+# CVE-2024-0564 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.8
+CVE_CHECK_IGNORE += "CVE-2024-0565"
+
+# cpe-stable-backport: Backported in 6.6.5
+CVE_CHECK_IGNORE += "CVE-2024-0582"
+
+# cpe-stable-backport: Backported in 6.6.5
+CVE_CHECK_IGNORE += "CVE-2024-0584"
+
+# cpe-stable-backport: Backported in 6.6.3
+CVE_CHECK_IGNORE += "CVE-2024-0607"
+
+# fixed-version: Fixed after version 6.5rc1
+CVE_CHECK_IGNORE += "CVE-2024-0639"
+
+# fixed-version: Fixed after version 6.6rc5
+CVE_CHECK_IGNORE += "CVE-2024-0641"
+
+# cpe-stable-backport: Backported in 6.6.7
+CVE_CHECK_IGNORE += "CVE-2024-0646"
+
+# fixed-version: Fixed after version 6.4rc2
+CVE_CHECK_IGNORE += "CVE-2024-0775"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-0841"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-1085"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-1086"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-1151"
+
+# fixed-version: Fixed after version 6.5rc4
+CVE_CHECK_IGNORE += "CVE-2024-1312"
+
+# CVE-2024-21803 has no known resolution
+
+# CVE-2024-2193 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.23
+CVE_CHECK_IGNORE += "CVE-2024-22099"
+
+# CVE-2024-22386 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.10
+CVE_CHECK_IGNORE += "CVE-2024-22705"
+
+# fixed-version: Fixed after version 6.5rc1
+CVE_CHECK_IGNORE += "CVE-2024-23196"
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-23307"
+
+# CVE-2024-23848 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-23849"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-23850"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-23851"
+
+# fixed-version: Fixed after version 6.5rc2
+CVE_CHECK_IGNORE += "CVE-2024-24855"
+
+# CVE-2024-24857 has no known resolution
+
+# CVE-2024-24858 has no known resolution
+
+# CVE-2024-24859 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-24860"
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-24861"
+
+# CVE-2024-24864 has no known resolution
+
+# CVE-2024-25739 has no known resolution
+
+# CVE-2024-25740 has no known resolution
+
+# CVE-2024-25741 has no known resolution
+
+# cpe-stable-backport: Backported in 6.6.7
+CVE_CHECK_IGNORE += "CVE-2024-25744"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26581"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26582"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26583"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26584"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26585"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26586"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26587"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26588"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26589"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26590"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26591"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26592"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26593"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26594"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26595"
+
+# CVE-2024-26596 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26597"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26598"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26599"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26600"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26601"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26602"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26603"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26604"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26605"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26606"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26607"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26608"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26610"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26611"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26612"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26614"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26615"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26616"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26617"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26618"
+
+# fixed-version: only affects 6.7rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26619"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26620"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26621"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26622"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26623"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26625"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26626"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26627"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26629"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26630"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26631"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26632"
+
+# cpe-stable-backport: Backported in 6.6.14
+CVE_CHECK_IGNORE += "CVE-2024-26633"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26634"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26635"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26636"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26637"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26638"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26639"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26640"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26641"
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-26642"
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-26643"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26644"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26645"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26646"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26647"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26648"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26649"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26650"
+
+# cpe-stable-backport: Backported in 6.6.23
+CVE_CHECK_IGNORE += "CVE-2024-26651"
+
+# cpe-stable-backport: Backported in 6.6.22
+CVE_CHECK_IGNORE += "CVE-2024-26652"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26653"
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-26654"
+
+# CVE-2024-26655 needs backporting (fixed from 6.9rc2)
+
+# cpe-stable-backport: Backported in 6.6.24
+CVE_CHECK_IGNORE += "CVE-2024-26656"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26657"
+
+# CVE-2024-26658 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26659"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26660"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26661"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26662"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26663"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26664"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26665"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26666"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26667"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26668"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26669"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26670"
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26671"
+
+# CVE-2024-26672 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.6.16
+CVE_CHECK_IGNORE += "CVE-2024-26673"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26674"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26675"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26676"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26677"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26678"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26679"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26680"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26681"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26682"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26683"
+
+# cpe-stable-backport: Backported in 6.6.17
+CVE_CHECK_IGNORE += "CVE-2024-26684"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26685"
+
+# CVE-2024-26686 needs backporting (fixed from 6.8rc4)
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26687"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26688"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26689"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26690"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26691"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26692"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26693"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26694"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26695"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26696"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26697"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26698"
+
+# CVE-2024-26699 needs backporting (fixed from 6.8rc5)
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26700"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26702"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26703"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26704"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26705"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26706"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26707"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26708"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26709"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26710"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26711"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26712"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26713"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26714"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26715"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26716"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26717"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26718"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26719"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26720"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26721"
+
+# fixed-version: only affects 6.7rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26722"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26723"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26724"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26725"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26726"
+
+# cpe-stable-backport: Backported in 6.6.18
+CVE_CHECK_IGNORE += "CVE-2024-26727"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26728"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26729"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26730"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26731"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26732"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26733"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26734"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26735"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26736"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26737"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26738"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26739"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26740"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26741"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26742"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26743"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26744"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26745"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26746"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26747"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26748"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26749"
+
+# fixed-version: only affects 6.8rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26750"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26751"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26752"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26753"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26754"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26755"
+
+# CVE-2024-26756 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26757 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26758 needs backporting (fixed from 6.8rc6)
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26759"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26760"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26761"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26762"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26763"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26764"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26765"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26766"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26767"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26768"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26769"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26770"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26771"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26772"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26773"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26774"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26775"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26776"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26777"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26778"
+
+# cpe-stable-backport: Backported in 6.6.19
+CVE_CHECK_IGNORE += "CVE-2024-26779"
+
+# fixed-version: only affects 6.8rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26780"
+
+# fixed-version: only affects 6.8rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26781"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26782"
+
+# cpe-stable-backport: Backported in 6.6.22
+CVE_CHECK_IGNORE += "CVE-2024-26783"
+
+# CVE-2024-26784 needs backporting (fixed from 6.8rc7)
+
+# CVE-2024-26785 needs backporting (fixed from 6.8rc7)
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26786"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26787"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26788"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26789"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26790"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26791"
+
+# fixed-version: only affects 6.8rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26792"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26793"
+
+# fixed-version: only affects 6.8rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26794"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26795"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26796"
+
+# CVE-2024-26797 needs backporting (fixed from 6.8rc7)
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26798"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26799"
+
+# fixed-version: only affects 6.8rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26800"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26801"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26802"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26803"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26804"
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26805"
+
+# CVE-2024-26806 needs backporting (fixed from 6.8rc7)
+
+# cpe-stable-backport: Backported in 6.6.21
+CVE_CHECK_IGNORE += "CVE-2024-26807"
+
+# cpe-stable-backport: Backported in 6.6.15
+CVE_CHECK_IGNORE += "CVE-2024-26808"
+
+# cpe-stable-backport: Backported in 6.6.23
+CVE_CHECK_IGNORE += "CVE-2024-26809"
 

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/x86_64-intel/igb-setup-Broadcom-54616-PHY-when-no-EEPROM-present.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/x86_64-intel/igb-setup-Broadcom-54616-PHY-when-no-EEPROM-present.patch
@@ -77,15 +77,15 @@ diff --git a/drivers/net/ethernet/intel/igb/e1000_phy.c b/drivers/net/ethernet/i
 index 38034d1d1830..6e477824f21a 100644
 --- a/drivers/net/ethernet/intel/igb/e1000_phy.c
 +++ b/drivers/net/ethernet/intel/igb/e1000_phy.c
-@@ -3,6 +3,7 @@
- 
- #include <linux/if_ether.h>
+@@ -4,6 +4,7 @@
+ #include <linux/bitfield.h>
  #include <linux/delay.h>
+ #include <linux/if_ether.h>
 +#include <linux/brcmphy.h>
- 
  #include "e1000_mac.h"
  #include "e1000_phy.h"
-@@ -460,6 +461,34 @@ s32 igb_write_phy_reg_igp(struct e1000_hw *hw, u32 offset, u16 data)
+ 
+@@ -461,6 +462,34 @@ s32 igb_write_phy_reg_igp(struct e1000_hw *hw, u32 offset, u16 data)
  	return ret_val;
  }
  

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.15"
+LINUX_VERSION ?= "6.6.29"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "51f354b815c44f1e423edb3f089ceece9bd26976"
+SRCREV_machine ?= "a3463f08104612fc979c41fa54733e925205d3d7"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "c32ab927d38291b1d2003ff491aa2ad4b60e1241"
+SRCREV_meta ?= "1cd08f1fb2b33510783fa31c11150038a1ff8c42"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update Linux 6.6 to 6.6.29 and kernel-meta to HEAD, in absence of a v6.6.29 commit.

Rebase igb-setup-Broadcom-54616-PHY-when-no-EEPROM-present.patch on changes upstream [1], which also reordered the includes.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.29
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.28
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.27
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.26
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.25
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.24
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.23
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.22
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.21
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.20
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.19
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.18
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.17
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.16

[1] https://github.com/gregkh/linux/commit/e383353b799269460a71e40bc100d91c4e892f31