### PR TITLE
v5.x: update linux 6.6 to 6.6.137

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-05 15:21:46.010182+00:00 for kernel version 6.6.136
+# Generated at 2026-05-05 15:41:12.017991+00:00 for kernel version 6.6.137
 # From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.136"
+    this_version = "6.6.137"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -31900,7 +31900,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31429"
 # cpe-stable-backport: Backported in 6.6.135
 CVE_CHECK_IGNORE += "CVE-2026-31430"
 
-# CVE-2026-31431 may need backporting (fixed from 6.6.137)
+# cpe-stable-backport: Backported in 6.6.137
+CVE_CHECK_IGNORE += "CVE-2026-31431"
 
 # CVE-2026-31432 needs backporting (fixed from 7.0)
 
@@ -32917,9 +32918,11 @@ CVE_CHECK_IGNORE += "CVE-2026-31784"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31785"
 
-# CVE-2026-31786 may need backporting (fixed from 6.6.137)
+# cpe-stable-backport: Backported in 6.6.137
+CVE_CHECK_IGNORE += "CVE-2026-31786"
 
-# CVE-2026-31787 may need backporting (fixed from 6.6.137)
+# cpe-stable-backport: Backported in 6.6.137
+CVE_CHECK_IGNORE += "CVE-2026-31787"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-31788"
@@ -33008,7 +33011,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43031"
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43032"
 
-# CVE-2026-43033 may need backporting (fixed from 6.6.137)
+# cpe-stable-backport: Backported in 6.6.137
+CVE_CHECK_IGNORE += "CVE-2026-43033"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43034"

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-04-21 15:17:25.834844+00:00 for kernel version 6.6.135
-# From cvelistV5 cve_2026-04-20_0900Z
+# Generated at 2026-05-05 15:21:46.010182+00:00 for kernel version 6.6.136
+# From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.135"
+    this_version = "6.6.136"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -24016,7 +24016,8 @@ CVE_CHECK_IGNORE += "CVE-2025-22123"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2025-22124"
 
-# CVE-2025-22125 needs backporting (fixed from 6.15)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2025-22125"
 
 # cpe-stable-backport: Backported in 6.6.88
 CVE_CHECK_IGNORE += "CVE-2025-22126"
@@ -26412,7 +26413,8 @@ CVE_CHECK_IGNORE += "CVE-2025-38529"
 # cpe-stable-backport: Backported in 6.6.100
 CVE_CHECK_IGNORE += "CVE-2025-38530"
 
-# CVE-2025-38531 needs backporting (fixed from 6.16)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2025-38531"
 
 # cpe-stable-backport: Backported in 6.6.100
 CVE_CHECK_IGNORE += "CVE-2025-38532"
@@ -30129,9 +30131,6 @@ CVE_CHECK_IGNORE += "CVE-2025-71147"
 CVE_CHECK_IGNORE += "CVE-2025-71148"
 
 # cpe-stable-backport: Backported in 6.6.120
-CVE_CHECK_IGNORE += "CVE-2025-71149"
-
-# cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-71150"
 
 # cpe-stable-backport: Backported in 6.6.120
@@ -31141,7 +31140,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23253"
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2026-23254"
 
-# CVE-2026-23255 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23255"
 
 # cpe-stable-backport: Backported in 6.6.124
 CVE_CHECK_IGNORE += "CVE-2026-23256"
@@ -31277,7 +31277,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23300"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23301"
 
-# CVE-2026-23302 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23302"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23303"
@@ -31309,7 +31310,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23311"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23312"
 
-# CVE-2026-23313 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23313"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23314"
@@ -31355,7 +31357,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23328"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23329"
 
-# CVE-2026-23330 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23330"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23331"
@@ -31479,7 +31482,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23372"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23373"
 
-# CVE-2026-23374 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23374"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23375"
@@ -31521,7 +31525,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23387"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23388"
 
-# CVE-2026-23389 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23389"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23390"
@@ -31549,7 +31554,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23397"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23398"
 
-# CVE-2026-23399 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23399"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23400"
@@ -31677,12 +31683,14 @@ CVE_CHECK_IGNORE += "CVE-2026-23440"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23441"
 
-# CVE-2026-23442 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23442"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23443"
 
