### PR TITLE
linux-yocto-onl: update 6.12 to 6.12.85

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-05 14:48:02.004385+00:00 for kernel version 6.12.83
+# Generated at 2026-05-05 14:58:39.304148+00:00 for kernel version 6.12.84
 # From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.83"
+    this_version = "6.12.84"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -21358,7 +21358,7 @@ CVE_STATUS[CVE-2026-23442] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-23443] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23444 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-23444] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-23445] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -21788,7 +21788,7 @@ CVE_STATUS[CVE-2026-31573] = "fixed-version: only affects 6.19.6 onwards"
 
 CVE_STATUS[CVE-2026-31574] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-31575 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31575] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31576] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -21826,7 +21826,7 @@ CVE_STATUS[CVE-2026-31590] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-31593] = "cpe-stable-backport: Backported in 6.12.83"
 
-# CVE-2026-31594 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31594] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31595] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -21990,7 +21990,7 @@ CVE_STATUS[CVE-2026-31674] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31675] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31676 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31676] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31677] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -22026,55 +22026,55 @@ CVE_STATUS[CVE-2026-31691] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-31693] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-31694 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31694] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31695] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31696 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31696] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31697 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31697] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31698 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31698] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31699 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31699] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31700 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31700] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31701 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31701] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31702 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31702] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31703] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-31704 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31704] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31705 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31705] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31706 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31706] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31707 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31707] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31708 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31708] = "cpe-stable-backport: Backported in 6.12.84"
 
 # CVE-2026-31709 needs backporting (fixed from 7.1rc1)
 
 CVE_STATUS[CVE-2026-31710] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-31711 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31711] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31712 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31712] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31713] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-31714 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31714] = "cpe-stable-backport: Backported in 6.12.84"
 
 # CVE-2026-31715 needs backporting (fixed from 7.1rc1)
 
-# CVE-2026-31716 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31716] = "cpe-stable-backport: Backported in 6.12.84"
 
 # CVE-2026-31717 needs backporting (fixed from 7.1rc1)
 
-# CVE-2026-31718 may need backporting (fixed from 6.12.84)
+CVE_STATUS[CVE-2026-31718] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31719] = "fixed-version: only affects 6.15 onwards"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 14:13:16.121960+00:00 for kernel version 6.12.82
-# From cvelistV5 cve_2026-04-20_0900Z
+# Generated at 2026-05-05 14:48:02.004385+00:00 for kernel version 6.12.83
+# From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.82"
+    this_version = "6.12.83"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -15308,7 +15308,7 @@ CVE_STATUS[CVE-2025-21707] = "cpe-stable-backport: Backported in 6.12.13"
 
 CVE_STATUS[CVE-2025-21708] = "cpe-stable-backport: Backported in 6.12.13"
 
-# CVE-2025-21709 needs backporting (fixed from 6.14)
+CVE_STATUS[CVE-2025-21709] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2025-21710] = "cpe-stable-backport: Backported in 6.12.13"
 
@@ -20300,8 +20300,6 @@ CVE_STATUS[CVE-2025-71147] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71148] = "cpe-stable-backport: Backported in 6.12.64"
 
-CVE_STATUS[CVE-2025-71149] = "cpe-stable-backport: Backported in 6.12.64"
-
 CVE_STATUS[CVE-2025-71150] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71151] = "cpe-stable-backport: Backported in 6.12.64"
@@ -20448,7 +20446,7 @@ CVE_STATUS[CVE-2026-22984] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22985] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-22986 needs backporting (fixed from 6.19)
+CVE_STATUS[CVE-2026-22986] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-22987] = "fixed-version: only affects 6.17 onwards"
 
@@ -21356,11 +21354,11 @@ CVE_STATUS[CVE-2026-23440] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23441] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23442 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23442] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-23443] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23444 needs backporting (fixed from 7.0)
+# CVE-2026-23444 may need backporting (fixed from 6.12.84)
 
 CVE_STATUS[CVE-2026-23445] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -21416,8 +21414,6 @@ CVE_STATUS[CVE-2026-23470] = "cpe-stable-backport: Backported in 6.12.78"
 
 # CVE-2026-23472 needs backporting (fixed from 7.0)
 
-# CVE-2026-23473 needs backporting (fixed from 7.0)
-
 CVE_STATUS[CVE-2026-23474] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23475] = "cpe-stable-backport: Backported in 6.12.78"
@@ -21458,7 +21454,7 @@ CVE_STATUS[CVE-2026-31405] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-31406] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31407 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31407] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-31408] = "cpe-stable-backport: Backported in 6.12.80"
 
