### PR TITLE
linux-yocto-onl: update to 6.12.82

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 14:00:34.805826+00:00 for kernel version 6.12.79
+# Generated at 2026-04-21 14:02:18.105408+00:00 for kernel version 6.12.80
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.79"
+    this_version = "6.12.80"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -16110,9 +16110,9 @@ CVE_STATUS[CVE-2025-22114] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2025-22115] = "cpe-stable-backport: Backported in 6.12.40"
 
-# CVE-2025-22116 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2025-22116] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2025-22117 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2025-22117] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2025-22118] = "fixed-version: only affects 6.13 onwards"
 
@@ -19554,7 +19554,7 @@ CVE_STATUS[CVE-2025-68173] = "cpe-stable-backport: Backported in 6.12.58"
 
 # CVE-2025-68174 needs backporting (fixed from 6.18)
 
-# CVE-2025-68175 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2025-68175] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2025-68176] = "cpe-stable-backport: Backported in 6.12.58"
 
@@ -19958,7 +19958,7 @@ CVE_STATUS[CVE-2025-68734] = "cpe-stable-backport: Backported in 6.12.59"
 
 # CVE-2025-68735 needs backporting (fixed from 6.19)
 
-# CVE-2025-68736 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2025-68736] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2025-68737] = "fixed-version: only affects 6.18 onwards"
 
@@ -20438,7 +20438,7 @@ CVE_STATUS[CVE-2026-22979] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22980] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22981 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-22981] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-22982] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20446,7 +20446,7 @@ CVE_STATUS[CVE-2026-22983] = "fixed-version: only affects 6.18.4 onwards"
 
 CVE_STATUS[CVE-2026-22984] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22985 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-22985] = "cpe-stable-backport: Backported in 6.12.80"
 
 # CVE-2026-22986 needs backporting (fixed from 6.19)
 
@@ -20462,7 +20462,7 @@ CVE_STATUS[CVE-2026-22991] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22992] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22993 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-22993] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-22994] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20890,13 +20890,13 @@ CVE_STATUS[CVE-2026-23205] = "cpe-stable-backport: Backported in 6.12.70"
 
 CVE_STATUS[CVE-2026-23206] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23207 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23207] = "cpe-stable-backport: Backported in 6.12.80"
 
 # CVE-2026-23208 needs backporting (fixed from 6.19)
 
 CVE_STATUS[CVE-2026-23209] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23210 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23210] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-23211] = "fixed-version: only affects 6.18 onwards"
 
@@ -20986,7 +20986,7 @@ CVE_STATUS[CVE-2026-23253] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23254] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23255 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23255] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-23256] = "cpe-stable-backport: Backported in 6.12.70"
 
@@ -21274,7 +21274,7 @@ CVE_STATUS[CVE-2026-23399] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23400] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-23401 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23401] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-23402] = "fixed-version: only affects 6.16 onwards"
 
@@ -21300,13 +21300,13 @@ CVE_STATUS[CVE-2026-23412] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23413] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23414 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23414] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-23415] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-23416] = "fixed-version: only affects 6.17 onwards"
 
-# CVE-2026-23417 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-23417] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-23418] = "fixed-version: only affects 6.14 onwards"
 
@@ -21456,11 +21456,11 @@ CVE_STATUS[CVE-2026-31404] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-31405] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-31406 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31406] = "cpe-stable-backport: Backported in 6.12.80"
 
 # CVE-2026-31407 needs backporting (fixed from 7.0)
 
-# CVE-2026-31408 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31408] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31409] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -21470,7 +21470,7 @@ CVE_STATUS[CVE-2026-31411] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-31412] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-31413 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31413] = "cpe-stable-backport: Backported in 6.12.80"
 
 # CVE-2026-31414 may need backporting (fixed from 6.12.81)
 
@@ -21496,11 +21496,11 @@ CVE_STATUS[CVE-2026-31412] = "cpe-stable-backport: Backported in 6.12.78"
 
 # CVE-2026-31425 may need backporting (fixed from 6.12.81)
 
