### PR TITLE
v5.x: linux-yocto-onl: update 6.6 to 6.6.135

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 15:01:35.785237+00:00 for kernel version 6.6.133
+# Generated at 2026-04-21 15:03:12.694978+00:00 for kernel version 6.6.134
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.133"
+    this_version = "6.6.134"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -14767,7 +14767,8 @@ CVE_CHECK_IGNORE += "CVE-2024-27020"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2024-27021"
 
-# CVE-2024-27022 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2024-27022"
 
 # cpe-stable-backport: Backported in 6.6.19
 CVE_CHECK_IGNORE += "CVE-2024-27023"
@@ -26930,7 +26931,8 @@ CVE_CHECK_IGNORE += "CVE-2025-38708"
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-38709"
 
-# CVE-2025-38710 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2025-38710"
 
 # cpe-stable-backport: Backported in 6.6.103
 CVE_CHECK_IGNORE += "CVE-2025-38711"
@@ -30307,7 +30309,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71267"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71268"
 
-# CVE-2025-71269 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2025-71269"
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71270"
@@ -31839,29 +31842,39 @@ CVE_CHECK_IGNORE += "CVE-2026-31412"
 # fixed-version: only affects 6.12.75 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31413"
 
-# CVE-2026-31414 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31414"
 
-# CVE-2026-31415 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31415"
 
-# CVE-2026-31416 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31416"
 
-# CVE-2026-31417 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31417"
 
-# CVE-2026-31418 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31418"
 
 # CVE-2026-31419 needs backporting (fixed from 7.0)
 
 # CVE-2026-31420 needs backporting (fixed from 7.0)
 
-# CVE-2026-31421 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31421"
 
-# CVE-2026-31422 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31422"
 
-# CVE-2026-31423 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31423"
 
-# CVE-2026-31424 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31424"
 
-# CVE-2026-31425 may need backporting (fixed from 6.6.134)
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31425"
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31426"

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 14:29:54.371654+00:00 for kernel version 6.6.130
+# Generated at 2026-04-21 15:01:35.785237+00:00 for kernel version 6.6.133
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.130"
+    this_version = "6.6.133"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -13511,7 +13511,8 @@ CVE_CHECK_IGNORE += "CVE-2023-54326"
 # fixed-version: Fixed from version 6.3
 CVE_CHECK_IGNORE += "CVE-2023-7324"
 
-# CVE-2024-14027 may need backporting (fixed from 6.6.133)
+# cpe-stable-backport: Backported in 6.6.133
+CVE_CHECK_IGNORE += "CVE-2024-14027"
 
 # cpe-stable-backport: Backported in 6.6.17
 CVE_CHECK_IGNORE += "CVE-2024-26581"
@@ -28652,7 +28653,8 @@ CVE_CHECK_IGNORE += "CVE-2025-40240"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2025-40241"
 
-# CVE-2025-40242 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2025-40242"
 
 # cpe-stable-backport: Backported in 6.6.115
 CVE_CHECK_IGNORE += "CVE-2025-40243"
@@ -31432,7 +31434,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23358"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23359"
 
-# CVE-2026-23360 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-23360"
 
 # CVE-2026-23361 needs backporting (fixed from 7.0)
 
@@ -31546,7 +31549,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23398"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23400"
 
-# CVE-2026-23401 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-23401"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23402"
@@ -31584,7 +31588,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23412"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23413"
 
-# CVE-2026-23414 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-23414"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23415"
@@ -31817,7 +31822,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31406"
 
 # CVE-2026-31407 needs backporting (fixed from 7.0)
 
-# CVE-2026-31408 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31408"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-31409"
@@ -31857,11 +31863,14 @@ CVE_CHECK_IGNORE += "CVE-2026-31413"
 
 # CVE-2026-31425 may need backporting (fixed from 6.6.134)
 
-# CVE-2026-31426 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31426"
 
-# CVE-2026-31427 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31427"
 
-# CVE-2026-31428 may need backporting (fixed from 6.6.131)
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31428"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-31788"

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 15:03:12.694978+00:00 for kernel version 6.6.134
+# Generated at 2026-04-21 15:17:25.834844+00:00 for kernel version 6.6.135
 # From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.134"
+    this_version = "6.6.135"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -22898,7 +22898,8 @@ CVE_CHECK_IGNORE += "CVE-2025-21737"
 # cpe-stable-backport: Backported in 6.6.78
 CVE_CHECK_IGNORE += "CVE-2025-21738"
 