@@ -21502,5 +21498,831 @@ CVE_STATUS[CVE-2026-31427] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31428] = "cpe-stable-backport: Backported in 6.12.80"
 
+CVE_STATUS[CVE-2026-31429] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31430] = "cpe-stable-backport: Backported in 6.12.82"
+
+# CVE-2026-31431 may need backporting (fixed from 6.12.85)
+
+CVE_STATUS[CVE-2026-31432] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31433] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31434] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31435 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31436] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31437] = "fixed-version: only affects 6.18.17 onwards"
+
+CVE_STATUS[CVE-2026-31438] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31439] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31440] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31441] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31442] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31443] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31444] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31445] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31446] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31447] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31448] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31449] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31450] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31451] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31452] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31453] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31454] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31455] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31456 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31457] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31458] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31459] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31460] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31461] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-31462] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31463] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31464] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31465] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31466] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31467] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31468] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31469] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31470] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31471] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31472] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31473] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31474] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31475] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31476] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31477] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31478] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31479] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31480] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31481] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31482] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31483] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31484] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31485] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31486 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31487] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31488] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31489] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31490] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31491] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31492] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31493 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31494] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31495] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31496] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31497] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31498] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31499] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31500] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31501] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31502] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31503] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31504] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31505] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31506] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31507] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31508] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31509] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31510] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31511] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31512] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31513] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31514] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31515] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31516] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31517] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31518] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31519] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31520] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31521] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31522] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31523] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31524] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31525] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31526 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31527] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31528] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31529] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31530] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31531] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31532] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31533] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31535] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-31536 needs backporting (fixed from 7.0)
+
+# CVE-2026-31537 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31538] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31539] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31540] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31541] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31542] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31543] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31544] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31545] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31546] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31547] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31548] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31549] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31550] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31551] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31552] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31553] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31554] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31555] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31556] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31557] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31558] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31559] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31560 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31561] = "cpe-stable-backport: Backported in 6.12.80"
+
+# CVE-2026-31562 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31563] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31564] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31565] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31566] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31567] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-31568 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31569] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-31570] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31571] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31572] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31573] = "fixed-version: only affects 6.19.6 onwards"
+
+CVE_STATUS[CVE-2026-31574] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-31575 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31576] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31577] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31578] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31579 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-31580] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31581] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31582] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31583] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31584] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31585] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31586] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31587] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31588] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31589] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-31590] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31591 needs backporting (fixed from 7.1rc1)
+
+# CVE-2026-31592 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-31593] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31594 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31595] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31596] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31597] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31598] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31599] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31600] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31601] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31602] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31603] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31604] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31605] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31606] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31607] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31608] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31609] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31610] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31611] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31612] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31613 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-31614] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31615] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31616] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31617] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31618] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31619] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31620] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31621] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31622] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31623] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31624] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31625] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31626] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31627] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31628] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31629] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31630 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31631] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31632] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31633] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31634] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31635] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31636] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31637] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31638] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31639] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31640] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31641] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31642] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31643] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31644] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31645] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31646] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31647] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31648] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31649] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31650] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31651] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31652] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31653] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31654] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31655] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31656] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31657] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31658] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31659] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31660] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31661] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31662] = "cpe-stable-backport: Backported in 6.12.82"
+
+# CVE-2026-31663 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31664] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31665] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31666] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31667] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31668] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31669] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31670] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31671] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31672] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31673] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31674] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31675] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-31676 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31677] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31678] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31679] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-31680] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31681] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31682] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31683] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-31684] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31685] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31686] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-31687] = "cpe-stable-backport: Backported in 6.12.73"
+
+# CVE-2026-31688 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31689] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31690] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31691] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-31692 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31693] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-31694 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31695] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-31696 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31697 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31698 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31699 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31700 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31701 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31702 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31703] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-31704 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31705 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31706 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31707 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31708 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31709 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-31710] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-31711 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31712 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31713] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-31714 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31715 needs backporting (fixed from 7.1rc1)
+
+# CVE-2026-31716 may need backporting (fixed from 6.12.84)
+
+# CVE-2026-31717 needs backporting (fixed from 7.1rc1)
+
+# CVE-2026-31718 may need backporting (fixed from 6.12.84)
+
+CVE_STATUS[CVE-2026-31719] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-31720] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31721] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31722] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31723] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31724] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31725] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31726] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31727] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31728] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31729] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31730] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31731] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-31732 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31733] = "cpe-stable-backport: Backported in 6.12.82"
+
+CVE_STATUS[CVE-2026-31734] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31735] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31736] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31737] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31738] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31739] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31740] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31741] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31742] = "fixed-version: only affects 6.18.20 onwards"
+
+CVE_STATUS[CVE-2026-31743] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31744] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31745] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31746] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31747] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31748] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31749] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31750] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31751] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31752] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31753] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31754] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31755] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31756] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31757] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31758] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31759] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31760] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-31761] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31762] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31763] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31764] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31765] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31766] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31767] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31768] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31769] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-31770] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-31771 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31772] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31773] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31774] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31775] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-31776] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-31777 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-31778] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31779] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31780] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31781] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-31782] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-31783] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-31784] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-31785] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-31786 may need backporting (fixed from 6.12.85)
+
+# CVE-2026-31787 may need backporting (fixed from 6.12.85)
+
 CVE_STATUS[CVE-2026-31788] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43004] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43005] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43006] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43007] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43008] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-43009 needs backporting (fixed from 7.0)