-# CVE-2026-31426 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31426] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31427 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31427] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31428 may need backporting (fixed from 6.12.80)
+CVE_STATUS[CVE-2026-31428] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31788] = "cpe-stable-backport: Backported in 6.12.78"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 14:04:08.770930+00:00 for kernel version 6.12.81
+# Generated at 2026-04-21 14:13:16.121960+00:00 for kernel version 6.12.82
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.81"
+    this_version = "6.12.82"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -18674,7 +18674,7 @@ CVE_STATUS[CVE-2025-39928] = "fixed-version: only affects 6.13 onwards"
 
 CVE_STATUS[CVE-2025-39929] = "cpe-stable-backport: Backported in 6.12.49"
 
-# CVE-2025-39930 may need backporting (fixed from 6.12.82)
+CVE_STATUS[CVE-2025-39930] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2025-39931] = "cpe-stable-backport: Backported in 6.12.49"
 
@@ -21080,7 +21080,7 @@ CVE_STATUS[CVE-2026-23300] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23301] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-23302 may need backporting (fixed from 6.12.82)
+CVE_STATUS[CVE-2026-23302] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-23303] = "cpe-stable-backport: Backported in 6.12.77"
 
@@ -21134,7 +21134,7 @@ CVE_STATUS[CVE-2026-23328] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-23329] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-23330 may need backporting (fixed from 6.12.82)
+CVE_STATUS[CVE-2026-23330] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-23331] = "fixed-version: only affects 6.13 onwards"
 
@@ -21220,7 +21220,7 @@ CVE_STATUS[CVE-2026-23372] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23373] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23374 may need backporting (fixed from 6.12.82)
+CVE_STATUS[CVE-2026-23374] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-23375] = "cpe-stable-backport: Backported in 6.12.78"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 14:02:18.105408+00:00 for kernel version 6.12.80
+# Generated at 2026-04-21 14:04:08.770930+00:00 for kernel version 6.12.81
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.80"
+    this_version = "6.12.81"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -18450,7 +18450,7 @@ CVE_STATUS[CVE-2025-39814] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2025-39815] = "cpe-stable-backport: Backported in 6.12.45"
 
-# CVE-2025-39816 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2025-39816] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2025-39817] = "cpe-stable-backport: Backported in 6.12.45"
 
@@ -20424,7 +20424,7 @@ CVE_STATUS[CVE-2025-71267] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-71268] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2025-71269 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2025-71269] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2025-71270] = "cpe-stable-backport: Backported in 6.12.70"
 
@@ -21250,7 +21250,7 @@ CVE_STATUS[CVE-2026-23387] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23388] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23389 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-23389] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-23390] = "cpe-stable-backport: Backported in 6.12.74"
 
@@ -21472,29 +21472,29 @@ CVE_STATUS[CVE-2026-31412] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-31413] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31414 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31414] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31415 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31415] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31416 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31416] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31417 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31417] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31418 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31418] = "cpe-stable-backport: Backported in 6.12.81"
 
 # CVE-2026-31419 needs backporting (fixed from 7.0)
 
 # CVE-2026-31420 needs backporting (fixed from 7.0)
 
-# CVE-2026-31421 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31421] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31422 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31422] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31423 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31423] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31424 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31424] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31425 may need backporting (fixed from 6.12.81)
+CVE_STATUS[CVE-2026-31425] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31426] = "cpe-stable-backport: Backported in 6.12.80"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-03-23 15:47:58.133856+00:00 for kernel version 6.12.77
-# From cvelistV5 cve_2026-03-21_0700Z
+# Generated at 2026-04-21 14:00:34.805826+00:00 for kernel version 6.12.79
+# From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.77"
+    this_version = "6.12.79"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -2769,8 +2769,6 @@ CVE_STATUS[CVE-2022-49264] = "fixed-version: Fixed from version 5.18"
 CVE_STATUS[CVE-2022-49265] = "fixed-version: Fixed from version 5.18"
 
 CVE_STATUS[CVE-2022-49266] = "fixed-version: Fixed from version 5.18"
-
-CVE_STATUS[CVE-2022-49267] = "fixed-version: Fixed from version 5.18"
 
 CVE_STATUS[CVE-2022-49268] = "fixed-version: Fixed from version 5.18"
 
