### PR TITLE
linux-yocto-onl/6.6: update to 6.6.71

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.66"
+LINUX_VERSION ?= "6.6.71"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "a66cdcdc9e44b4c508190ea3cde5750954d1c4eb"
+SRCREV_machine ?= "843e64492a7ed11436cc5c9bbfba46835939071a"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "693358ea6816821663168ac9063d60e52a8ee4fe"
+SRCREV_meta ?= "5bb13b9a424ef1f218011e0f0a27ad4cf52e4f61"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel 6.6 to 6.6.71 and kmeta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.71
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.70
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.69
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.68
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.67