### PR TITLE
linux-yocto-onl: update 6.12 to 6.12.90

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-18 13:50:53.284763+00:00 for kernel version 6.12.89
+# Generated at 2026-05-18 13:55:13.652906+00:00 for kernel version 6.12.90
 # From cvelistV5 cve_2026-05-18_1300Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.89"
+    this_version = "6.12.90"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -20860,7 +20860,7 @@ CVE_STATUS[CVE-2026-23169] = "cpe-stable-backport: Backported in 6.12.72"
 
 CVE_STATUS[CVE-2026-23170] = "cpe-stable-backport: Backported in 6.12.69"
 
-# CVE-2026-23171 may need backporting (fixed from 6.12.90)
+CVE_STATUS[CVE-2026-23171] = "cpe-stable-backport: Backported in 6.12.90"
 
 CVE_STATUS[CVE-2026-23172] = "cpe-stable-backport: Backported in 6.12.69"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-18 13:47:36.096969+00:00 for kernel version 6.12.88
+# Generated at 2026-05-18 13:50:53.284763+00:00 for kernel version 6.12.89
 # From cvelistV5 cve_2026-05-18_1300Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.88"
+    this_version = "6.12.89"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -23236,5 +23236,5 @@ CVE_STATUS[CVE-2026-43490] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-43500] = "cpe-stable-backport: Backported in 6.12.88"
 
-# CVE-2026-46333 may need backporting (fixed from 6.12.89)
+CVE_STATUS[CVE-2026-46333] = "cpe-stable-backport: Backported in 6.12.89"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-08 08:59:45.076165+00:00 for kernel version 6.12.87
-# From cvelistV5 cve_2026-05-08_0800Z-1-gcaa049683f4
+# Generated at 2026-05-18 13:47:36.096969+00:00 for kernel version 6.12.88
+# From cvelistV5 cve_2026-05-18_1300Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.87"
+    this_version = "6.12.88"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -20456,6 +20456,20 @@ CVE_STATUS[CVE-2025-71294] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-71295] = "cpe-stable-backport: Backported in 6.12.75"
 
+CVE_STATUS[CVE-2025-71296] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2025-71297] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71298] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2025-71299] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2025-71300] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71301] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2025-71302 needs backporting (fixed from 7.0)
+
 CVE_STATUS[CVE-2026-22976] = "cpe-stable-backport: Backported in 6.12.66"
 
 CVE_STATUS[CVE-2026-22977] = "cpe-stable-backport: Backported in 6.12.66"
@@ -20846,7 +20860,7 @@ CVE_STATUS[CVE-2026-23169] = "cpe-stable-backport: Backported in 6.12.72"
 
 CVE_STATUS[CVE-2026-23170] = "cpe-stable-backport: Backported in 6.12.69"
 
-# CVE-2026-23171 needs backporting (fixed from 6.19)
+# CVE-2026-23171 may need backporting (fixed from 6.12.90)
 
 CVE_STATUS[CVE-2026-23172] = "cpe-stable-backport: Backported in 6.12.69"
 
@@ -21668,7 +21682,7 @@ CVE_STATUS[CVE-2026-31497] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31498] = "cpe-stable-backport: Backported in 6.12.80"
 
-CVE_STATUS[CVE-2026-31499] = "fixed-version: only affects 6.14 onwards"
+CVE_STATUS[CVE-2026-31499] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-31500] = "cpe-stable-backport: Backported in 6.12.80"
 
@@ -22414,7 +22428,7 @@ CVE_STATUS[CVE-2026-43086] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-43087] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-43088 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-43088] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-43089] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -22456,7 +22470,7 @@ CVE_STATUS[CVE-2026-43107] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-43108] = "cpe-stable-backport: Backported in 6.12.83"
 
-# CVE-2026-43109 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-43109] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-43110] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -22678,7 +22692,7 @@ CVE_STATUS[CVE-2026-43218] = "cpe-stable-backport: Backported in 6.12.75"
 
 # CVE-2026-43219 needs backporting (fixed from 7.0)
 
-# CVE-2026-43220 has no known resolution
+CVE_STATUS[CVE-2026-43220] = "fixed-version: Fixed from version 6.12.88"
 
 CVE_STATUS[CVE-2026-43221] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22806,5 +22820,421 @@ CVE_STATUS[CVE-2026-43282] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-43283] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-43284 has no known resolution