@@ -9916,8 +9914,6 @@ CVE_STATUS[CVE-2024-27040] = "fixed-version: Fixed from version 6.9"
 
 CVE_STATUS[CVE-2024-27041] = "fixed-version: Fixed from version 6.9"
 
-CVE_STATUS[CVE-2024-27042] = "fixed-version: Fixed from version 6.9"
-
 CVE_STATUS[CVE-2024-27043] = "fixed-version: Fixed from version 6.9"
 
 CVE_STATUS[CVE-2024-27044] = "fixed-version: Fixed from version 6.9"
@@ -16114,9 +16110,9 @@ CVE_STATUS[CVE-2025-22114] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2025-22115] = "cpe-stable-backport: Backported in 6.12.40"
 
-# CVE-2025-22116 needs backporting (fixed from 6.15)
+# CVE-2025-22116 may need backporting (fixed from 6.12.80)
 
-# CVE-2025-22117 needs backporting (fixed from 6.15)
+# CVE-2025-22117 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2025-22118] = "fixed-version: only affects 6.13 onwards"
 
@@ -17552,7 +17548,7 @@ CVE_STATUS[CVE-2025-38424] = "cpe-stable-backport: Backported in 6.12.35"
 
 CVE_STATUS[CVE-2025-38425] = "cpe-stable-backport: Backported in 6.12.35"
 
-# CVE-2025-38426 needs backporting (fixed from 6.16)
+CVE_STATUS[CVE-2025-38426] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-38427] = "cpe-stable-backport: Backported in 6.12.35"
 
@@ -17950,7 +17946,7 @@ CVE_STATUS[CVE-2025-38625] = "cpe-stable-backport: Backported in 6.12.42"
 
 CVE_STATUS[CVE-2025-38626] = "cpe-stable-backport: Backported in 6.12.42"
 
-# CVE-2025-38627 needs backporting (fixed from 6.17)
+CVE_STATUS[CVE-2025-38627] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-38628] = "cpe-stable-backport: Backported in 6.12.42"
 
@@ -18352,7 +18348,7 @@ CVE_STATUS[CVE-2025-39761] = "cpe-stable-backport: Backported in 6.12.43"
 
 CVE_STATUS[CVE-2025-39763] = "cpe-stable-backport: Backported in 6.12.43"
 
-# CVE-2025-39764 needs backporting (fixed from 6.17)
+CVE_STATUS[CVE-2025-39764] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-39765] = "cpe-stable-backport: Backported in 6.12.44"
 
@@ -18454,7 +18450,7 @@ CVE_STATUS[CVE-2025-39814] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2025-39815] = "cpe-stable-backport: Backported in 6.12.45"
 
-CVE_STATUS[CVE-2025-39816] = "cpe-stable-backport: Backported in 6.12.49"
+# CVE-2025-39816 may need backporting (fixed from 6.12.81)
 
 CVE_STATUS[CVE-2025-39817] = "cpe-stable-backport: Backported in 6.12.45"
 
@@ -18678,7 +18674,7 @@ CVE_STATUS[CVE-2025-39928] = "fixed-version: only affects 6.13 onwards"
 
 CVE_STATUS[CVE-2025-39929] = "cpe-stable-backport: Backported in 6.12.49"
 
-CVE_STATUS[CVE-2025-39930] = "fixed-version: only affects 6.14 onwards"
+# CVE-2025-39930 may need backporting (fixed from 6.12.82)
 
 CVE_STATUS[CVE-2025-39931] = "cpe-stable-backport: Backported in 6.12.49"
 
@@ -18828,7 +18824,7 @@ CVE_STATUS[CVE-2025-40003] = "cpe-stable-backport: Backported in 6.12.54"
 
 CVE_STATUS[CVE-2025-40004] = "cpe-stable-backport: Backported in 6.12.53"
 
-# CVE-2025-40005 needs backporting (fixed from 6.17)
+CVE_STATUS[CVE-2025-40005] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-40006] = "cpe-stable-backport: Backported in 6.12.50"
 
@@ -19086,7 +19082,7 @@ CVE_STATUS[CVE-2025-40133] = "cpe-stable-backport: Backported in 6.12.55"
 
 CVE_STATUS[CVE-2025-40134] = "cpe-stable-backport: Backported in 6.12.53"
 
