### PR TITLE
v5.x: linux-yocto-onl: update 6.6 to 6.6.140

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-08 09:27:06.971116+00:00 for kernel version 6.6.138
-# From cvelistV5 cve_2026-05-08_0800Z-1-gcaa049683f4
+# Generated at 2026-05-18 15:30:59.331078+00:00 for kernel version 6.6.139
+# From cvelistV5 cve_2026-05-18_1300Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.138"
+    this_version = "6.6.139"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -9919,8 +9919,7 @@ CVE_CHECK_IGNORE += "CVE-2023-52918"
 # fixed-version: Fixed from version 6.6
 CVE_CHECK_IGNORE += "CVE-2023-52919"
 
-# cpe-stable-backport: Backported in 6.6.70
-CVE_CHECK_IGNORE += "CVE-2023-52920"
+# CVE-2023-52920 may need backporting (fixed from 6.6.140)
 
 # fixed-version: Fixed from version 6.5
 CVE_CHECK_IGNORE += "CVE-2023-52921"
@@ -21601,7 +21600,7 @@ CVE_CHECK_IGNORE += "CVE-2024-56645"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2024-56646"
 
-# CVE-2024-56647 needs backporting (fixed from 6.13)
+# CVE-2024-56647 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.66
 CVE_CHECK_IGNORE += "CVE-2024-56648"
@@ -26572,7 +26571,7 @@ CVE_CHECK_IGNORE += "CVE-2025-38582"
 # cpe-stable-backport: Backported in 6.6.102
 CVE_CHECK_IGNORE += "CVE-2025-38583"
 
-# CVE-2025-38584 needs backporting (fixed from 6.17)
+# CVE-2025-38584 may need backporting (fixed from 6.6.140)
 
 # CVE-2025-38585 needs backporting (fixed from 6.17)
 
@@ -27903,7 +27902,7 @@ CVE_CHECK_IGNORE += "CVE-2025-39979"
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-39980"
 
-# CVE-2025-39981 needs backporting (fixed from 6.17)
+# CVE-2025-39981 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-39982"
@@ -29401,7 +29400,7 @@ CVE_CHECK_IGNORE += "CVE-2025-68313"
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68314"
 
-# CVE-2025-68315 needs backporting (fixed from 6.18)
+# CVE-2025-68315 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68316"
@@ -30357,6 +30356,27 @@ CVE_CHECK_IGNORE += "CVE-2025-71294"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2025-71295"
 
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71296"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2025-71297"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71298"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71299"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71300"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71301"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71302"
+
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2026-22976"
 
@@ -30938,7 +30958,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23169"
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23170"
 
-# CVE-2026-23171 needs backporting (fixed from 6.19)
+# CVE-2026-23171 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23172"
@@ -31802,7 +31822,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23466"
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23467"
 
-# CVE-2026-23468 needs backporting (fixed from 7.0)
+# CVE-2026-23468 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23469"
@@ -31967,7 +31987,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31438"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31439"
 
-# CVE-2026-31440 needs backporting (fixed from 7.0)
+# CVE-2026-31440 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31441"
@@ -31993,7 +32013,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31447"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31448"
 
-# CVE-2026-31449 needs backporting (fixed from 7.0)
+# CVE-2026-31449 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-31450"
@@ -32106,9 +32126,9 @@ CVE_CHECK_IGNORE += "CVE-2026-31485"
 
 # CVE-2026-31487 needs backporting (fixed from 7.0)
 
-# CVE-2026-31488 needs backporting (fixed from 7.0)
+# CVE-2026-31488 may need backporting (fixed from 6.6.140)
 
-# CVE-2026-31489 needs backporting (fixed from 7.0)
+# CVE-2026-31489 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31490"
@@ -32136,7 +32156,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31497"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31498"
 
-# fixed-version: only affects 6.14 onwards
+# fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31499"
 
 # cpe-stable-backport: Backported in 6.6.131
@@ -32739,7 +32759,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31705"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31708"
 
-# CVE-2026-31709 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31709 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31710"
@@ -32747,7 +32767,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31710"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31711"
 
-# CVE-2026-31712 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31712 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31713"
@@ -32755,7 +32775,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31713"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31714"
 
-# CVE-2026-31715 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31715 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31716"
@@ -32763,8 +32783,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31716"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31717"
 
-# fixed-version: only affects 6.9 onwards
-CVE_CHECK_IGNORE += "CVE-2026-31718"
+# CVE-2026-31718 may need backporting (fixed from 6.6.140)
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31719"
@@ -33269,7 +33288,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43106"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43108"
 
