### PR TITLE
v5.x: linux-yocto-onl: switch git.yoctoproject.org to https

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl_5.15.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_5.15.bb
@@ -17,7 +17,7 @@ SRCREV_machine ?= "0c935c049b5c196b83b968c72d348ae6fff83ea2"
 SRCREV_meta ?= "896128cbf5fc140cad076227af3456cc38e8f442"
 
 SRC_URI += "\
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \
+    git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-5.15;destsuffix=kernel-meta \
     file://bisdn-kmeta;type=kmeta;name=bisdn-kmeta;destsuffix=bisdn-kmeta \
 "
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -17,7 +17,7 @@ SRCREV_machine ?= "3b9f64db049687c0d38b4b3ef2f297f0642179af"
 SRCREV_meta ?= "7d4cafa710da4e27a86cb015e50d91cf458af06f"
 
 SRC_URI += "\
-    git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \
+    git://git.yoctoproject.org/yocto-kernel-cache;protocol=https;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \
     file://bisdn-kmeta;type=kmeta;name=bisdn-kmeta;destsuffix=bisdn-kmeta \
 "
 


### PR DESCRIPTION
Yocto Project disabled the git transport on their git servers due to persistent DDoS by AI scrapers, so switch our checkout to https.