-# CVE-2025-40135 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-40135] = "cpe-stable-backport: Backported in 6.12.78"
 
 # CVE-2025-40136 needs backporting (fixed from 6.18)
 
@@ -19108,13 +19104,13 @@ CVE_STATUS[CVE-2025-40145] = "fixed-version: only affects 6.15 onwards"
 
 # CVE-2025-40146 needs backporting (fixed from 6.18)
 
-# CVE-2025-40147 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-40147] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-40148] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2025-40149] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2025-40150 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-40150] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-40151] = "fixed-version: only affects 6.17 onwards"
 
@@ -19252,7 +19248,7 @@ CVE_STATUS[CVE-2025-40216] = "cpe-stable-backport: Backported in 6.12.36"
 
 CVE_STATUS[CVE-2025-40218] = "cpe-stable-backport: Backported in 6.12.54"
 
-CVE_STATUS[CVE-2025-40219] = "cpe-stable-backport: Backported in 6.12.54"
+CVE_STATUS[CVE-2025-40219] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-40220] = "cpe-stable-backport: Backported in 6.12.54"
 
@@ -19558,7 +19554,7 @@ CVE_STATUS[CVE-2025-68173] = "cpe-stable-backport: Backported in 6.12.58"
 
 # CVE-2025-68174 needs backporting (fixed from 6.18)
 
-# CVE-2025-68175 needs backporting (fixed from 6.18)
+# CVE-2025-68175 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2025-68176] = "cpe-stable-backport: Backported in 6.12.58"
 
@@ -19682,7 +19678,7 @@ CVE_STATUS[CVE-2025-68237] = "cpe-stable-backport: Backported in 6.12.60"
 
 CVE_STATUS[CVE-2025-68238] = "cpe-stable-backport: Backported in 6.12.60"
 
-# CVE-2025-68239 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-68239] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-68240] = "cpe-stable-backport: Backported in 6.12.59"
 
@@ -19844,7 +19840,7 @@ CVE_STATUS[CVE-2025-68332] = "cpe-stable-backport: Backported in 6.12.62"
 
 CVE_STATUS[CVE-2025-68333] = "cpe-stable-backport: Backported in 6.12.68"
 
-# CVE-2025-68334 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-68334] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-68335] = "cpe-stable-backport: Backported in 6.12.62"
 
@@ -19962,7 +19958,7 @@ CVE_STATUS[CVE-2025-68734] = "cpe-stable-backport: Backported in 6.12.59"
 
 # CVE-2025-68735 needs backporting (fixed from 6.19)
 
-# CVE-2025-68736 needs backporting (fixed from 6.19)
+# CVE-2025-68736 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2025-68737] = "fixed-version: only affects 6.18 onwards"
 
@@ -20111,8 +20107,6 @@ CVE_STATUS[CVE-2025-68809] = "cpe-stable-backport: Backported in 6.12.64"
 CVE_STATUS[CVE-2025-68810] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-68811] = "cpe-stable-backport: Backported in 6.12.64"
-
-CVE_STATUS[CVE-2025-68812] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2025-68813] = "cpe-stable-backport: Backported in 6.12.64"
 
@@ -20312,7 +20306,7 @@ CVE_STATUS[CVE-2025-71150] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71151] = "cpe-stable-backport: Backported in 6.12.64"
 
-# CVE-2025-71152 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2025-71152] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-71153] = "cpe-stable-backport: Backported in 6.12.64"
 
@@ -20330,7 +20324,7 @@ CVE_STATUS[CVE-2025-71159] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2025-71160] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2025-71161 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2025-71161] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-71162] = "cpe-stable-backport: Backported in 6.12.67"
 
@@ -20388,7 +20382,7 @@ CVE_STATUS[CVE-2025-71204] = "cpe-stable-backport: Backported in 6.12.70"
 
 CVE_STATUS[CVE-2025-71220] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2025-71221 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2025-71221] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-71222] = "cpe-stable-backport: Backported in 6.12.70"
 
@@ -20430,7 +20424,7 @@ CVE_STATUS[CVE-2025-71267] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-71268] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2025-71269 needs backporting (fixed from 6.19)
+# CVE-2025-71269 may need backporting (fixed from 6.12.81)
 
 CVE_STATUS[CVE-2025-71270] = "cpe-stable-backport: Backported in 6.12.70"
 