-# CVE-2025-21739 may need backporting (fixed from 6.6.135)
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2025-21739"
 
 # cpe-stable-backport: Backported in 6.6.78
 CVE_CHECK_IGNORE += "CVE-2025-21741"
@@ -27751,7 +27752,8 @@ CVE_CHECK_IGNORE += "CVE-2025-39928"
 # cpe-stable-backport: Backported in 6.6.108
 CVE_CHECK_IGNORE += "CVE-2025-39929"
 
-# CVE-2025-39930 may need backporting (fixed from 6.6.135)
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2025-39930"
 
 # cpe-stable-backport: Backported in 6.6.108
 CVE_CHECK_IGNORE += "CVE-2025-39931"

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-03-23 09:55:33.225993+00:00 for kernel version 6.6.129
-# From cvelistV5 cve_2026-03-21_0700Z
+# Generated at 2026-04-21 14:29:54.371654+00:00 for kernel version 6.6.130
+# From cvelistV5 cve_2026-04-20_0900Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.129"
+    this_version = "6.6.130"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -4130,9 +4130,6 @@ CVE_CHECK_IGNORE += "CVE-2022-49265"
 
 # fixed-version: Fixed from version 5.18
 CVE_CHECK_IGNORE += "CVE-2022-49266"
-
-# fixed-version: Fixed from version 5.18
-CVE_CHECK_IGNORE += "CVE-2022-49267"
 
 # fixed-version: Fixed from version 5.18
 CVE_CHECK_IGNORE += "CVE-2022-49268"
@@ -13514,8 +13511,7 @@ CVE_CHECK_IGNORE += "CVE-2023-54326"
 # fixed-version: Fixed from version 6.3
 CVE_CHECK_IGNORE += "CVE-2023-7324"
 
-# fixed-version: only affects 6.11 onwards
-CVE_CHECK_IGNORE += "CVE-2024-14027"
+# CVE-2024-14027 may need backporting (fixed from 6.6.133)
 
 # cpe-stable-backport: Backported in 6.6.17
 CVE_CHECK_IGNORE += "CVE-2024-26581"
@@ -14770,7 +14766,7 @@ CVE_CHECK_IGNORE += "CVE-2024-27020"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2024-27021"
 
-# CVE-2024-27022 needs backporting (fixed from 6.9)
+# CVE-2024-27022 may need backporting (fixed from 6.6.134)
 
 # cpe-stable-backport: Backported in 6.6.19
 CVE_CHECK_IGNORE += "CVE-2024-27023"
@@ -14828,9 +14824,6 @@ CVE_CHECK_IGNORE += "CVE-2024-27040"
 
 # cpe-stable-backport: Backported in 6.6.23
 CVE_CHECK_IGNORE += "CVE-2024-27041"
-
-# cpe-stable-backport: Backported in 6.6.23
-CVE_CHECK_IGNORE += "CVE-2024-27042"
 
 # cpe-stable-backport: Backported in 6.6.23
 CVE_CHECK_IGNORE += "CVE-2024-27043"
@@ -17845,7 +17838,8 @@ CVE_CHECK_IGNORE += "CVE-2024-43823"
 # cpe-stable-backport: Backported in 6.6.44
 CVE_CHECK_IGNORE += "CVE-2024-43825"
 
-# CVE-2024-43826 needs backporting (fixed from 6.11)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2024-43826"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2024-43827"
@@ -18447,7 +18441,7 @@ CVE_CHECK_IGNORE += "CVE-2024-46689"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2024-46690"
 
-# fixed-version: only affects 6.10 onwards
+# cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2024-46691"
 
 # cpe-stable-backport: Backported in 6.6.49
@@ -22744,7 +22738,8 @@ CVE_CHECK_IGNORE += "CVE-2025-21680"
 # cpe-stable-backport: Backported in 6.6.74
 CVE_CHECK_IGNORE += "CVE-2025-21681"
 
-# CVE-2025-21682 needs backporting (fixed from 6.13)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-21682"
 
 # cpe-stable-backport: Backported in 6.6.74
 CVE_CHECK_IGNORE += "CVE-2025-21683"