+CVE_STATUS[CVE-2026-43284] = "cpe-stable-backport: Backported in 6.12.87"
+
+CVE_STATUS[CVE-2026-43285] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43286] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43287] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43288] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43289] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43290] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43291] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43292] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43293] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43294 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43295] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43296] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43297] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43298 needs backporting (fixed from 7.0)
+
+# CVE-2026-43299 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43300] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43301 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43302] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43303 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43304] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43305] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43306] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43307] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-43308 needs backporting (fixed from 7.0)
+
+# CVE-2026-43309 needs backporting (fixed from 7.0)
+
+# CVE-2026-43310 needs backporting (fixed from 7.0)
+
+# CVE-2026-43311 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43312] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43313] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43314] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43315] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43316] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43317] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43318] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43319] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43320] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-43321] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43322] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43323] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43324] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43325 needs backporting (fixed from 7.0)
+
+# CVE-2026-43326 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43327] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43328] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43329] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43330] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43331 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43332] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43333] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43334] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43335] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43336] = "cpe-stable-backport: Backported in 6.12.82"
+
+# CVE-2026-43337 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43338] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43339] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43340] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43341] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43342] = "cpe-stable-backport: Backported in 6.12.81"
+
+CVE_STATUS[CVE-2026-43343] = "cpe-stable-backport: Backported in 6.12.81"
+
+# CVE-2026-43344 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43345] = "cpe-stable-backport: Backported in 6.12.83"
+
+CVE_STATUS[CVE-2026-43346] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43347] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-43348] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43349] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43350] = "cpe-stable-backport: Backported in 6.12.84"
+
+CVE_STATUS[CVE-2026-43351] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-43352 needs backporting (fixed from 7.0)
+
+# CVE-2026-43353 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43354] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-43355 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43356] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43357] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43358] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43359] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43360] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43361] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43362] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43363] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43364] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43365] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43366] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43367] = "fixed-version: only affects 6.18.16 onwards"
+
+CVE_STATUS[CVE-2026-43368] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43369] = "fixed-version: only affects 6.18.16 onwards"
+
+CVE_STATUS[CVE-2026-43370] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43371] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43372] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43373] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43374] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43375] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43376] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43377] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43378] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43379] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43380] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43381] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43382] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43383] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43384] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43385] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43386] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43387] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43388] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-43389] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43390] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43391] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43392] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43393] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43394] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43395] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43396] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43397] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43398] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43399] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43400] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43401] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43402] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-43403] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43404] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43405] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43406] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43407] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43408] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43409] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43410] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43411] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43412] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43413] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-43414 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43415] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-43416 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43417] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43418] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43419] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43420] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43421] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43422] = "fixed-version: only affects 6.18.17 onwards"
+
+CVE_STATUS[CVE-2026-43423] = "fixed-version: only affects 6.18.17 onwards"
+
+CVE_STATUS[CVE-2026-43424] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43425] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43426] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43427] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43428] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43429] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43430] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43431] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43432] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43433] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43434] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43435] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43436] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43437] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43438] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43439] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43440] = "fixed-version: only affects 6.18.16 onwards"
+
+CVE_STATUS[CVE-2026-43441] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43442] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-43443 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43444] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43445] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43446] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43447] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-43448] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43449] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43450] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43451] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43452] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43453] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43454] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43455] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43456] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43457] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43458] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43459] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43460] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-43461] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43462] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-43463 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43464] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43465] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-43466] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43467] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43468] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43469] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43470] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43471] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43472] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43473] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43474] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43475] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43476] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43477] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-43478] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43479] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-43480] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43481] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-43482] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43483] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43484] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-43485 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-43486] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43487] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43488] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-43489] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43490] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43500] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46333 may need backporting (fixed from 6.12.89)
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.89"
+LINUX_VERSION ?= "6.12.90"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "51eba7e6c91ada319dc9ebee3f88e4472b5efbc4"
+SRCREV_machine ?= "2538fbeff8a94ee2b54eb09d92209e24a1e650d4"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.88"
+LINUX_VERSION ?= "6.12.89"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "a40f33ea3573bb57683ac39138ff64010dc25cb3"
+SRCREV_machine ?= "51eba7e6c91ada319dc9ebee3f88e4472b5efbc4"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,13 +7,13 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.87"
+LINUX_VERSION ?= "6.12.88"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "8bf2f55ef536982e44802d99340119dac6f50636"
+SRCREV_machine ?= "a40f33ea3573bb57683ac39138ff64010dc25cb3"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12
-SRCREV_meta ?= "89cdc6b11d8516512a1e7b584bbe19900a55059b"
+SRCREV_meta ?= "921317ea8b9096f403af3f5a4ec32bc7cf62b0dd"
 
 SRC_URI += "\
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.12;destsuffix=kernel-meta \


### PR DESCRIPTION
Update linux 6.12 to 6.12.90 and kmeta to HEAD.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.90
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.89
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.88