### PR TITLE
yocto-cfg-fragments: use fragments from 6.12

### DIFF
--- a/recipes-kernel/linux/yocto-cfg-fragments.bbappend
+++ b/recipes-kernel/linux/yocto-cfg-fragments.bbappend
@@ -1,3 +1,9 @@
+# yocto-cfg-fragments defaults to 6.6 with a fixed revision, so switch to 6.12
+# to match our kernel
+
+LINUX_VERSION = "6.12"
+SRCREV = "19b5087399932add6bc893493fe1146fca7d4799"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto-onl-linux-${LINUX_VERSION}.y:"
 # "Revert" 917043019b46 ("virtio: Add prereqs for tiny") from yocto-kernel-cache
 # as it forces several subsystems like DRM on, which we do not need since none


### PR DESCRIPTION
The yocto-cfg-fragments recipe does not check the built kernel version, but hardcodes linux 6.6. Since we re-use our kmeta patch from the kernel to apply to it, when we dropped linux 6.6 support with commit fac1a5837206 ("linux-yocto-onl: drop 6.6 support"), we dropped the patch used by it, which broke the build.

Fix this by retargeting linux 6.12 for yocto-cfg-fragments.

Fixes the following errors on when trying to build:

```
ERROR: .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments.bb: Unable to get checksum for nativesdk-yocto-cfg-fragments SRC_URI entry 0001-Revert-virtio-Add-prereqs-for-tiny.patch: file could not be found The following paths were searched:
.../poky/meta-open-network-linux/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-linux/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments-v6.12+git19b5087399932add6bc893493fe1146fca7d4799/bisdn-linux/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments/bisdn-linux/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/files/bisdn-linux/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-open-network-linux/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments-v6.12+git19b5087399932add6bc893493fe1146fca7d4799/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/files/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-open-network-linux/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/x86-64/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments-v6.12+git19b5087399932add6bc893493fe1146fca7d4799/x86-64/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments/x86-64/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/files/x86-64/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-open-network-linux/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments-v6.12+git19b5087399932add6bc893493fe1146fca7d4799/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/yocto-cfg-fragments/0001-Revert-virtio-Add-prereqs-for-tiny.patch .../poky/meta-virtualization/recipes-kernel/linux/files/0001-Revert-virtio-Add-prereqs-for-tiny.patch ERROR: Parsing halted due to errors, see error messages above
```

Fixes: fac1a5837206 ("linux-yocto-onl: drop 6.6 support")
Fixes: 5b948b454ec5 ("linux-yocto-onl: add support for kernel 6.12")