@@ -20444,7 +20438,7 @@ CVE_STATUS[CVE-2026-22979] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22980] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22981 needs backporting (fixed from 6.19)
+# CVE-2026-22981 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2026-22982] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20452,7 +20446,7 @@ CVE_STATUS[CVE-2026-22983] = "fixed-version: only affects 6.18.4 onwards"
 
 CVE_STATUS[CVE-2026-22984] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22985 needs backporting (fixed from 6.19)
+# CVE-2026-22985 may need backporting (fixed from 6.12.80)
 
 # CVE-2026-22986 needs backporting (fixed from 6.19)
 
@@ -20468,7 +20462,7 @@ CVE_STATUS[CVE-2026-22991] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22992] = "cpe-stable-backport: Backported in 6.12.66"
 
-# CVE-2026-22993 needs backporting (fixed from 6.19)
+# CVE-2026-22993 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2026-22994] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20490,7 +20484,7 @@ CVE_STATUS[CVE-2026-23002] = "cpe-stable-backport: Backported in 6.12.67"
 
 CVE_STATUS[CVE-2026-23003] = "cpe-stable-backport: Backported in 6.12.67"
 
-# CVE-2026-23004 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23004] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23005] = "cpe-stable-backport: Backported in 6.12.67"
 
@@ -20614,7 +20608,7 @@ CVE_STATUS[CVE-2026-23064] = "cpe-stable-backport: Backported in 6.12.68"
 
 CVE_STATUS[CVE-2026-23065] = "cpe-stable-backport: Backported in 6.12.68"
 
-# CVE-2026-23066 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23066] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23067] = "fixed-version: only affects 6.16 onwards"
 
@@ -20622,7 +20616,7 @@ CVE_STATUS[CVE-2026-23068] = "cpe-stable-backport: Backported in 6.12.68"
 
 CVE_STATUS[CVE-2026-23069] = "cpe-stable-backport: Backported in 6.12.68"
 
-# CVE-2026-23070 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23070] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23071] = "cpe-stable-backport: Backported in 6.12.68"
 
@@ -20690,7 +20684,7 @@ CVE_STATUS[CVE-2026-23101] = "cpe-stable-backport: Backported in 6.12.68"
 
 CVE_STATUS[CVE-2026-23103] = "cpe-stable-backport: Backported in 6.12.68"
 
-# CVE-2026-23104 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23104] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23105] = "cpe-stable-backport: Backported in 6.12.68"
 
@@ -20758,7 +20752,7 @@ CVE_STATUS[CVE-2026-23136] = "cpe-stable-backport: Backported in 6.12.66"
 
 # CVE-2026-23137 needs backporting (fixed from 6.19)
 
-# CVE-2026-23138 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23138] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23139] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20796,7 +20790,7 @@ CVE_STATUS[CVE-2026-23155] = "cpe-stable-backport: Backported in 6.12.69"
 
 CVE_STATUS[CVE-2026-23156] = "cpe-stable-backport: Backported in 6.12.69"
 
-# CVE-2026-23157 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-23157] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23158] = "cpe-stable-backport: Backported in 6.12.69"
 
@@ -20896,13 +20890,13 @@ CVE_STATUS[CVE-2026-23205] = "cpe-stable-backport: Backported in 6.12.70"
 
 CVE_STATUS[CVE-2026-23206] = "cpe-stable-backport: Backported in 6.12.70"
 
-CVE_STATUS[CVE-2026-23207] = "fixed-version: only affects 6.18.2 onwards"
+# CVE-2026-23207 may need backporting (fixed from 6.12.80)
 
 # CVE-2026-23208 needs backporting (fixed from 6.19)
 
 CVE_STATUS[CVE-2026-23209] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23210 needs backporting (fixed from 6.19)
+# CVE-2026-23210 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2026-23211] = "fixed-version: only affects 6.18 onwards"
 
@@ -20972,11 +20966,11 @@ CVE_STATUS[CVE-2026-23243] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-23244] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23245 needs backporting (fixed from 7.0rc3)
+CVE_STATUS[CVE-2026-23245] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23246] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23247 needs backporting (fixed from 7.0rc3)
+# CVE-2026-23247 needs backporting (fixed from 7.0)
 
 CVE_STATUS[CVE-2026-23248] = "fixed-version: only affects 6.14 onwards"
 
