### PR TITLE
platform-onl-init: move scripts to /usr/libexec/

### DIFF
--- a/recipes-core/platform-onl-init/files/platform-onl-init.service
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.service
@@ -4,7 +4,7 @@ After=systemd-modules-load.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/platform-onl-init.sh
+ExecStart=/usr/libexec/platform-onl-init/platform-onl-init.sh
 RemainAfterExit=true
 StandardOutput=journal
 

--- a/recipes-core/platform-onl-init/files/platform-onl-init.sh
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.sh
@@ -41,4 +41,4 @@ wait_for_file() {
 
 onl_platform="$(cat /etc/onl/platform)"
 
-[ -e "/usr/bin/platform-${onl_platform}-init.sh" ] && . /usr/bin/platform-${onl_platform}-init.sh
+[ -e "/usr/libexec/platform-onl-init/platform-${onl_platform}-init.sh" ] && . /usr/libexec/platform-onl-init/platform-${onl_platform}-init.sh

--- a/recipes-core/platform-onl-init/platform-onl-init_0.1.bb
+++ b/recipes-core/platform-onl-init/platform-onl-init_0.1.bb
@@ -28,8 +28,8 @@ SRC_URI += " \
 do_install() {
         install -d ${D}${systemd_system_unitdir}
         install -m 0644 ${WORKDIR}/platform-onl-init.service ${D}${systemd_system_unitdir}
-        install -d ${D}${bindir}
-        install -m 0755 ${WORKDIR}/*.sh ${D}${bindir}
+        install -d ${D}${libexecdir}/platform-onl-init
+        install -m 0755 ${WORKDIR}/*.sh ${D}${libexecdir}/platform-onl-init
 }
 
 SYSTEMD_SERVICE:${PN}:append = "platform-onl-init.service"


### PR DESCRIPTION
FHS says [1]:

    /usr/libexec includes internal binaries that are not intended to be
    executed directly by users or shell scripts. Applications may use a
    single subdirectory under /usr/libexec.

which sounds exactly what these scripts are, so move them there.

[1] https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html