### PR TITLE
linux-yocto-onl: update 6.12 to 6.12.87

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-05 15:12:59.936360+00:00 for kernel version 6.12.85
-# From cvelistV5 cve_2026-05-05_1200Z-2-g4ce712c2b22
+# Generated at 2026-05-08 08:56:28.162134+00:00 for kernel version 6.12.86
+# From cvelistV5 cve_2026-05-08_0800Z-1-gcaa049683f4
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.85"
+    this_version = "6.12.86"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -17864,7 +17864,7 @@ CVE_STATUS[CVE-2025-38582] = "cpe-stable-backport: Backported in 6.12.42"
 
 CVE_STATUS[CVE-2025-38583] = "cpe-stable-backport: Backported in 6.12.42"
 
-# CVE-2025-38584 needs backporting (fixed from 6.17)
+CVE_STATUS[CVE-2025-38584] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2025-38585] = "cpe-stable-backport: Backported in 6.12.42"
 
@@ -20426,6 +20426,36 @@ CVE_STATUS[CVE-2025-71269] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2025-71270] = "cpe-stable-backport: Backported in 6.12.70"
 
+CVE_STATUS[CVE-2025-71271] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2025-71272] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71273] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71274] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2025-71285 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2025-71286] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71287] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2025-71288] = "cpe-stable-backport: Backported in 6.12.77"
+
+# CVE-2025-71289 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2025-71290] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2025-71291] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71292] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71293] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2025-71294] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71295] = "cpe-stable-backport: Backported in 6.12.75"
+
 CVE_STATUS[CVE-2026-22976] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22977] = "cpe-stable-backport: Backported in 6.12.66"
@@ -21406,7 +21436,7 @@ CVE_STATUS[CVE-2026-23466] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23467] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2026-23468 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23468] = "cpe-stable-backport: Backported in 6.12.86"
 
 # CVE-2026-23469 needs backporting (fixed from 7.0)
 
@@ -21478,7 +21508,7 @@ CVE_STATUS[CVE-2026-31417] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31418] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31419 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31419] = "cpe-stable-backport: Backported in 6.12.86"
 
 # CVE-2026-31420 needs backporting (fixed from 7.0)
 
@@ -22056,7 +22086,7 @@ CVE_STATUS[CVE-2026-31707] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31708] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31709 needs backporting (fixed from 7.1rc1)
+CVE_STATUS[CVE-2026-31709] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-31710] = "fixed-version: only affects 7.0 onwards"
 
@@ -22068,7 +22098,7 @@ CVE_STATUS[CVE-2026-31713] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-31714] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31715 needs backporting (fixed from 7.1rc1)
+CVE_STATUS[CVE-2026-31715] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-31716] = "cpe-stable-backport: Backported in 6.12.84"
 
@@ -22325,4 +22355,456 @@ CVE_STATUS[CVE-2026-43056] = "cpe-stable-backport: Backported in 6.12.81"
 CVE_STATUS[CVE-2026-43057] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-43058] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43059] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43060] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43061] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43062] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43063] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43064] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43065] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43066] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43067] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43068] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43069] = "cpe-stable-backport: Backported in 6.12.80"
+
+CVE_STATUS[CVE-2026-43070] = "fixed-version: only affects 6.18.17 onwards"
+
+CVE_STATUS[CVE-2026-43071] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43072] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43073] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43074] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43075] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43076] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43077] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43078] = "cpe-stable-backport: Backported in 6.12.85"
+
+CVE_STATUS[CVE-2026-43079] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43080] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43081] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43082] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-43083 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43084] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43085] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43086] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43087] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-43088 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43089] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43090] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43091] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43092] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43093] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43094] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43095] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43096] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43097] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43098] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43099] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43100] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-43101 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43102] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43103] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43104] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43105] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43106] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43107] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43108] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-43109 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43110] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43111] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43112] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43113] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43114] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-43115 needs backporting (fixed from 7.0)
+
+# CVE-2026-43116 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43117] = "cpe-stable-backport: Backported in 6.12.83"
+
+# CVE-2026-43118 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43119] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43120] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43121] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43122] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43123] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43124] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43125] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43126] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43127] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43128] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43129] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-43130] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43131] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43132] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43133] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43134] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43135] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43136] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43137] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43138] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43139] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43140] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43141] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43142] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43143] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43144] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43145] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43146] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43147] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43148] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43149] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43150] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43151] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43152] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43153] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43154] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43155] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43156] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43157] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43158] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43159] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43160] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43161] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-43162] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-43163] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43164] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43165] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43166] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43167] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43168] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43169] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43170] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43171] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43172 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43173] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43174] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43175] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43176] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43177] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43178] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43179] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43180] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43181] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43182] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43183] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43184] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43185 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43186] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43187] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43188] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43189] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43190] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43191 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43192] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43193] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43194] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43195] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43196] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43197 needs backporting (fixed from 7.0)
+
+# CVE-2026-43198 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43199] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43200] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43201] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43202] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43203] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43204 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43205] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43206] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43207] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43208] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43209] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43210] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43211] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43212] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43213 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43214] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43215] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43216 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43217] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43218] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43219 needs backporting (fixed from 7.0)
+
+# CVE-2026-43220 has no known resolution
+
+CVE_STATUS[CVE-2026-43221] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43222] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43223] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43224] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43225] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43226] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43227] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43228] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43229] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43230] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43231] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43232] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43233] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43234 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43235] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43236] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43237] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43238] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43239] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43240] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43241] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43242] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43243] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43244] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43245 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43246] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43247] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43248] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43249] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43250] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43251] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43252] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43253] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43254] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43255] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43256] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43257] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43258] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43259] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43260] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43261] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43262] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43263 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43264] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43265] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-43266] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43267] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43268] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43269] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43270] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43271] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43272 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43273] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43274] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-43275] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43276] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43277] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43278] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43279] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43280] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43281] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-43282] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43283] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43284 has no known resolution
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-08 08:56:28.162134+00:00 for kernel version 6.12.86
+# Generated at 2026-05-08 08:59:45.076165+00:00 for kernel version 6.12.87
 # From cvelistV5 cve_2026-05-08_0800Z-1-gcaa049683f4
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.86"
+    this_version = "6.12.87"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.85"
+LINUX_VERSION ?= "6.12.86"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "18cd79ce247a35c2938698145d1834a09b5f7777"
+SRCREV_machine ?= "bf89928ffeb731c623a15ee7327261131a80ddcb"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.86"
+LINUX_VERSION ?= "6.12.87"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "bf89928ffeb731c623a15ee7327261131a80ddcb"
+SRCREV_machine ?= "8bf2f55ef536982e44802d99340119dac6f50636"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12


### PR DESCRIPTION
Update linux 6.12 to 6.12.87.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.87
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.86