@@ -20986,13 +20980,13 @@ CVE_STATUS[CVE-2026-23250] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-23251] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-23252 needs backporting (fixed from 7.0rc1)
+CVE_STATUS[CVE-2026-23252] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23253] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23254] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23255 needs backporting (fixed from 6.19)
+# CVE-2026-23255 may need backporting (fixed from 6.12.80)
 
 CVE_STATUS[CVE-2026-23256] = "cpe-stable-backport: Backported in 6.12.70"
 
@@ -21012,7 +21006,7 @@ CVE_STATUS[CVE-2026-23263] = "fixed-version: only affects 6.17 onwards"
 
 CVE_STATUS[CVE-2026-23264] = "cpe-stable-backport: Backported in 6.12.70"
 
-# CVE-2026-23265 needs backporting (fixed from 7.0rc1)
+# CVE-2026-23265 needs backporting (fixed from 7.0)
 
 CVE_STATUS[CVE-2026-23266] = "cpe-stable-backport: Backported in 6.12.74"
 
@@ -21026,17 +21020,487 @@ CVE_STATUS[CVE-2026-23270] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23271] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23272 needs backporting (fixed from 7.0rc3)
+# CVE-2026-23272 needs backporting (fixed from 7.0)
 
 CVE_STATUS[CVE-2026-23273] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-23274 needs backporting (fixed from 7.0rc4)