-# CVE-2026-43109 needs backporting (fixed from 7.0)
+# CVE-2026-43109 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43110"
@@ -33582,7 +33601,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43218"
 
 # CVE-2026-43219 needs backporting (fixed from 7.0)
 
-# CVE-2026-43220 has no known resolution
+# CVE-2026-43220 may need backporting (fixed from 6.6.140)
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43221"
@@ -33766,5 +33785,608 @@ CVE_CHECK_IGNORE += "CVE-2026-43282"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43283"
 
-# CVE-2026-43284 has no known resolution
+# cpe-stable-backport: Backported in 6.6.138
+CVE_CHECK_IGNORE += "CVE-2026-43284"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43285"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43286"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43287"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43288"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43289"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43290"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43291"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43292"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43293"
+
+# CVE-2026-43294 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43295"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43296"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43297"
+
+# CVE-2026-43298 needs backporting (fixed from 7.0)
+
+# CVE-2026-43299 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43300"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43301"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43302"
+
+# CVE-2026-43303 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43304"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43305"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43306"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43307"
+
+# CVE-2026-43308 needs backporting (fixed from 7.0)
+
+# CVE-2026-43309 needs backporting (fixed from 7.0)
+
+# CVE-2026-43310 needs backporting (fixed from 7.0)
+
+# CVE-2026-43311 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43312"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43313"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43314"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43315"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-43316"
+
+# CVE-2026-43317 needs backporting (fixed from 7.0)
+
+# CVE-2026-43318 needs backporting (fixed from 7.0)
+
+# CVE-2026-43319 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43320"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43321"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43322"
+
+# fixed-version: only affects 6.12.78 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43323"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43324"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43325"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43326"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43327"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43328"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43329"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43330"
+
+# CVE-2026-43331 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43332"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43333"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43334"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43335"
+
+# cpe-stable-backport: Backported in 6.6.135
+CVE_CHECK_IGNORE += "CVE-2026-43336"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43337"
+
+# CVE-2026-43338 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43339"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43340"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43341"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43342"
+
+# cpe-stable-backport: Backported in 6.6.134
+CVE_CHECK_IGNORE += "CVE-2026-43343"
+
+# CVE-2026-43344 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-43345"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43346"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43347"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43348"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43349"
+
+# cpe-stable-backport: Backported in 6.6.136
+CVE_CHECK_IGNORE += "CVE-2026-43350"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43351"
+
+# CVE-2026-43352 needs backporting (fixed from 7.0)
+
+# CVE-2026-43353 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43354"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43355"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43356"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43357"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43358"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43359"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43360"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43361"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43362"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43363"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43364"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43365"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43366"
+
+# fixed-version: only affects 6.18.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43367"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43368"
+
+# fixed-version: only affects 6.18.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43369"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43370"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43371"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43372"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43373"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43374"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43375"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43376"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43377"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43378"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43379"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43380"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43381"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43382"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43383"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43384"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43385"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43386"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43387"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43388"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43389"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43390"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43391"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43392"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43393"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43394"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43395"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43396"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43397"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43398"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43399"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43400"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43401"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43402"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43403"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43404"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43405"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43406"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43407"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43408"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43409"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43410"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43411"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43412"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43413"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43414"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43415"
+
+# CVE-2026-43416 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43417"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43418"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43419"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43420"
+
+# CVE-2026-43421 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.18.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43422"
+
+# fixed-version: only affects 6.18.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43423"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43424"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43425"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43426"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43427"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43428"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43429"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43430"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43431"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43432"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43433"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43434"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43435"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43436"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43437"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43438"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43439"
+
+# fixed-version: only affects 6.18.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43440"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43441"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43442"
+
+# CVE-2026-43443 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43444"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43445"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43446"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43447"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43448"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43449"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43450"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43451"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43452"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43453"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43454"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43455"
+
+# CVE-2026-43456 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43457"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43458"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43459"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43460"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43461"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43462"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43463"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43464"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43465"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43466"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43467"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43468"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43469"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43470"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43471"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43472"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43473"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43474"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43475"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43476"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43477"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43478"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43479"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43480"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43481"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43482"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43483"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43484"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43485"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43486"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43487"
+
+# cpe-stable-backport: Backported in 6.6.130
+CVE_CHECK_IGNORE += "CVE-2026-43488"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-43489"
+
+# CVE-2026-43490 needs backporting (fixed from 7.1rc3)
+
+# CVE-2026-43500 may need backporting (fixed from 6.6.140)
+
+# cpe-stable-backport: Backported in 6.6.139
+CVE_CHECK_IGNORE += "CVE-2026-46333"
 

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-18 15:30:59.331078+00:00 for kernel version 6.6.139
+# Generated at 2026-05-18 15:33:30.485225+00:00 for kernel version 6.6.140
 # From cvelistV5 cve_2026-05-18_1300Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.139"
