### PR TITLE
PoE module fixes

### DIFF
--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4610_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4610_poe_mcu.c
@@ -389,7 +389,6 @@ static int as4610_poe_pse_probe(struct serdev_device *serdev)
 static void as4610_poe_pse_remove(struct serdev_device *serdev)
 {
 	struct as4610_poe_pse *pse = serdev_device_get_drvdata(serdev);
-	int reg;
 
 	bcm591xx_remove(&pse->mcu);
 

--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4610_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4610_poe_mcu.c
@@ -29,8 +29,6 @@
 #include <linux/completion.h>
 #include <linux/debugfs.h>
 
-#include <asm/unaligned.h>
-
 #include "bcm591xx.h"
 
 /* TODO: replace these with regmap or something more sane */

--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -113,7 +113,7 @@ static const struct bcm591xx_ops as4630_poe_pse_ops = {
 
 static int as4630_poe_pse_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
 {
-	int ret, reg, psu_rating;
+	int ret;
 	struct as4630_poe_pse *pse;
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK))

--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -138,7 +138,6 @@ static int as4630_poe_pse_probe_6_3(struct i2c_client *client)
 static int as4630_poe_pse_remove(struct i2c_client *client)
 {
 	struct as4630_poe_pse *pse = i2c_get_clientdata(client);
-	int reg;
 
 	bcm591xx_remove(&pse->mcu);
 

--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -28,7 +28,6 @@
 #include <linux/kernel.h>
 #include <linux/debugfs.h>
 
-#include <asm/unaligned.h>
 #include <linux/version.h>
 
 #include "bcm591xx.h"

--- a/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/accton_as4630_54pe_poe_mcu.c
@@ -113,7 +113,6 @@ static const struct bcm591xx_ops as4630_poe_pse_ops = {
 
 static int as4630_poe_pse_probe(struct i2c_client *client, const struct i2c_device_id *dev_id)
 {
-	int ret;
 	struct as4630_poe_pse *pse;
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK))

--- a/recipes-kernel/bcm591xx-poe-mcu/files/bcm591xx.c
+++ b/recipes-kernel/bcm591xx-poe-mcu/files/bcm591xx.c
@@ -405,7 +405,7 @@ int bcm591xx_init(struct bcm591xx_pse_mcu *mcu, struct device *dev,
 	dev_info(mcu->dev, "Found %i port PoE PSE\n", mcu->num_ports);
 
 	mcu->ports = devm_kcalloc(mcu->dev, sizeof(mcu->ports[0]), mcu->num_ports, GFP_KERNEL);
-	if (mcu->ports)
+	if (!mcu->ports)
 		return -ENOMEM;
 
 	for (i = 0; i < mcu->num_ports; i++) {


### PR DESCRIPTION
Fix an inverted condition in the new bcm591xx library code code recently introduced preventing the code from working, and drop various unused variables and includes.