### PR TITLE
linux-yocto-onl/6.1: update to 6.1.88

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.1.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.1.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2024-01-29 10:27:20.474080 for version 6.1.75
+# Generated at 2024-04-29 10:19:25.543251 for version 6.1.88
 
 python check_kernel_cve_status_version() {
-    this_version = "6.1.75"
+    this_version = "6.1.88"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -4298,6 +4298,12 @@ CVE_CHECK_IGNORE += "CVE-2019-25044"
 # fixed-version: Fixed after version 5.1
 CVE_CHECK_IGNORE += "CVE-2019-25045"
 
+# fixed-version: Fixed after version 5.0
+CVE_CHECK_IGNORE += "CVE-2019-25160"
+
+# fixed-version: Fixed after version 6.0rc1
+CVE_CHECK_IGNORE += "CVE-2019-25162"
+
 # fixed-version: Fixed after version 5.6rc1
 CVE_CHECK_IGNORE += "CVE-2019-3016"
 
@@ -4985,6 +4991,45 @@ CVE_CHECK_IGNORE += "CVE-2020-36694"
 # fixed-version: Fixed after version 5.9rc1
 CVE_CHECK_IGNORE += "CVE-2020-36766"
 
+# fixed-version: Fixed after version 5.7rc1
+CVE_CHECK_IGNORE += "CVE-2020-36775"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36776"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36777"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36778"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36779"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36780"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36781"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36782"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36783"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36784"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36785"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36786"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2020-36787"
+
 # fixed-version: Fixed after version 5.12rc1
 CVE_CHECK_IGNORE += "CVE-2020-3702"
 
@@ -5299,6 +5344,12 @@ CVE_CHECK_IGNORE += "CVE-2021-3348"
 
 # fixed-version: Fixed after version 5.13rc7
 CVE_CHECK_IGNORE += "CVE-2021-33624"
+
+# fixed-version: Fixed after version 5.4rc1
+CVE_CHECK_IGNORE += "CVE-2021-33630"
+
+# cpe-stable-backport: Backported in 6.1.4
+CVE_CHECK_IGNORE += "CVE-2021-33631"
 
 # fixed-version: Fixed after version 5.19rc6
 CVE_CHECK_IGNORE += "CVE-2021-33655"
@@ -5692,6 +5743,807 @@ CVE_CHECK_IGNORE += "CVE-2021-45868"
 
 # fixed-version: Fixed after version 5.13rc7
 CVE_CHECK_IGNORE += "CVE-2021-46283"
+
+# fixed-version: Fixed after version 5.12rc7
+CVE_CHECK_IGNORE += "CVE-2021-46904"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46905"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-46906"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46908"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46909"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46910"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46911"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46912"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46913"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46914"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46915"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46916"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46917"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46918"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46919"
+
+# fixed-version: Fixed after version 5.12rc8
+CVE_CHECK_IGNORE += "CVE-2021-46920"
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2021-46921"
+
+# fixed-version: Fixed after version 5.12
+CVE_CHECK_IGNORE += "CVE-2021-46922"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46923"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46924"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46925"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-46926"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46927"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-46928"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46929"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46930"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46931"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46932"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46933"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46934"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46935"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46936"
+
+# fixed-version: Fixed after version 5.16rc8
+CVE_CHECK_IGNORE += "CVE-2021-46937"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46938"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46939"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46940"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46941"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46942"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46943"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46944"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46945"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46947"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46948"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46949"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46950"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46951"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46952"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46953"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46954"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46955"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46956"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46957"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46958"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46959"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46960"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46961"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46962"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46963"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46964"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46965"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46966"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46967"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46968"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46969"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46970"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46971"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46972"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46973"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46974"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46976"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46977"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46978"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46979"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46980"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46981"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46982"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46983"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46984"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46985"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46986"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46987"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46988"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46989"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-46990"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46991"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46992"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46993"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46994"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46995"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46996"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46997"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46998"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-46999"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47000"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47001"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47002"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47003"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47004"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47005"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47006"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47007"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47008"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47009"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47010"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47011"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47012"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47013"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47014"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47015"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47016"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47017"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47018"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47019"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47020"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47021"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47022"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47023"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47024"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47025"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47026"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47027"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47028"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47029"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47030"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47031"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47032"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47033"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47034"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47035"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47036"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47037"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47038"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47039"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47040"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47041"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47042"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47043"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47044"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47045"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47046"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47047"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47048"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47049"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47050"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47051"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47052"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47053"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47054"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47055"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47056"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47057"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47058"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47059"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47060"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47061"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47062"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47063"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47064"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47065"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47066"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47067"
+
+# fixed-version: Fixed after version 5.13rc1
+CVE_CHECK_IGNORE += "CVE-2021-47068"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47069"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47070"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47071"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47072"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47073"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47074"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47075"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47076"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47077"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47078"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47079"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47080"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47081"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47082"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47083"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47086"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47087"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47088"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47089"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47090"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47091"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47092"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47093"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47094"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47095"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47096"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47097"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47098"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47099"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47100"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47101"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47102"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47103"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47104"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47105"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47106"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47107"
+
+# fixed-version: Fixed after version 5.16rc7
+CVE_CHECK_IGNORE += "CVE-2021-47108"
+
+# fixed-version: Fixed after version 5.13rc7
+CVE_CHECK_IGNORE += "CVE-2021-47109"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47110"
+
+# fixed-version: Fixed after version 5.13rc6
+CVE_CHECK_IGNORE += "CVE-2021-47111"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47112"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47113"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47114"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47116"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47117"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47118"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47119"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47120"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47121"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47122"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47123"
+
+# fixed-version: Fixed after version 5.13rc2
+CVE_CHECK_IGNORE += "CVE-2021-47124"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47125"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47126"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47127"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47128"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47129"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47130"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47131"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47132"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47133"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47134"
+
+# fixed-version: Fixed after version 5.13rc5
+CVE_CHECK_IGNORE += "CVE-2021-47135"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47136"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47137"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47138"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47139"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47140"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47141"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47142"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47143"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47144"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47145"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47146"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47147"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47148"
+
+# fixed-version: Fixed after version 5.13rc3
+CVE_CHECK_IGNORE += "CVE-2021-47149"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47150"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47151"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47152"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47153"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47158"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47159"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47160"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47161"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47162"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47163"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47164"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47165"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47166"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47167"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47168"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47169"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47170"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47171"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47172"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47173"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47174"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47175"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47176"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47177"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47178"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47179"
+
+# fixed-version: Fixed after version 5.13rc4
+CVE_CHECK_IGNORE += "CVE-2021-47180"
 
 # fixed-version: Fixed after version 5.17rc8
 CVE_CHECK_IGNORE += "CVE-2022-0001"
@@ -6407,7 +7259,8 @@ CVE_CHECK_IGNORE += "CVE-2022-3636"
 # fixed-version: Fixed after version 6.1rc4
 CVE_CHECK_IGNORE += "CVE-2022-3640"
 
-# CVE-2022-36402 has no known resolution
+# cpe-stable-backport: Backported in 6.1.50
+CVE_CHECK_IGNORE += "CVE-2022-36402"
 
 # CVE-2022-3642 has no known resolution
 
@@ -6645,6 +7498,21 @@ CVE_CHECK_IGNORE += "CVE-2022-48502"
 # fixed-version: Fixed after version 5.18rc1
 CVE_CHECK_IGNORE += "CVE-2022-48619"
 
+# fixed-version: Fixed after version 5.17rc4
+CVE_CHECK_IGNORE += "CVE-2022-48626"
+
+# fixed-version: Fixed after version 5.19rc7
+CVE_CHECK_IGNORE += "CVE-2022-48627"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2022-48628"
+
+# fixed-version: Fixed after version 5.17
+CVE_CHECK_IGNORE += "CVE-2022-48629"
+
+# fixed-version: Fixed after version 5.18
+CVE_CHECK_IGNORE += "CVE-2022-48630"
+
 # fixed-version: Fixed after version 5.0rc1
 CVE_CHECK_IGNORE += "CVE-2023-0030"
 
@@ -6876,7 +7744,8 @@ CVE_CHECK_IGNORE += "CVE-2023-2163"
 # fixed-version: Fixed after version 6.1
 CVE_CHECK_IGNORE += "CVE-2023-2166"
 
-# CVE-2023-2176 needs backporting (fixed from 6.3rc1)
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2023-2176"
 
 # fixed-version: Fixed after version 5.19
 CVE_CHECK_IGNORE += "CVE-2023-2177"
@@ -6999,6 +7868,9 @@ CVE_CHECK_IGNORE += "CVE-2023-28466"
 
 # fixed-version: Fixed after version 6.0rc5
 CVE_CHECK_IGNORE += "CVE-2023-2860"
+
+# cpe-stable-backport: Backported in 6.1.82
+CVE_CHECK_IGNORE += "CVE-2023-28746"
 
 # fixed-version: Fixed after version 5.14rc1
 CVE_CHECK_IGNORE += "CVE-2023-28772"
@@ -7390,12 +8262,19 @@ CVE_CHECK_IGNORE += "CVE-2023-4611"
 CVE_CHECK_IGNORE += "CVE-2023-4623"
 
 # cpe-stable-backport: Backported in 6.1.60
+CVE_CHECK_IGNORE += "CVE-2023-46343"
+
+# cpe-stable-backport: Backported in 6.1.60
 CVE_CHECK_IGNORE += "CVE-2023-46813"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-46838"
 
 # cpe-stable-backport: Backported in 6.1.61
 CVE_CHECK_IGNORE += "CVE-2023-46862"
 
-# CVE-2023-47233 has no known resolution
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2023-47233"
 
 # fixed-version: Fixed after version 5.14rc1
 CVE_CHECK_IGNORE += "CVE-2023-4732"
@@ -7406,10 +8285,17 @@ CVE_CHECK_IGNORE += "CVE-2023-4881"
 # cpe-stable-backport: Backported in 6.1.54
 CVE_CHECK_IGNORE += "CVE-2023-4921"
 
-# CVE-2023-50431 has no known resolution
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-50431"
 
 # cpe-stable-backport: Backported in 6.1.62
 CVE_CHECK_IGNORE += "CVE-2023-5090"
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2023-51042"
+
+# cpe-stable-backport: Backported in 6.1.40
+CVE_CHECK_IGNORE += "CVE-2023-51043"
 
 # cpe-stable-backport: Backported in 6.1.57
 CVE_CHECK_IGNORE += "CVE-2023-5158"
@@ -7431,6 +8317,526 @@ CVE_CHECK_IGNORE += "CVE-2023-51782"
 
 # cpe-stable-backport: Backported in 6.1.56
 CVE_CHECK_IGNORE += "CVE-2023-5197"
+
+# cpe-stable-backport: Backported in 6.1.73
+CVE_CHECK_IGNORE += "CVE-2023-52340"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52429"
+
+# fixed-version: only affects 6.5rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52433"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52434"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52435"
+
+# cpe-stable-backport: Backported in 6.1.74
+CVE_CHECK_IGNORE += "CVE-2023-52436"
+
+# cpe-stable-backport: Backported in 6.1.74
+CVE_CHECK_IGNORE += "CVE-2023-52438"
+
+# cpe-stable-backport: Backported in 6.1.74
+CVE_CHECK_IGNORE += "CVE-2023-52439"
+
+# cpe-stable-backport: Backported in 6.1.52
+CVE_CHECK_IGNORE += "CVE-2023-52440"
+
+# cpe-stable-backport: Backported in 6.1.53
+CVE_CHECK_IGNORE += "CVE-2023-52441"
+
+# cpe-stable-backport: Backported in 6.1.53
+CVE_CHECK_IGNORE += "CVE-2023-52442"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52443"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52444"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52445"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52446"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52447"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52448"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52449"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52450"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52451"
+
+# CVE-2023-52452 needs backporting (fixed from 6.8rc1)
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52453"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52454"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52455"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52456"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52457"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52458"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52459"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52460"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52461"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52462"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52463"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52464"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52465"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52467"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52468"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52469"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52470"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52471"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52472"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52473"
+
+# cpe-stable-backport: Backported in 6.1.28
+CVE_CHECK_IGNORE += "CVE-2023-52474"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52475"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52476"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52477"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52478"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52479"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52480"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52481"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52482"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52483"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52484"
+
+# CVE-2023-52485 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52486"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52487"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52488"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52489"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52490"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52491"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52492"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52493"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52494"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52495"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52497"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52498"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52499"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52500"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52501"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52502"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52503"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52504"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52505"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52506"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52507"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52508"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52509"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52510"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52511"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52512"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52513"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52515"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52516"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52517"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52518"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52519"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52520"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52522"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52523"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52524"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52525"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52526"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52527"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52528"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52529"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52530"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52531"
+
+# cpe-stable-backport: Backported in 6.1.59
+CVE_CHECK_IGNORE += "CVE-2023-52532"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2023-52559"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52560"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52561"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52562"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52563"
+
+# fixed-version: only affects 6.5rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52564"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52565"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52566"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52567"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52568"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52569"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52570"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52571"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52572"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52573"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52574"
+
+# fixed-version: only affects 6.5rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52575"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52576"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52577"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52578"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52580"
+
+# fixed-version: only affects 6.5rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52581"
+
+# cpe-stable-backport: Backported in 6.1.56
+CVE_CHECK_IGNORE += "CVE-2023-52582"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52583"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52584"
+
+# CVE-2023-52585 needs backporting (fixed from 6.8rc1)
+
+# CVE-2023-52586 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52587"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52588"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52589"
+
+# CVE-2023-52590 needs backporting (fixed from 6.8rc1)
+
+# CVE-2023-52591 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52593"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52594"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52595"
+
+# CVE-2023-52596 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52597"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52598"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52599"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52600"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52601"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52602"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52603"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52604"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52606"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52607"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52608"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52609"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52610"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52611"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-52612"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52613"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52614"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52615"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52616"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52617"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52618"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52619"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2023-52620"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52621"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52622"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52623"
+
+# CVE-2023-52624 needs backporting (fixed from 6.8rc1)
+
+# CVE-2023-52625 needs backporting (fixed from 6.8rc1)
+
+# fixed-version: only affects 6.7rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52626"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2023-52627"
+
+# cpe-stable-backport: Backported in 6.1.54
+CVE_CHECK_IGNORE += "CVE-2023-52628"
+
+# CVE-2023-52629 needs backporting (fixed from 6.6rc1)
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2023-52630"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2023-52631"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52632"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52633"
+
+# CVE-2023-52634 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2023-52635"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-52636"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52637"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2023-52638"
+
+# cpe-stable-backport: Backported in 6.1.82
+CVE_CHECK_IGNORE += "CVE-2023-52639"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2023-52640"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2023-52641"
 
 # cpe-stable-backport: Backported in 6.1.56
 CVE_CHECK_IGNORE += "CVE-2023-5345"
@@ -7458,18 +8864,26 @@ CVE_CHECK_IGNORE += "CVE-2023-6121"
 # cpe-stable-backport: Backported in 6.1.54
 CVE_CHECK_IGNORE += "CVE-2023-6176"
 
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2023-6200"
+
 # CVE-2023-6238 has no known resolution
 
-# CVE-2023-6270 has no known resolution
+# CVE-2023-6240 has no known resolution
 
-# CVE-2023-6356 has no known resolution
+# cpe-stable-backport: Backported in 6.1.83
+CVE_CHECK_IGNORE += "CVE-2023-6270"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-6356"
 
 # cpe-stable-backport: Backported in 6.1.68
 CVE_CHECK_IGNORE += "CVE-2023-6531"
 
 # CVE-2023-6535 has no known resolution
 
-# CVE-2023-6536 has no known resolution
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2023-6536"
 
 # cpe-stable-backport: Backported in 6.1.47
 CVE_CHECK_IGNORE += "CVE-2023-6546"
@@ -7479,7 +8893,8 @@ CVE_CHECK_IGNORE += "CVE-2023-6546"
 # cpe-stable-backport: Backported in 6.1.70
 CVE_CHECK_IGNORE += "CVE-2023-6606"
 
-# CVE-2023-6610 needs backporting (fixed from 6.7rc7)
+# cpe-stable-backport: Backported in 6.1.74
+CVE_CHECK_IGNORE += "CVE-2023-6610"
 
 # cpe-stable-backport: Backported in 6.1.68
 CVE_CHECK_IGNORE += "CVE-2023-6622"
@@ -7490,13 +8905,17 @@ CVE_CHECK_IGNORE += "CVE-2023-6679"
 # cpe-stable-backport: Backported in 6.1.68
 CVE_CHECK_IGNORE += "CVE-2023-6817"
 
+# cpe-stable-backport: Backported in 6.1.74
+CVE_CHECK_IGNORE += "CVE-2023-6915"
+
 # cpe-stable-backport: Backported in 6.1.68
 CVE_CHECK_IGNORE += "CVE-2023-6931"
 
 # cpe-stable-backport: Backported in 6.1.66
 CVE_CHECK_IGNORE += "CVE-2023-6932"
 
-# CVE-2023-7042 has no known resolution
+# cpe-stable-backport: Backported in 6.1.83
+CVE_CHECK_IGNORE += "CVE-2023-7042"
 
 # cpe-stable-backport: Backported in 6.1.18
 CVE_CHECK_IGNORE += "CVE-2023-7192"
@@ -7504,10 +8923,747 @@ CVE_CHECK_IGNORE += "CVE-2023-7192"
 # fixed-version: only affects 6.5rc6 onwards
 CVE_CHECK_IGNORE += "CVE-2024-0193"
 
-# CVE-2024-0340 needs backporting (fixed from 6.4rc6)
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-0340"
 
 # fixed-version: only affects 6.2rc1 onwards
 CVE_CHECK_IGNORE += "CVE-2024-0443"
 
-# Skipping dd=CVE-2023-1476, no affected_versions
+# fixed-version: Fixed after version 6.0rc3
+CVE_CHECK_IGNORE += "CVE-2024-0562"
+
+# CVE-2024-0564 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.69
+CVE_CHECK_IGNORE += "CVE-2024-0565"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-0582"
+
+# cpe-stable-backport: Backported in 6.1.66
+CVE_CHECK_IGNORE += "CVE-2024-0584"
+
+# cpe-stable-backport: Backported in 6.1.64
+CVE_CHECK_IGNORE += "CVE-2024-0607"
+
+# cpe-stable-backport: Backported in 6.1.39
+CVE_CHECK_IGNORE += "CVE-2024-0639"
+
+# cpe-stable-backport: Backported in 6.1.57
+CVE_CHECK_IGNORE += "CVE-2024-0641"
+
+# cpe-stable-backport: Backported in 6.1.69
+CVE_CHECK_IGNORE += "CVE-2024-0646"
+
+# cpe-stable-backport: Backported in 6.1.29
+CVE_CHECK_IGNORE += "CVE-2024-0775"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-0841"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-1085"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-1086"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-1151"
+
+# CVE-2024-1312 needs backporting (fixed from 6.5rc4)
+
+# CVE-2024-21803 has no known resolution
+
+# CVE-2024-2193 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.83
+CVE_CHECK_IGNORE += "CVE-2024-22099"
+
+# CVE-2024-22386 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.71
+CVE_CHECK_IGNORE += "CVE-2024-22705"
+
+# cpe-stable-backport: Backported in 6.1.47
+CVE_CHECK_IGNORE += "CVE-2024-23196"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-23307"
+
+# CVE-2024-23848 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-23849"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-23850"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-23851"
+
+# CVE-2024-24855 needs backporting (fixed from 6.5rc2)
+
+# CVE-2024-24857 has no known resolution
+
+# CVE-2024-24858 has no known resolution
+
+# CVE-2024-24859 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-24860"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-24861"
+
+# CVE-2024-24864 has no known resolution
+
+# CVE-2024-25739 has no known resolution
+
+# CVE-2024-25740 has no known resolution
+
+# CVE-2024-25741 has no known resolution
+
+# cpe-stable-backport: Backported in 6.1.68
+CVE_CHECK_IGNORE += "CVE-2024-25744"
+
+# fixed-version: only affects 6.5rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26581"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26582"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26583"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-26584"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-26585"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26586"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26587"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26588"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26589"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26590"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26591"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26592"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26593"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26594"
+
+# CVE-2024-26595 needs backporting (fixed from 6.8rc1)
+
+# CVE-2024-26596 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26597"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26598"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26599"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26600"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26601"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26602"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26603"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26604"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26605"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26606"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26607"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26608"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26610"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26611"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26612"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26614"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26615"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26616"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26617"
+
+# fixed-version: only affects 6.5rc7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26618"
+
+# fixed-version: only affects 6.7rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26619"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26620"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26621"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26622"
+
+# CVE-2024-26623 needs backporting (fixed from 6.8rc3)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26625"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26626"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26627"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26629"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26630"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26631"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26632"
+
+# cpe-stable-backport: Backported in 6.1.75
+CVE_CHECK_IGNORE += "CVE-2024-26633"
+
+# fixed-version: only affects 6.6rc7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26634"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26635"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26636"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26637"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26638"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26639"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26640"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26641"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-26642"
+
+# fixed-version: only affects 6.5rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26643"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26644"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26645"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26646"
+
+# CVE-2024-26647 needs backporting (fixed from 6.8rc1)
+
+# CVE-2024-26648 needs backporting (fixed from 6.8rc1)
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26649"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26650"
+
+# cpe-stable-backport: Backported in 6.1.83
+CVE_CHECK_IGNORE += "CVE-2024-26651"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26652"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26653"
+
+# cpe-stable-backport: Backported in 6.1.84
+CVE_CHECK_IGNORE += "CVE-2024-26654"
+
+# CVE-2024-26655 needs backporting (fixed from 6.9rc2)
+
+# CVE-2024-26656 needs backporting (fixed from 6.9rc1)
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26657"
+
+# CVE-2024-26658 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.82
+CVE_CHECK_IGNORE += "CVE-2024-26659"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26660"
+
+# CVE-2024-26661 needs backporting (fixed from 6.8rc4)
+
+# CVE-2024-26662 needs backporting (fixed from 6.8rc4)
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26663"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26664"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26665"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26666"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26667"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26668"
+
+# CVE-2024-26669 needs backporting (fixed from 6.8rc2)
+
+# fixed-version: only affects 6.6rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26670"
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26671"
+
+# CVE-2024-26672 needs backporting (fixed from 6.8rc1)
+
+# cpe-stable-backport: Backported in 6.1.77
+CVE_CHECK_IGNORE += "CVE-2024-26673"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26674"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26675"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26676"
+
+# CVE-2024-26677 needs backporting (fixed from 6.8rc4)
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26678"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26679"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26680"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26681"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26682"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26683"
+
+# cpe-stable-backport: Backported in 6.1.78
+CVE_CHECK_IGNORE += "CVE-2024-26684"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26685"
+
+# cpe-stable-backport: Backported in 6.1.82
+CVE_CHECK_IGNORE += "CVE-2024-26686"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26687"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26688"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26689"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26690"
+
+# CVE-2024-26691 needs backporting (fixed from 6.8rc5)
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26692"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26693"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26694"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26695"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26696"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26697"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26698"
+
+# CVE-2024-26699 needs backporting (fixed from 6.8rc5)
+
+# cpe-stable-backport: Backported in 6.1.82
+CVE_CHECK_IGNORE += "CVE-2024-26700"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26702"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26703"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26704"
+
+# fixed-version: only affects 6.6rc2 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26705"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26706"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26707"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26708"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26709"
+
+# fixed-version: only affects 6.8rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26710"
+
+# fixed-version: only affects 6.2rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26711"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26712"
+
+# CVE-2024-26713 needs backporting (fixed from 6.8rc5)
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26714"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26715"
+
+# fixed-version: only affects 6.5rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26716"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26717"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26718"
+
+# CVE-2024-26719 needs backporting (fixed from 6.8rc3)
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26720"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26721"
+
+# fixed-version: only affects 6.7rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26722"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26723"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26724"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26725"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26726"
+
+# cpe-stable-backport: Backported in 6.1.79
+CVE_CHECK_IGNORE += "CVE-2024-26727"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26728"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26729"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26730"
+
+# fixed-version: only affects 6.4rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26731"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26732"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26733"
+
+# fixed-version: only affects 6.3rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26734"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26735"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26736"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26737"
+
+# CVE-2024-26738 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26739 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26740 needs backporting (fixed from 6.8rc6)
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26741"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26742"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26743"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26744"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26745"
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26746"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26747"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26748"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26749"
+
+# fixed-version: only affects 6.8rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26750"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26751"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26752"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26753"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26754"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26755"
+
+# CVE-2024-26756 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26757 needs backporting (fixed from 6.8rc6)
+
+# CVE-2024-26758 needs backporting (fixed from 6.8rc6)
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26759"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26760"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26761"
+
+# fixed-version: only affects 6.7rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26762"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26763"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26764"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26765"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26766"
+
+# CVE-2024-26767 needs backporting (fixed from 6.8rc5)
+
+# CVE-2024-26768 needs backporting (fixed from 6.8rc4)
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26769"
+
+# CVE-2024-26770 needs backporting (fixed from 6.8rc3)
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26771"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26772"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26773"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26774"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26775"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26776"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26777"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26778"
+
+# cpe-stable-backport: Backported in 6.1.80
+CVE_CHECK_IGNORE += "CVE-2024-26779"
+
+# fixed-version: only affects 6.8rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26780"
+
+# fixed-version: only affects 6.8rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26781"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26782"
+
+# CVE-2024-26783 needs backporting (fixed from 6.8rc7)
+
+# CVE-2024-26784 needs backporting (fixed from 6.8rc7)
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26785"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26786"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26787"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26788"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26789"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26790"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26791"
+
+# fixed-version: only affects 6.8rc4 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26792"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26793"
+
+# fixed-version: only affects 6.8rc6 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26794"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26795"
+
+# fixed-version: only affects 6.6rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26796"
+
+# CVE-2024-26797 needs backporting (fixed from 6.8rc7)
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26798"
+
+# CVE-2024-26799 needs backporting (fixed from 6.8rc7)
+
+# fixed-version: only affects 6.8rc5 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26800"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26801"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26802"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26803"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26804"
+
+# cpe-stable-backport: Backported in 6.1.81
+CVE_CHECK_IGNORE += "CVE-2024-26805"
+
+# CVE-2024-26806 needs backporting (fixed from 6.8rc7)
+
+# fixed-version: only affects 6.4rc1 onwards
+CVE_CHECK_IGNORE += "CVE-2024-26807"
+
+# cpe-stable-backport: Backported in 6.1.76
+CVE_CHECK_IGNORE += "CVE-2024-26808"
+
+# cpe-stable-backport: Backported in 6.1.83
+CVE_CHECK_IGNORE += "CVE-2024-26809"
 

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.1.y/bisdn-kmeta/bsp/x86_64-intel/x86_64-intel.cfg
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.1.y/bisdn-kmeta/bsp/x86_64-intel/x86_64-intel.cfg
@@ -965,7 +965,6 @@ CONFIG_NET_SCHED=y
 #
 # Queueing/Scheduling
 #
-# CONFIG_NET_SCH_CBQ is not set
 # CONFIG_NET_SCH_HTB is not set
 # CONFIG_NET_SCH_HFSC is not set
 # CONFIG_NET_SCH_PRIO is not set
@@ -979,7 +978,6 @@ CONFIG_NET_SCHED=y
 # CONFIG_NET_SCH_ETF is not set
 # CONFIG_NET_SCH_TAPRIO is not set
 # CONFIG_NET_SCH_GRED is not set
-# CONFIG_NET_SCH_DSMARK is not set
 # CONFIG_NET_SCH_NETEM is not set
 # CONFIG_NET_SCH_DRR is not set
 # CONFIG_NET_SCH_MQPRIO is not set

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.75"
+LINUX_VERSION ?= "6.1.88"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "883d1a9562083922c6d293e9adad8cca4626adf3"
+SRCREV_machine ?= "f2295faba5e8249ae4082791bfc1664c88fff83a"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "7ca3655cbccce6330c6f947abf667b5e3ae5350b"
+SRCREV_meta ?= "2ccedc62a19929df39eef4a5f2255b6f03652b31"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.1 to 6.1.88 and update kernel-meta to HEAD, in absence of a v6.1.88 commit.

Also drop two kernel config symbols that were removed in 6.1.80:

* NET_SCH_DSMARK with a41f6e170b85 ("net/sched: Retire dsmark qdisc")
* NET_SCH_CBQ with 02149c7cd115 ("net/sched: Retire CBQ qdisc")

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.88
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.87
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.86
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.85
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.84
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.83
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.82
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.81
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.80
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.79
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.78
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.77
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.76