@@ -22901,7 +22896,7 @@ CVE_CHECK_IGNORE += "CVE-2025-21737"
 # cpe-stable-backport: Backported in 6.6.78
 CVE_CHECK_IGNORE += "CVE-2025-21738"
 
-# CVE-2025-21739 needs backporting (fixed from 6.14)
+# CVE-2025-21739 may need backporting (fixed from 6.6.135)
 
 # cpe-stable-backport: Backported in 6.6.78
 CVE_CHECK_IGNORE += "CVE-2025-21741"
@@ -25340,7 +25335,7 @@ CVE_CHECK_IGNORE += "CVE-2025-38162"
 # cpe-stable-backport: Backported in 6.6.94
 CVE_CHECK_IGNORE += "CVE-2025-38163"
 
-# fixed-version: only affects 6.9 onwards
+# cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2025-38164"
 
 # cpe-stable-backport: Backported in 6.6.94
@@ -26101,7 +26096,8 @@ CVE_CHECK_IGNORE += "CVE-2025-38424"
 # cpe-stable-backport: Backported in 6.6.95
 CVE_CHECK_IGNORE += "CVE-2025-38425"
 
-# CVE-2025-38426 needs backporting (fixed from 6.16)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-38426"
 
 # cpe-stable-backport: Backported in 6.6.95
 CVE_CHECK_IGNORE += "CVE-2025-38427"
@@ -26916,7 +26912,8 @@ CVE_CHECK_IGNORE += "CVE-2025-38702"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2025-38703"
 
-# CVE-2025-38704 needs backporting (fixed from 6.17)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-38704"
 
 # CVE-2025-38705 needs backporting (fixed from 6.17)
 
@@ -26932,7 +26929,7 @@ CVE_CHECK_IGNORE += "CVE-2025-38708"
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-38709"
 
-# CVE-2025-38710 needs backporting (fixed from 6.17)
+# CVE-2025-38710 may need backporting (fixed from 6.6.134)
 
 # cpe-stable-backport: Backported in 6.6.103
 CVE_CHECK_IGNORE += "CVE-2025-38711"
@@ -27232,7 +27229,8 @@ CVE_CHECK_IGNORE += "CVE-2025-39745"
 
 # CVE-2025-39747 needs backporting (fixed from 6.17)
 
-# CVE-2025-39748 needs backporting (fixed from 6.17)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-39748"
 
 # cpe-stable-backport: Backported in 6.6.103
 CVE_CHECK_IGNORE += "CVE-2025-39749"
@@ -27274,7 +27272,8 @@ CVE_CHECK_IGNORE += "CVE-2025-39761"
 # cpe-stable-backport: Backported in 6.6.103
 CVE_CHECK_IGNORE += "CVE-2025-39763"
 
-# CVE-2025-39764 needs backporting (fixed from 6.17)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-39764"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2025-39765"
@@ -27749,8 +27748,7 @@ CVE_CHECK_IGNORE += "CVE-2025-39928"
 # cpe-stable-backport: Backported in 6.6.108
 CVE_CHECK_IGNORE += "CVE-2025-39929"
 
-# fixed-version: only affects 6.14 onwards
-CVE_CHECK_IGNORE += "CVE-2025-39930"
+# CVE-2025-39930 may need backporting (fixed from 6.6.135)
 
 # cpe-stable-backport: Backported in 6.6.108
 CVE_CHECK_IGNORE += "CVE-2025-39931"
@@ -28343,7 +28341,8 @@ CVE_CHECK_IGNORE += "CVE-2025-40133"
 # cpe-stable-backport: Backported in 6.6.112
 CVE_CHECK_IGNORE += "CVE-2025-40134"
 
-# CVE-2025-40135 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-40135"
 
 # CVE-2025-40136 needs backporting (fixed from 6.18)
 
@@ -28381,7 +28380,7 @@ CVE_CHECK_IGNORE += "CVE-2025-40148"
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2025-40149"
 
-# fixed-version: only affects 6.9 onwards
+# cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2025-40150"
 
 # fixed-version: only affects 6.17 onwards
@@ -28584,7 +28583,7 @@ CVE_CHECK_IGNORE += "CVE-2025-40217"
 # cpe-stable-backport: Backported in 6.6.113
 CVE_CHECK_IGNORE += "CVE-2025-40218"
 
-# cpe-stable-backport: Backported in 6.6.113
+# cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2025-40219"
 
 # cpe-stable-backport: Backported in 6.6.115
