### PR TITLE
onl: fix compilation with unsupported platforms

### DIFF
--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -96,6 +96,9 @@ FILES:${PN} = " \
 # - "broken" - does not build (mostly as "known broken" list)
 PACKAGECONFIG ??= ""
 
+PACKAGECONFIG[unsupported] = ""
+PACKAGECONFIG[broken] = ""
+
 ONL_PLATFORMS_BUILD = " \
     ${ONL_PLATFORMS_SUPPORTED} \
     ${@bb.utils.contains('PACKAGECONFIG', 'unsupported', '${ONL_PLATFORMS_UNSUPPORTED}', '', d)} \

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -160,8 +160,6 @@ ONL_PLATFORMS_UNSUPPORTED:x86-64 = " \
     x86-64-accton-as7716-24sc-r0 \
     x86-64-accton-as7716-24xc-r0 \
     x86-64-accton-as7816-64x-r0 \
-    x86-64-accton-as7926-40xfb-r0 \
-    x86-64-accton-as7946-74xkb-r0 \
     x86-64-accton-as9926-24d-r0 \
     x86-64-accton-asxvolt16-r0 \
     x86-64-accton-csp9250-r0 \
@@ -173,8 +171,6 @@ ONL_MODULE_VENDORS_UNSUPPORTED:arm = " \
 "
 
 ONL_MODULE_VENDORS_UNSUPPORTED:x86-64 = " \
-    ingrasys \
-    inventec \
 "
 
 # platforms that do not build for various reasons, e.g:
@@ -202,9 +198,11 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-accton-as7535-28xb-r0 \
     x86-64-accton-as7712-32x-r0 \
     x86-64-accton-as7716-32x-r0 \
+    x86-64-accton-as7926-40xfb-r0 \
     x86-64-accton-as7926-40xke-r0 \
     x86-64-accton-as7926-80xk-r0 \
     x86-64-accton-as7936-22xke-r0 \
+    x86-64-accton-as7946-74xkb-r0 \
     x86-64-accton-as9516-32d-r0 \
     x86-64-accton-as9716-32d-r0 \
     x86-64-accton-as9926-24db-r0 \
@@ -212,8 +210,8 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-accton-es7632bt3-r0 \
     x86-64-accton-minipack-r0 \
     x86-64-accton-wedge-16x-r0 \
-    x86-64-accton-wedge100-r0 \
     x86-64-accton-wedge100-32x-r0 \
+    x86-64-accton-wedge100-r0 \
     x86-64-accton-wedge100bf-32x-r0 \
     x86-64-accton-wedge100bf-65x-r0 \
     x86-64-accton-wedge100s-32x-r0 \
@@ -228,11 +226,11 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-delta-ag7648c-r0 \
     x86-64-delta-ag8032-r0 \
     x86-64-delta-ag9032v1-r0 \
-    x86-64-delta-ag9032v2a-r0 \
     x86-64-delta-ag9032v2-r0 \
+    x86-64-delta-ag9032v2a-r0 \
     x86-64-delta-ag9064-r0 \
-    x86-64-delta-agc032a-r0 \
     x86-64-delta-agc032-r0 \
+    x86-64-delta-agc032a-r0 \
     x86-64-delta-agc5648s-r0 \
     x86-64-delta-agc7008s-r0 \
     x86-64-delta-agc7646slv1b-r0 \
@@ -270,23 +268,23 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-mlnx-msb7700-r0 \
     x86-64-mlnx-msb7800-r0 \
     x86-64-mlnx-msn2010-r0 \
-    x86-64-mlnx-msn2100b-r0 \
     x86-64-mlnx-msn2100-r0 \
+    x86-64-mlnx-msn2100b-r0 \
+    x86-64-mlnx-msn2410-r0 \
     x86-64-mlnx-msn24102-r0 \
     x86-64-mlnx-msn2410b-r0 \
-    x86-64-mlnx-msn2410-r0 \
+    x86-64-mlnx-msn2700-r0 \
     x86-64-mlnx-msn27002-r0 \
     x86-64-mlnx-msn2700b-r0 \
-    x86-64-mlnx-msn2700-r0 \
-    x86-64-mlnx-msn2740b-r0 \
     x86-64-mlnx-msn2740-r0 \
+    x86-64-mlnx-msn2740b-r0 \
     x86-64-mlnx-msn3420-r0 \
     x86-64-mlnx-msn3510-r0 \
-    x86-64-mlnx-msn3700c-r0 \
     x86-64-mlnx-msn3700-r0 \
+    x86-64-mlnx-msn3700c-r0 \
     x86-64-mlnx-msn3800-r0 \
-    x86-64-mlnx-msn4600c-r0 \
     x86-64-mlnx-msn4600-r0 \
+    x86-64-mlnx-msn4600c-r0 \
     x86-64-mlnx-msn4700-r0 \
     x86-64-mlnx-mtq8100-r0 \
     x86-64-mlnx-mtq8200-r0 \
@@ -297,8 +295,8 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-netberg-aurora-720-rangeley-r0 \
     x86-64-netberg-aurora-750-r0 \
     x86-64-netberg-aurora-820-r0 \
-    x86-64-quanta-ix1b-rglbmc-r0 \
     x86-64-quanta-ix1-rangeley-r0 \
+    x86-64-quanta-ix1b-rglbmc-r0 \
     x86-64-quanta-ix2-rangeley-r0 \
     x86-64-quanta-ix7-rglbmc-r0 \
     x86-64-quanta-ix8-rglbmc-r0 \
@@ -318,6 +316,7 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-ufispace-s9700-23d-r8 \
     x86-64-ufispace-s9700-53dx-r0 \
     x86-64-ufispace-s9700-53dx-r1 \
+    x86-64-ufispace-s9700-53dx-r10 \
     x86-64-ufispace-s9700-53dx-r2 \
     x86-64-ufispace-s9700-53dx-r3 \
     x86-64-ufispace-s9700-53dx-r4 \
@@ -326,7 +325,6 @@ ONL_PLATFORMS_BROKEN:x86-64 = " \
     x86-64-ufispace-s9700-53dx-r7 \
     x86-64-ufispace-s9700-53dx-r8 \
     x86-64-ufispace-s9700-53dx-r9 \
-    x86-64-ufispace-s9700-53dx-r10 \
     x86-64-ufispace-s9705-48d-r0 \
     x86-64-ufispace-s9705-48d-r1 \
     x86-64-ufispace-s9705-48d-r2 \
@@ -346,6 +344,8 @@ ONL_MODULE_VENDORS_BROKEN:arm = " \
 # technically accton builds, but conflicts with csp7550's modules
 ONL_MODULE_VENDORS_BROKEN:x86-64 = " \
     accton \
+    ingrasys \
+    inventec \
     netberg \
     quanta \
     ufispace \


### PR DESCRIPTION
Fix two issues when building with unsupported platform support:

- Yocto was complaining about invalid PACKAGECONFIG, silence it by providing (empty) PACKAGECONFIG for it (and broken)
- Switching to kernel 6.12 broke more platforms, so move these from unsupported to broken