+    this_version = "6.6.140"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -9919,7 +9919,8 @@ CVE_CHECK_IGNORE += "CVE-2023-52918"
 # fixed-version: Fixed from version 6.6
 CVE_CHECK_IGNORE += "CVE-2023-52919"
 
-# CVE-2023-52920 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2023-52920"
 
 # fixed-version: Fixed from version 6.5
 CVE_CHECK_IGNORE += "CVE-2023-52921"
@@ -21600,7 +21601,8 @@ CVE_CHECK_IGNORE += "CVE-2024-56645"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2024-56646"
 
-# CVE-2024-56647 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2024-56647"
 
 # cpe-stable-backport: Backported in 6.6.66
 CVE_CHECK_IGNORE += "CVE-2024-56648"
@@ -26571,7 +26573,8 @@ CVE_CHECK_IGNORE += "CVE-2025-38582"
 # cpe-stable-backport: Backported in 6.6.102
 CVE_CHECK_IGNORE += "CVE-2025-38583"
 
-# CVE-2025-38584 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2025-38584"
 
 # CVE-2025-38585 needs backporting (fixed from 6.17)
 
@@ -27902,7 +27905,8 @@ CVE_CHECK_IGNORE += "CVE-2025-39979"
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-39980"
 
-# CVE-2025-39981 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2025-39981"
 
 # cpe-stable-backport: Backported in 6.6.109
 CVE_CHECK_IGNORE += "CVE-2025-39982"
@@ -29400,7 +29404,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68313"
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68314"
 
-# CVE-2025-68315 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2025-68315"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68316"
@@ -30958,7 +30963,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23169"
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23170"
 
-# CVE-2026-23171 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-23171"
 
 # cpe-stable-backport: Backported in 6.6.123
 CVE_CHECK_IGNORE += "CVE-2026-23172"
@@ -31822,7 +31828,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23466"
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23467"
 
-# CVE-2026-23468 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-23468"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23469"
@@ -31987,7 +31994,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31438"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31439"
 
-# CVE-2026-31440 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31440"
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31441"
@@ -32013,7 +32021,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31447"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31448"
 
-# CVE-2026-31449 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31449"
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-31450"
@@ -32126,9 +32135,11 @@ CVE_CHECK_IGNORE += "CVE-2026-31485"
 
 # CVE-2026-31487 needs backporting (fixed from 7.0)
 
-# CVE-2026-31488 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31488"
 
-# CVE-2026-31489 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31489"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31490"
@@ -32759,7 +32770,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31705"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31708"
 
-# CVE-2026-31709 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31709"
 
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31710"
@@ -32767,7 +32779,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31710"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31711"
 
-# CVE-2026-31712 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31712"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31713"
@@ -32775,7 +32788,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31713"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31714"
 
-# CVE-2026-31715 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31715"
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31716"
@@ -32783,7 +32797,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31716"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31717"
 
-# CVE-2026-31718 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-31718"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31719"
@@ -33288,7 +33303,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43106"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43108"
 
-# CVE-2026-43109 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-43109"
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43110"
@@ -33601,7 +33617,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43218"
 
 # CVE-2026-43219 needs backporting (fixed from 7.0)
 
-# CVE-2026-43220 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-43220"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43221"
@@ -34385,7 +34402,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43489"
 
 # CVE-2026-43490 needs backporting (fixed from 7.1rc3)
 
-# CVE-2026-43500 may need backporting (fixed from 6.6.140)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-43500"
 
 # cpe-stable-backport: Backported in 6.6.139
 CVE_CHECK_IGNORE += "CVE-2026-46333"

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.139"
+LINUX_VERSION ?= "6.6.140"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "4d922539ad7df6e3c64e4a0c246d976e4e1f8d41"
+SRCREV_machine ?= "eac8889a3a1c81d7113cc4656b9420e84c379cf5"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,13 +8,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.138"
+LINUX_VERSION ?= "6.6.139"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "3b9f64db049687c0d38b4b3ef2f297f0642179af"
+SRCREV_machine ?= "4d922539ad7df6e3c64e4a0c246d976e4e1f8d41"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6
-SRCREV_meta ?= "7d4cafa710da4e27a86cb015e50d91cf458af06f"
+SRCREV_meta ?= "0a6ad7549c97f8703f1f742f73ee65d29d121958"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.6 to 6.6.140 and kmeta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.140
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.139