+CVE_STATUS[CVE-2026-23274] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23275] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2026-23276 needs backporting (fixed from 7.0rc4)
+CVE_STATUS[CVE-2026-23276] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23277 needs backporting (fixed from 7.0rc4)
+CVE_STATUS[CVE-2026-23277] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23278 needs backporting (fixed from 7.0rc4)
+CVE_STATUS[CVE-2026-23278] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23279] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23280] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23281] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23282] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-23283] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23284] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23285] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23286] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23287] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23288] = "fixed-version: only affects 6.19.4 onwards"
+
+CVE_STATUS[CVE-2026-23289] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23290] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23291] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23292] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23293] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23294] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23295] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23296] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23297] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23298] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23299] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-23300] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23301] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-23302 may need backporting (fixed from 6.12.82)
+
+CVE_STATUS[CVE-2026-23303] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23304] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23305] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23306] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23307] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23308] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23309] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23310] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23311] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-23312] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23313] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23314] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23315] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23316] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23317] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23318] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23319] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23321] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23322] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23323] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23324] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23325] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23326] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-23327 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23328] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-23329] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-23330 may need backporting (fixed from 6.12.82)
+
+CVE_STATUS[CVE-2026-23331] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-23332] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23334] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23335] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23336] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23337] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23338] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23339] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23340] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23341] = "fixed-version: only affects 6.19.4 onwards"
+
+CVE_STATUS[CVE-2026-23342] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23343] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23344] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23345] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-23346 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23347] = "cpe-stable-backport: Backported in 6.12.77"
+
+# CVE-2026-23348 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23349] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23350] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23351] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23352] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23353] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23354] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23355] = "fixed-version: only affects 6.18.14 onwards"
+
+CVE_STATUS[CVE-2026-23356] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23357] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23358] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23359] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23360] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23361] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23362] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23363] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23364] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23365] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23366] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23367] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23368] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23369] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23370] = "cpe-stable-backport: Backported in 6.12.77"
+
+# CVE-2026-23371 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23372] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23373] = "cpe-stable-backport: Backported in 6.12.77"
+
+# CVE-2026-23374 may need backporting (fixed from 6.12.82)
+
+CVE_STATUS[CVE-2026-23375] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23376] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-23377 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23378] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23379] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23380] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23381] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23382] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23383] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23384] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-23385 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23386] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23387] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23388] = "cpe-stable-backport: Backported in 6.12.77"
+
+# CVE-2026-23389 may need backporting (fixed from 6.12.81)
+
+CVE_STATUS[CVE-2026-23390] = "cpe-stable-backport: Backported in 6.12.74"
+
+CVE_STATUS[CVE-2026-23391] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23392] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23393] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-23394 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23395] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23396] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23397] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23398] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23399] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23400] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-23401 may need backporting (fixed from 6.12.80)
+
+CVE_STATUS[CVE-2026-23402] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23403] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23404] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23405] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23406] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23407] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23408] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23409] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23410] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23411] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23412] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23413] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-23414 may need backporting (fixed from 6.12.80)
+
+CVE_STATUS[CVE-2026-23415] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23416] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-23417 may need backporting (fixed from 6.12.80)
+
+CVE_STATUS[CVE-2026-23418] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-23419] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23420] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23421] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23422] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23423] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-23424] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-23425] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-23426] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-23427] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23428] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23429] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23430] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-23431] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-23432] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23433] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23434] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23435] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-23436] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-23437] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-23438] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23439] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23440] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23441] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-23442 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23443] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-23444 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23445] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23446] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23447] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23448] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23449] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23450] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23451] = "fixed-version: only affects 6.18.19 onwards"
+
+CVE_STATUS[CVE-2026-23452] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23453] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-23454] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23455] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23456] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23457] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23458] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23459] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-23460] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23461] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23462] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23463] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23464] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23465] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23466] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23467] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-23468 needs backporting (fixed from 7.0)
+
+# CVE-2026-23469 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23470] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-23472 needs backporting (fixed from 7.0)
+
+# CVE-2026-23473 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-23474] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-23475] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31389] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31390] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31391] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31392] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31393] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31394] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31395] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-31396] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31397] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31398] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31399] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31400] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31401] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31402] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31403] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31404] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31405] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-31406 may need backporting (fixed from 6.12.80)
+
+# CVE-2026-31407 needs backporting (fixed from 7.0)
+
+# CVE-2026-31408 may need backporting (fixed from 6.12.80)
+
+CVE_STATUS[CVE-2026-31409] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31410] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31411] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-31412] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-31413 may need backporting (fixed from 6.12.80)
+
+# CVE-2026-31414 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31415 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31416 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31417 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31418 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31419 needs backporting (fixed from 7.0)
+
+# CVE-2026-31420 needs backporting (fixed from 7.0)
+
+# CVE-2026-31421 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31422 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31423 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31424 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31425 may need backporting (fixed from 6.12.81)
+
+# CVE-2026-31426 may need backporting (fixed from 6.12.80)
+
+# CVE-2026-31427 may need backporting (fixed from 6.12.80)
+
+# CVE-2026-31428 may need backporting (fixed from 6.12.80)
+
+CVE_STATUS[CVE-2026-31788] = "cpe-stable-backport: Backported in 6.12.78"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.77"
+LINUX_VERSION ?= "6.12.79"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "6f232446a62980e51f537db1c655e686d869b9ed"
+SRCREV_machine ?= "c2d104a355013a14bcd73e31fb2c4bc21922115a"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "19b5087399932add6bc893493fe1146fca7d4799"
+SRCREV_meta ?= "50fc2fcce39b1abff6f5438f410b2ef015e10479"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.79"
+LINUX_VERSION ?= "6.12.80"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "c2d104a355013a14bcd73e31fb2c4bc21922115a"
+SRCREV_machine ?= "00d7934ffcc35e65b113ba4991c8a3338bd85fc1"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "50fc2fcce39b1abff6f5438f410b2ef015e10479"
+SRCREV_meta ?= "8bb0dbe2b50860402b07a506a5aa3a4ef7aba0a7"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.81"
+LINUX_VERSION ?= "6.12.82"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "e7a3953084a7050ca349010deb22546834c2e196"
+SRCREV_machine ?= "d75ae3350fe8a29588a3f489952d06928cb85675"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.80"
+LINUX_VERSION ?= "6.12.81"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "00d7934ffcc35e65b113ba4991c8a3338bd85fc1"
+SRCREV_machine ?= "e7a3953084a7050ca349010deb22546834c2e196"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "8bb0dbe2b50860402b07a506a5aa3a4ef7aba0a7"
+SRCREV_meta ?= "b507ba98ba3ecc385b14a231dddafaea3421f778"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.12 to 6.12.82 and kmeta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.82
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.81
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.80
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.79