@@ -28653,7 +28652,7 @@ CVE_CHECK_IGNORE += "CVE-2025-40240"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2025-40241"
 
-# CVE-2025-40242 needs backporting (fixed from 6.18)
+# CVE-2025-40242 may need backporting (fixed from 6.6.131)
 
 # cpe-stable-backport: Backported in 6.6.115
 CVE_CHECK_IGNORE += "CVE-2025-40243"
@@ -29118,7 +29117,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68204"
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68205"
 
-# CVE-2025-68206 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-68206"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68207"
@@ -29210,7 +29210,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68237"
 # cpe-stable-backport: Backported in 6.6.118
 CVE_CHECK_IGNORE += "CVE-2025-68238"
 
-# CVE-2025-68239 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-68239"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68240"
@@ -29446,7 +29447,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68332"
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68333"
 
-# CVE-2025-68334 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-68334"
 
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-68335"
@@ -29512,7 +29514,7 @@ CVE_CHECK_IGNORE += "CVE-2025-68355"
 
 # CVE-2025-68356 needs backporting (fixed from 6.19)
 
-# fixed-version: only affects 6.12.63 onwards
+# cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2025-68357"
 
 # cpe-stable-backport: Backported in 6.6.124
@@ -29838,9 +29840,6 @@ CVE_CHECK_IGNORE += "CVE-2025-68810"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68811"
 
-# fixed-version: only affects 6.15 onwards
-CVE_CHECK_IGNORE += "CVE-2025-68812"
-
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-68813"
 
@@ -30132,7 +30131,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71150"
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-71151"
 
-# CVE-2025-71152 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-71152"
 
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-71153"
@@ -30158,7 +30158,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71159"
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2025-71160"
 
-# CVE-2025-71161 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-71161"
 
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2025-71162"
@@ -30178,7 +30179,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71182"
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2025-71183"
 
-# CVE-2025-71184 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-71184"
 
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2025-71185"
@@ -30233,7 +30235,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71201"
 
 # CVE-2025-71202 needs backporting (fixed from 6.19)
 
-# CVE-2025-71203 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-71203"
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71204"
@@ -30241,7 +30244,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71204"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71220"
 
-# CVE-2025-71221 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2025-71221"
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71222"
@@ -30301,7 +30305,7 @@ CVE_CHECK_IGNORE += "CVE-2025-71267"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71268"
 
-# CVE-2025-71269 needs backporting (fixed from 6.19)
+# CVE-2025-71269 may need backporting (fixed from 6.6.134)
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2025-71270"
@@ -30388,7 +30392,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23002"
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2026-23003"
 
-# CVE-2026-23004 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23004"
 
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2026-23005"
@@ -30524,7 +30529,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23048"
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2026-23049"
 
-# CVE-2026-23050 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23050"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23051"
@@ -30532,7 +30538,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23051"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23052"
 
-# CVE-2026-23053 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23053"
 
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2026-23054"
@@ -30570,7 +30577,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23064"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23065"
 
-# CVE-2026-23066 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23066"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23067"
@@ -30725,7 +30733,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23116"
 # fixed-version: only affects 6.18.2 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23117"
 
-# CVE-2026-23118 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23118"
 
 # cpe-stable-backport: Backported in 6.6.122
 CVE_CHECK_IGNORE += "CVE-2026-23119"
@@ -30783,7 +30792,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23136"
 
 # CVE-2026-23137 needs backporting (fixed from 6.19)
 
-# CVE-2026-23138 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23138"
 
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2026-23139"
@@ -30830,7 +30840,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23152"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23153"
 
-# CVE-2026-23154 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23154"
 
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23155"
@@ -30838,7 +30849,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23155"
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23156"
 
-# CVE-2026-23157 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23157"
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23158"
@@ -30985,7 +30997,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23205"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2026-23206"
 
-# fixed-version: only affects 6.18.2 onwards
+# fixed-version: only affects 6.12.63 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23207"
 
 # CVE-2026-23208 needs backporting (fixed from 6.19)
@@ -31039,9 +31051,10 @@ CVE_CHECK_IGNORE += "CVE-2026-23224"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23225"
 
-# CVE-2026-23226 needs backporting (fixed from 7.0rc1)
+# CVE-2026-23226 needs backporting (fixed from 7.0)
 
