### PR TITLE
v5.x: linux-libc-headers: fix -dev dependencies

### DIFF
--- a/recipes-kernel/linux-libc-headers/linux-libc-headers.inc
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers.inc
@@ -105,7 +105,7 @@ do_install_armmultilib () {
 
 BBCLASSEXTEND = "nativesdk"
 
-DEV_PKG_DEPENDENCY = ""
+RDEPENDS:${PN}-dev = ""
 RRECOMMENDS:${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"
 
 INHIBIT_DEFAULT_DEPS = "1"


### PR DESCRIPTION
Yocto does not generate a linux-libc-headers package, as all headers go into the -dev package. By default the -dev package has a dependency on the main package, but since there is no main package in this case, we need to inhibit the dependency generation.

The Yocto version from where we imported the recipe does this via `DEV_PKG_DEPENDENCY`, but kirkstone does not understand this. So switch to the "old" way by declaring an empty `RDEPENDS:${PN}-dev`.

Fixes: 07a5f3d126e3 ("linux-libc-headers: import 6.6 from poky master")