### PR TITLE
generic-armel-iproc: remove local workaround for GO linuxloader

### DIFF
--- a/conf/machine/generic-armel-iproc.conf
+++ b/conf/machine/generic-armel-iproc.conf
@@ -49,8 +49,3 @@ UBOOT_CONFIG = "sandbox"
 UBOOT_CONFIG[sandbox] = "sandbox_defconfig"
 
 PREFERRED_RPROVIDER_u-boot-default-env = "platform-onl-init"
-
-# GO on ARM links against the wrong linuxloader, so manually override it until
-# the issue is fixed upstream.
-# https://patchwork.yoctoproject.org/project/oe-core/patch/20240626141453.84243-1-jonas.gorski@bisdn.de/
-GO_LINUXLOADER="-I /lib/ld-linux.so.3"


### PR DESCRIPTION
Now that upstream has backported the fix for kirkstone [1], we can drop our local workaround for the issue.

This reverts commit 622ae9b19c47a47f18b8f90ea2ee3321476cceea.

[1] https://github.com/openembedded/openembedded-core/commit/c7426629245db2ea8d9f3cf25b575ac31b5a83b0