### PR TITLE
make onl services depend on /etc/onl/platform

### DIFF
--- a/recipes-core/platform-onl-init/files/platform-onl-init.service
+++ b/recipes-core/platform-onl-init/files/platform-onl-init.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Setup ONL platform
 After=systemd-modules-load.service
+ConditionPathExists=/etc/onl/platform
 
 [Service]
 Type=oneshot

--- a/recipes-extended/onl/files/onlpd.service
+++ b/recipes-extended/onl/files/onlpd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=onlpd platform manager daemon
 After=network.target
+ConditionPathExists=/etc/onl/platform
 
 [Service]
 ExecStart=@BINDIR@/onlpd -M /run/onlpd.pid


### PR DESCRIPTION
Both onlpd and platform-onl-init depend on `/etc/onl/platform` being populated, so make their services dependend on that.

Should have no functional impact on current systems, but prepares for non-ONL/ONIE platforms.