-# CVE-2026-23227 needs backporting (fixed from 7.0rc1)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23227"
 
 # cpe-stable-backport: Backported in 6.6.125
 CVE_CHECK_IGNORE += "CVE-2026-23228"
@@ -31076,9 +31089,9 @@ CVE_CHECK_IGNORE += "CVE-2026-23237"
 # cpe-stable-backport: Backported in 6.6.127
 CVE_CHECK_IGNORE += "CVE-2026-23238"
 
-# CVE-2026-23239 needs backporting (fixed from 7.0rc2)
+# CVE-2026-23239 needs backporting (fixed from 7.0)
 
-# CVE-2026-23240 needs backporting (fixed from 7.0rc2)
+# CVE-2026-23240 needs backporting (fixed from 7.0)
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23241"
@@ -31089,13 +31102,16 @@ CVE_CHECK_IGNORE += "CVE-2026-23242"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-23243"
 
-# CVE-2026-23244 needs backporting (fixed from 7.0rc3)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23244"
 
-# CVE-2026-23245 needs backporting (fixed from 7.0rc3)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23245"
 
-# CVE-2026-23246 needs backporting (fixed from 7.0rc2)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23246"
 
-# CVE-2026-23247 needs backporting (fixed from 7.0rc3)
+# CVE-2026-23247 needs backporting (fixed from 7.0)
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23248"
@@ -31112,7 +31128,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23251"
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23252"
 
-# CVE-2026-23253 needs backporting (fixed from 7.0rc2)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23253"
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2026-23254"
@@ -31146,7 +31163,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23263"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2026-23264"
 
-# CVE-2026-23265 needs backporting (fixed from 7.0rc1)
+# CVE-2026-23265 needs backporting (fixed from 7.0)
 
 # cpe-stable-backport: Backported in 6.6.127
 CVE_CHECK_IGNORE += "CVE-2026-23266"
@@ -31154,28 +31171,698 @@ CVE_CHECK_IGNORE += "CVE-2026-23266"
 # cpe-stable-backport: Backported in 6.6.127
 CVE_CHECK_IGNORE += "CVE-2026-23267"
 
-# CVE-2026-23268 needs backporting (fixed from 7.0rc4)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23268"
 
-# CVE-2026-23269 needs backporting (fixed from 7.0rc4)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23269"
 
-# fixed-version: only affects 6.8 onwards
+# cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23270"
 
-# CVE-2026-23271 needs backporting (fixed from 7.0rc2)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23271"
 
-# CVE-2026-23272 needs backporting (fixed from 7.0rc3)
+# CVE-2026-23272 needs backporting (fixed from 7.0)
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-23273"
 
-# CVE-2026-23274 needs backporting (fixed from 7.0rc4)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23274"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23275"
 
-# CVE-2026-23276 needs backporting (fixed from 7.0rc4)
+# CVE-2026-23276 needs backporting (fixed from 7.0)
 
-# CVE-2026-23277 needs backporting (fixed from 7.0rc4)
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23277"
 
