### PR TITLE
generic-armel-iproc: override GO linuxloader

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -49,3 +49,8 @@ UBOOT_CONFIG = "sandbox"
 UBOOT_CONFIG[sandbox] = "sandbox_defconfig"
 
 PREFERRED_RPROVIDER_u-boot-default-env = "platform-onl-init"
+
+# GO on ARM links against the wrong linuxloader, so manually override it until
+# the issue is fixed upstream.
+# https://patchwork.yoctoproject.org/project/oe-core/patch/20240626141453.84243-1-jonas.gorski@bisdn.de/
+GO_LINUXLOADER="-I /lib/ld-linux.so.3"


### PR DESCRIPTION
GO on ARM links against the wrong linuxloader, so manually override it until the issue is fixed upstream.

[1] https://patchwork.yoctoproject.org/project/oe-core/patch/20240626141453.84243-1-jonas.gorski@bisdn.de/