-# CVE-2026-23444 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-23444"
 
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23445"
@@ -31763,8 +31771,6 @@ CVE_CHECK_IGNORE += "CVE-2026-23470"
 
 # CVE-2026-23472 needs backporting (fixed from 7.0)
 
-# CVE-2026-23473 needs backporting (fixed from 7.0)
-
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23474"
 
@@ -31825,7 +31831,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31405"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31406"
 
-# CVE-2026-31407 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31407"
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31408"
@@ -31887,6 +31894,1188 @@ CVE_CHECK_IGNORE += "CVE-2026-31427"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31428"
 
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31429"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31430"
+
+# CVE-2026-31431 may need backporting (fixed from 6.6.137)
+
+# CVE-2026-31432 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31433"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31434"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31435"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31436"
+
+# fixed-version: only affects 6.18.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31437"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31438"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31439"
+
+# CVE-2026-31440 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31441"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31442"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31443"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31444"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31445"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31446"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31447"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31448"
+
+# CVE-2026-31449 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31450"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31451"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31452"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31453"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31454"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31455"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31456"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31457"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31458"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31459"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31460"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31461"
+
+# CVE-2026-31462 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31463"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31464"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31465"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31466"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31467"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31468"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31469"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31470"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31471"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31472"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31473"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31474"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31475"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31476"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31477"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31478"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31479"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31480"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31481"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31482"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31483"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31484"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31485"
+
+# CVE-2026-31486 needs backporting (fixed from 7.0)
+
+# CVE-2026-31487 needs backporting (fixed from 7.0)
+
+# CVE-2026-31488 needs backporting (fixed from 7.0)
+
+# CVE-2026-31489 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31490"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31491"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31492"
+
+# CVE-2026-31493 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31494"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31495"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31496"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31497"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31498"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31499"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31500"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31501"
+
+# CVE-2026-31502 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31503"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31504"
+
+# CVE-2026-31505 needs backporting (fixed from 7.0)
+
+# CVE-2026-31506 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31507"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31508"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31509"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31510"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31511"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31512"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31513"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31514"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31515"
+
+# CVE-2026-31516 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31517"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31518"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31519"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31520"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31521"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31522"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31523"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31524"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31525"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31526"
+
+# CVE-2026-31527 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31528"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31529"
+
+# CVE-2026-31530 needs backporting (fixed from 7.0)
+
+# CVE-2026-31531 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31532"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31533"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31535"
+
+# CVE-2026-31536 needs backporting (fixed from 7.0)
+
+# CVE-2026-31537 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31538"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31539"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31540"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31541"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31542"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31543"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31544"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31545"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31546"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31547"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31548"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31549"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31550"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31551"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31552"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31553"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31554"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31555"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31556"
+
+# CVE-2026-31557 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31558"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31559"
+
+# CVE-2026-31560 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31561"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31562"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31563"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31564"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31565"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31566"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31567"
+
+# CVE-2026-31568 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31569"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31570"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31571"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31572"
+
+# fixed-version: only affects 6.19.6 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31573"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31574"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31575"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31576"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31577"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31578"
+
+# CVE-2026-31579 needs backporting (fixed from 7.1rc1)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31580"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31581"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31582"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31583"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31584"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31585"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31586"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31587"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31588"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31589"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31590"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31591"
+
+# CVE-2026-31592 needs backporting (fixed from 7.1rc1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31593"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31594"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31595"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31596"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31597"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31598"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31599"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31600"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31601"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31602"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31603"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31604"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31605"
+
+# CVE-2026-31606 needs backporting (fixed from 7.1rc1)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31607"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31608"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31609"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31610"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31611"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31612"
+
+# CVE-2026-31613 needs backporting (fixed from 7.1rc1)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31614"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31615"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31616"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31617"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31618"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31619"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31620"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31621"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31622"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31623"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31624"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31625"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31626"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31627"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31628"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31629"
+
+# CVE-2026-31630 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31631"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31632"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31633"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31634"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31635"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31636"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31637"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31638"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31639"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31640"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31641"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31642"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31643"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31644"
+
+# CVE-2026-31645 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31646"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31647"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31648"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31649"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31650"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31651"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31652"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31653"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31654"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31655"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31656"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31657"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31658"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31659"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31660"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31661"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31662"
+
+# CVE-2026-31663 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31664"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31665"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31666"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31667"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31668"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31669"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31670"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31671"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31672"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31673"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31674"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31675"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31676"
+
+# CVE-2026-31677 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31678"
+
+# cpe-stable-backport: Backported in 6.6.131
+CVE_CHECK_IGNORE += "CVE-2026-31679"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31680"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31681"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31682"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-31683"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31684"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31685"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31686"
+
+# cpe-stable-backport: Backported in 6.6.126
+CVE_CHECK_IGNORE += "CVE-2026-31687"
+
+# CVE-2026-31688 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31689"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31690"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31691"
+
+# CVE-2026-31692 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-31693"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31694"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31695"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31696"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31697"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31698"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31699"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31700"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31701"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31702"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31703"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31704"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31705"
+
+# CVE-2026-31706 needs backporting (fixed from 7.1rc1)
+
+# CVE-2026-31707 needs backporting (fixed from 7.1rc1)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31708"
+
+# CVE-2026-31709 needs backporting (fixed from 7.1rc1)
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31710"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31711"
+
+# CVE-2026-31712 needs backporting (fixed from 7.1rc1)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31713"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31714"
+
+# CVE-2026-31715 needs backporting (fixed from 7.1rc1)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-31716"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31717"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31718"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31719"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31720"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-31721"
+
+# CVE-2026-31722 needs backporting (fixed from 7.0)
+
+# CVE-2026-31723 needs backporting (fixed from 7.0)
+
+# CVE-2026-31724 needs backporting (fixed from 7.0)
+
+# CVE-2026-31725 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31726"
+
+# fixed-version: only affects 6.12.78 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31727"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31728"
+
+# CVE-2026-31729 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31730"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31731"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31732"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31733"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31734"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31735"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31736"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31737"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31738"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31739"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31740"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31741"
+
+# fixed-version: only affects 6.18.20 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31742"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31743"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31744"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31745"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31746"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31747"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31748"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31749"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31750"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31751"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31752"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31753"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31754"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31755"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31756"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31757"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31758"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31759"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31760"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31761"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31762"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31763"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31764"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31765"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31766"
+
+# CVE-2026-31767 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31768"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31769"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31770"
+
+# CVE-2026-31771 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31772"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31773"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31774"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31775"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31776"
+
+# CVE-2026-31777 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31778"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31779"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31780"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-31781"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31782"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31783"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31784"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-31785"
+
+# CVE-2026-31786 may need backporting (fixed from 6.6.137)
+
+# CVE-2026-31787 may need backporting (fixed from 6.6.137)
+
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-31788"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43004"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43005"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43006"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43007"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43008"
+
+# CVE-2026-43009 needs backporting (fixed from 7.0)
+
+# CVE-2026-43010 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43011"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43012"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43013"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43014"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43015"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43016"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43017"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43018"
+
+# CVE-2026-43019 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43020"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43021"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43022"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43023"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43024"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43025"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43026"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43027"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43028"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43029"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43030"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43031"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43032"
+
+# CVE-2026-43033 may need backporting (fixed from 6.6.137)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43034"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43035"
+
+# CVE-2026-43036 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43037"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43038"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43039"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43040"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43041"
+
+# CVE-2026-43042 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43043"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43044"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43045"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43046"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43047"
+
+# CVE-2026-43048 needs backporting (fixed from 7.0)
+
+# CVE-2026-43049 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43050"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43051"
+
+# CVE-2026-43052 needs backporting (fixed from 7.0)
+
+# CVE-2026-43053 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43054"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43055"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43056"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43057"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-43058"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,13 +8,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.136"
+LINUX_VERSION ?= "6.6.137"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "142cd8382222d9b135e0029da6830e5e30444d34"
+SRCREV_machine ?= "258cf62a6dfde3c6a39d120a56a298f2ed6a8901"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "888e60b42c251c492d6f41f154bb8c4eef5f8875"
+SRCREV_meta ?= "7d4cafa710da4e27a86cb015e50d91cf458af06f"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.135"
+LINUX_VERSION ?= "6.6.136"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "9760bf04666dfe154161d49b6207c3486685bf29"
+SRCREV_machine ?= "142cd8382222d9b135e0029da6830e5e30444d34"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6


### PR DESCRIPTION
Update linux 6.6 to 6.6.137 and kmeta accordingly.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.137
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.136