-# CVE-2026-23278 needs backporting (fixed from 7.0rc4)
+# CVE-2026-23278 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23279"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23280"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23281"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23282"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23283"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23284"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23285"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23286"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23287"
+
+# fixed-version: only affects 6.19.4 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23288"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23289"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23290"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23291"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23292"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23293"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23294"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23295"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23296"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23297"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23298"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23299"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23300"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23301"
+
+# CVE-2026-23302 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23303"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23304"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23305"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23306"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23307"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23308"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23309"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23310"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23311"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23312"
+
+# CVE-2026-23313 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23314"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23315"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23316"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23317"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23318"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23319"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23321"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23322"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23323"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23324"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23325"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23326"
+
+# CVE-2026-23327 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23328"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23329"
+
+# CVE-2026-23330 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23331"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23332"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23334"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23335"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23336"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23337"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23338"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23339"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23340"
+
+# fixed-version: only affects 6.19.4 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23341"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23342"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23343"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23344"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23345"
+
+# CVE-2026-23346 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23347"
+
+# CVE-2026-23348 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23349"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23350"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23351"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23352"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23353"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23354"
+
+# fixed-version: only affects 6.18.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23355"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23356"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23357"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23358"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23359"
+
+# CVE-2026-23360 may need backporting (fixed from 6.6.131)
+
+# CVE-2026-23361 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23362"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23363"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23364"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23365"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23366"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23367"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23368"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23369"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23370"
+
+# CVE-2026-23371 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23372"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23373"
+
+# CVE-2026-23374 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23375"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23376"
+
+# CVE-2026-23377 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23378"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23379"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23380"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23381"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23382"
+
+# CVE-2026-23383 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23384"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23385"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23386"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23387"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23388"
+
+# CVE-2026-23389 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23390"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23391"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23392"
+
+# CVE-2026-23393 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23394"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23395"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23396"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23397"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23398"
+
+# CVE-2026-23399 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23400"
+
+# CVE-2026-23401 may need backporting (fixed from 6.6.131)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23402"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23403"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23404"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23405"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23406"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23407"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23408"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23409"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23410"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23411"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23412"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23413"
+
+# CVE-2026-23414 may need backporting (fixed from 6.6.131)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23415"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23416"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23417"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23418"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23419"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23420"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23421"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23422"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23423"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23424"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23425"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23426"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23427"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23428"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23429"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23430"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23431"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23432"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23433"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23434"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23435"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23436"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23437"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23438"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23439"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23440"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23441"
+
+# CVE-2026-23442 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23443"
+
+# CVE-2026-23444 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23445"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23446"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23447"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23448"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23449"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23450"
+
+# fixed-version: only affects 6.18.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23451"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23452"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23453"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23454"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23455"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23456"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23457"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23458"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23459"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23460"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23461"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23462"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23463"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23464"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23465"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23466"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23467"
+
+# CVE-2026-23468 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23469"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-23470"
+
+# CVE-2026-23472 needs backporting (fixed from 7.0)
+
+# CVE-2026-23473 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23474"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-23475"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31389"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31390"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31391"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31392"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31393"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31394"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31395"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31396"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31397"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31398"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31399"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31400"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31401"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31402"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31403"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31404"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31405"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31406"
+
+# CVE-2026-31407 needs backporting (fixed from 7.0)
+
+# CVE-2026-31408 may need backporting (fixed from 6.6.131)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31409"
+
+# CVE-2026-31410 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-31411"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31412"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31413"
+
+# CVE-2026-31414 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31415 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31416 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31417 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31418 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31419 needs backporting (fixed from 7.0)
+
+# CVE-2026-31420 needs backporting (fixed from 7.0)
+
+# CVE-2026-31421 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31422 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31423 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31424 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31425 may need backporting (fixed from 6.6.134)
+
+# CVE-2026-31426 may need backporting (fixed from 6.6.131)
+
+# CVE-2026-31427 may need backporting (fixed from 6.6.131)
+
+# CVE-2026-31428 may need backporting (fixed from 6.6.131)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31788"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,13 +8,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.133"
+LINUX_VERSION ?= "6.6.134"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "80de0a9581338406f591d505f9545244c7a99b68"
+SRCREV_machine ?= "8cee53b8eaeb5d1f7c97b7f2381653ed00ffc26b"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "8cfac9f000ccc138d1a11ed500406c4394d803d6"
+SRCREV_meta ?= "888e60b42c251c492d6f41f154bb8c4eef5f8875"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,13 +8,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.130"
+LINUX_VERSION ?= "6.6.133"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "c09fbcd31ae6d71e7c69545839bec92d8e15c13b"
+SRCREV_machine ?= "80de0a9581338406f591d505f9545244c7a99b68"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "a5d680f4986edab4c2c4636c0dc80ca559fc70ef"
+SRCREV_meta ?= "8cfac9f000ccc138d1a11ed500406c4394d803d6"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.134"
+LINUX_VERSION ?= "6.6.135"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "8cee53b8eaeb5d1f7c97b7f2381653ed00ffc26b"
+SRCREV_machine ?= "9760bf04666dfe154161d49b6207c3486685bf29"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,13 +8,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.129"
+LINUX_VERSION ?= "6.6.130"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "4fc00fe35d46b4fc8dac2eb543a0e3d44bb15f47"
+SRCREV_machine ?= "c09fbcd31ae6d71e7c69545839bec92d8e15c13b"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "fdd48963e673d657f0df21b4b1fb6b18dbaa96bc"
+SRCREV_meta ?= "a5d680f4986edab4c2c4636c0dc80ca559fc70ef"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update kernel 6.6 to 6.6.135, and kmeta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.135
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.134
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.133
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.132
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.131
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.130