### PR TITLE
linux-yocto-onl/6.6: update to 6.6.30

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,9 +1,9 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2024-04-29 07:37:41.973537 for version 6.6.29
+# Generated at 2024-05-07 11:14:22.224509 for version 6.6.30
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.29"
+    this_version = "6.6.30"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.29"
+LINUX_VERSION ?= "6.6.30"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "a3463f08104612fc979c41fa54733e925205d3d7"
+SRCREV_machine ?= "5697d159afef8c475f13a0b7b85f09bd4578106c"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "1cd08f1fb2b33510783fa31c11150038a1ff8c42"
+SRCREV_meta ?= "fca7e62b0d67399b174d9af0a04fc56e85a80fa3"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.6 and kernel-meta to 6.6.30.

Most noteworthy change from 6.6.30:

    vxlan: drop packets from invalid src-address

    [ Upstream commit f58f45c1e5b92975e91754f5407250085a6ae7cf ]

    The VXLAN driver currently does not check if the inner layer2
    source-address is valid.

    In case source-address snooping/learning is enabled, a entry in the FDB
    for the invalid address is created with the layer3 address of the tunnel
    endpoint.

    If the frame happens to have a non-unicast address set, all this
    non-unicast traffic is subsequently not flooded to the tunnel network
    but sent to the learnt host in the FDB. To make matters worse, this FDB
    entry does not expire.

    Apply the same filtering for packets as it is done for bridges. This not
    only drops these invalid packets but avoids them from being learnt into
    the FDB.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.30