+
+# CVE-2026-43010 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43011] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43012] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43013] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43014] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43015] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43016] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43017] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43018] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43019] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43020] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43021] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-43022 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43023] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43024] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43025] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43026] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43027] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43028] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43029] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43030] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43031] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43032] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43033 may need backporting (fixed from 6.12.85)
+
+# CVE-2026-43034 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43035] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43036] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43037] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43038] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43039] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43040] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43041] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43042 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43043] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43044] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43045] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43046] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43047] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43048 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43049] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43050] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43051] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43052] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43053 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43054] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43055] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43056] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43057] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43058] = "cpe-stable-backport: Backported in 6.12.83"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-05 14:58:39.304148+00:00 for kernel version 6.12.84
+# Generated at 2026-05-05 15:12:59.936360+00:00 for kernel version 6.12.85
 # From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.84"
+    this_version = "6.12.85"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -21502,7 +21502,7 @@ CVE_STATUS[CVE-2026-31429] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-31430] = "cpe-stable-backport: Backported in 6.12.82"
 
-# CVE-2026-31431 may need backporting (fixed from 6.12.85)
+CVE_STATUS[CVE-2026-31431] = "cpe-stable-backport: Backported in 6.12.85"
 
 CVE_STATUS[CVE-2026-31432] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -22210,9 +22210,9 @@ CVE_STATUS[CVE-2026-31784] = "fixed-version: only affects 6.17 onwards"
 
 CVE_STATUS[CVE-2026-31785] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-31786 may need backporting (fixed from 6.12.85)
+CVE_STATUS[CVE-2026-31786] = "cpe-stable-backport: Backported in 6.12.85"
 
-# CVE-2026-31787 may need backporting (fixed from 6.12.85)
+CVE_STATUS[CVE-2026-31787] = "cpe-stable-backport: Backported in 6.12.85"
 
 CVE_STATUS[CVE-2026-31788] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -22274,7 +22274,7 @@ CVE_STATUS[CVE-2026-43031] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-43032] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-43033 may need backporting (fixed from 6.12.85)
+CVE_STATUS[CVE-2026-43033] = "cpe-stable-backport: Backported in 6.12.85"
 
 # CVE-2026-43034 needs backporting (fixed from 7.0)
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.84"
+LINUX_VERSION ?= "6.12.85"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "c286ea5e62389897291fa742d2bb909ecc9ef2d0"
+SRCREV_machine ?= "18cd79ce247a35c2938698145d1834a09b5f7777"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "d957406b6228fc9996e7f0a5c320f9793d0d22fa"
+SRCREV_meta ?= "89cdc6b11d8516512a1e7b584bbe19900a55059b"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.83"
+LINUX_VERSION ?= "6.12.84"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "eefc95626b5cb02ea6268d1ae58237768004a60d"
+SRCREV_machine ?= "c286ea5e62389897291fa742d2bb909ecc9ef2d0"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "1a28be589c9aa79335563af67fbce0dadf570537"
+SRCREV_meta ?= "d957406b6228fc9996e7f0a5c320f9793d0d22fa"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.82"
+LINUX_VERSION ?= "6.12.83"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "d75ae3350fe8a29588a3f489952d06928cb85675"
+SRCREV_machine ?= "eefc95626b5cb02ea6268d1ae58237768004a60d"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "b507ba98ba3ecc385b14a231dddafaea3421f778"
+SRCREV_meta ?= "1a28be589c9aa79335563af67fbce0dadf570537"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.12 to 6.12.85 and kmeta accordingly.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.85
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.84
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.83