### PR TITLE
onl: do not use ${nonarch_base_libdir} for internal ONL paths

### DIFF
--- a/recipes-extended/onl/onl.inc
+++ b/recipes-extended/onl/onl.inc
@@ -215,13 +215,13 @@ do_install() {
 
       # install platform modules
       MODULES_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onl-platform-modules-${baseplatform}:${ONL_BUILD_ARCH})
-      cp -r ${MODULES_DIR}/builds/${nonarch_base_libdir}/modules ${D}${nonarch_base_libdir}
+      cp -r ${MODULES_DIR}/builds/lib/modules ${D}${nonarch_base_libdir}
   done
 
   # install vendor modules
   for vendor in ${ONL_MODULE_VENDORS_BUILD}; do
       MODULES_DIR=$(ONL=${ONL} ONL_DEBIAN_SUITE=${ONL_DEBIAN_SUITE} tools/onlpm.py --packagedirs=${S}/packages --repo=${S}/REPO --show-build-dirs onl-vendor-${vendor}-modules:${ONL_BUILD_ARCH})
-      cp -r ${MODULES_DIR}/builds/${nonarch_base_libdir}/modules ${D}${nonarch_base_libdir}
+      cp -r ${MODULES_DIR}/builds/lib/modules ${D}${nonarch_base_libdir}
   done
 
   # install libonlp shared library


### PR DESCRIPTION
The ONL module code does not follow ${nonarch_base_libdir}, so don't expect ONL to install modules into it, and instead follow its hardcoded path at /lib/modules.

Fixes the build with enabling usrmerge, which is required for newer systemd versions.