### PR TITLE
linux-yocto-onl/6.6: update to 6.6.35

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -2,14 +2,6 @@
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
 # Generated at 2024-05-07 11:14:22.224509 for version 6.6.30
 
-python check_kernel_cve_status_version() {
-    this_version = "6.6.30"
-    kernel_version = d.getVar("LINUX_VERSION")
-    if kernel_version != this_version:
-        bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
-}
-do_cve_check[prefuncs] += "check_kernel_cve_status_version"
-
 # fixed-version: Fixed after version 2.6.12rc2
 CVE_CHECK_IGNORE += "CVE-2003-1604"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.30"
+LINUX_VERSION ?= "6.6.35"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "5697d159afef8c475f13a0b7b85f09bd4578106c"
+SRCREV_machine ?= "5f2d0708acd0e1d2475d73c61819053de284bcc4"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "fca7e62b0d67399b174d9af0a04fc56e85a80fa3"
+SRCREV_meta ?= "fe550a76832d3c144e7af34ab78d5da0dcf092ce"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.6 and kernel-meta to 6.6.35.

Since the upstream repo for the CVE changes got archived, it does not make sense to keep updating the exclusion file, therefore just remove the version check.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.35
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.34
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.33
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.32
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.31