### PR TITLE
linux-yocto-onl/6.6: update to 6.6.44

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.35"
+LINUX_VERSION ?= "6.6.44"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "5f2d0708acd0e1d2475d73c61819053de284bcc4"
+SRCREV_machine ?= "7213910600667c51c978e577bf5454d3f7b313b7"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "fe550a76832d3c144e7af34ab78d5da0dcf092ce"
+SRCREV_meta ?= "da7df244f19612d5a886942519ec1f60cad76f60"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.6 to latest 6.6.44, and kernel-meta to latest HEAD.

Brings the usual set of fixes, including some VRF and source address selection fixes in 6.6.44:

    ipv6: take care of scope when choosing the src addr

    commit abb9a68d2c64dd9b128ae1f2e635e4d805e7ce64 upstream.

    When the source address is selected, the scope must be checked. For
    example, if a loopback address is assigned to the vrf device, it must not
    be chosen for packets sent outside.

and

    ipv4: fix source address selection with route leak

    commit 6807352353561187a718e87204458999dbcbba1b upstream.

    By default, an address assigned to the output interface is selected when
    the source address is not specified. This is problematic when a route,
    configured in a vrf, uses an interface from another vrf (aka route leak).
    The original vrf does not own the selected source address.

    Let's add a check against the output interface and call the appropriate
    function to select the source address.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.44
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.43
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.42
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.41
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.40
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.39
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.38
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.37
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.36