### PR TITLE
linux-yocto-onl/6.6: update to 6.6.45

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.44"
+LINUX_VERSION ?= "6.6.45"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "7213910600667c51c978e577bf5454d3f7b313b7"
+SRCREV_machine ?= "878fbff41def4649a2884e9d33bb423f5a7726b0"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "da7df244f19612d5a886942519ec1f60cad76f60"
+SRCREV_meta ?= "4a494b202029e94a72ebb3c3966d9f1d249900f3"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.6 to latest 6.6.45, and kernel-meta to HEAD.

Changelog:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.45