### PR TITLE
linux-yocto-onl/6.1: update to 6.1.90

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.1.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.1.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2024-04-29 10:19:25.543251 for version 6.1.88
+# Generated at 2024-05-07 11:14:07.345504 for version 6.1.90
 
 python check_kernel_cve_status_version() {
-    this_version = "6.1.88"
+    this_version = "6.1.90"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))

--- a/recipes-kernel/linux/linux-yocto-onl_6.1.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.1.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.1.88"
+LINUX_VERSION ?= "6.1.90"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.1.y
-SRCREV_machine ?= "f2295faba5e8249ae4082791bfc1664c88fff83a"
+SRCREV_machine ?= "909ba1f1b4146de529469910c1bd0b1248964536"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.1
-SRCREV_meta ?= "2ccedc62a19929df39eef4a5f2255b6f03652b31"
+SRCREV_meta ?= "0d05df1574034f29d1db106063adf5fe522271b1"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.1;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.1 and kernel-meta to 6.1.90.

Most noteworthy change from 6.1.90:

    vxlan: drop packets from invalid src-address

    [ Upstream commit f58f45c1e5b92975e91754f5407250085a6ae7cf ]

    The VXLAN driver currently does not check if the inner layer2
    source-address is valid.

    In case source-address snooping/learning is enabled, a entry in the FDB
    for the invalid address is created with the layer3 address of the tunnel
    endpoint.

    If the frame happens to have a non-unicast address set, all this
    non-unicast traffic is subsequently not flooded to the tunnel network
    but sent to the learnt host in the FDB. To make matters worse, this FDB
    entry does not expire.

    Apply the same filtering for packets as it is done for bridges. This not
    only drops these invalid packets but avoids them from being learnt into
    the FDB.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.90
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.1.89