### PR TITLE
linux-yocto-onl: update 6.12 to 6.12.92

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-06-01 08:57:02.066166+00:00 for kernel version 6.12.91
-# From cvelistV5 cve_2026-06-01_0700Z
+# Generated at 2026-06-02 08:04:12.566661+00:00 for kernel version 6.12.92
+# From cvelistV5 cve_2026-06-02_0700Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.91"
+    this_version = "6.12.92"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -16016,7 +16016,7 @@ CVE_STATUS[CVE-2025-22067] = "cpe-stable-backport: Backported in 6.12.23"
 
 CVE_STATUS[CVE-2025-22068] = "cpe-stable-backport: Backported in 6.12.23"
 
-# CVE-2025-22069 may need backporting (fixed from 6.13)
+CVE_STATUS[CVE-2025-22069] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2025-22070] = "cpe-stable-backport: Backported in 6.12.23"
 
@@ -20442,7 +20442,7 @@ CVE_STATUS[CVE-2025-71287] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2025-71288] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2025-71289 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2025-71289] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2025-71290] = "fixed-version: only affects 6.16 onwards"
 
@@ -21320,7 +21320,7 @@ CVE_STATUS[CVE-2026-23392] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23393] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-23394 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23394] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-23395] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -21470,7 +21470,7 @@ CVE_STATUS[CVE-2026-23467] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-23468] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-23469 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23469] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-23470] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -21542,7 +21542,7 @@ CVE_STATUS[CVE-2026-31418] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31419] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-31420 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31420] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-31421] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -21674,7 +21674,7 @@ CVE_STATUS[CVE-2026-31484] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-31485] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31486 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31486] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-31487] = "cpe-stable-backport: Backported in 6.12.80"
 
@@ -21820,7 +21820,7 @@ CVE_STATUS[CVE-2026-31558] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31559] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31560 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31560] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-31561] = "cpe-stable-backport: Backported in 6.12.80"
 
@@ -22134,7 +22134,7 @@ CVE_STATUS[CVE-2026-31715] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-31716] = "cpe-stable-backport: Backported in 6.12.84"
 
-# CVE-2026-31717 needs backporting (fixed from 7.1rc1)
+CVE_STATUS[CVE-2026-31717] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-31718] = "cpe-stable-backport: Backported in 6.12.84"
 
@@ -23926,7 +23926,7 @@ CVE_STATUS[CVE-2026-46156] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-46157] = "cpe-stable-backport: Backported in 6.12.88"
 
-# CVE-2026-46158 needs backporting (fixed from 7.1rc3)
+CVE_STATUS[CVE-2026-46158] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-46159] = "cpe-stable-backport: Backported in 6.12.90"
 
@@ -23950,7 +23950,7 @@ CVE_STATUS[CVE-2026-46168] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-46169] = "cpe-stable-backport: Backported in 6.12.88"
 
-# CVE-2026-46170 needs backporting (fixed from 7.1rc3)
+CVE_STATUS[CVE-2026-46170] = "cpe-stable-backport: Backported in 6.12.92"
 
 # CVE-2026-46171 needs backporting (fixed from 7.1rc1)
 
@@ -24042,7 +24042,7 @@ CVE_STATUS[CVE-2026-46214] = "cpe-stable-backport: Backported in 6.12.90"
 
 CVE_STATUS[CVE-2026-46215] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-46216 needs backporting (fixed from 7.1rc3)
+CVE_STATUS[CVE-2026-46216] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-46217] = "fixed-version: only affects 7.1rc1 onwards"
 
@@ -24095,6 +24095,8 @@ CVE_STATUS[CVE-2026-46240] = "fixed-version: only affects 6.18.16 onwards"
 CVE_STATUS[CVE-2026-46241] = "cpe-stable-backport: Backported in 6.12.90"
 
 # CVE-2026-46242 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46243] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-46300] = "cpe-stable-backport: Backported in 6.12.91"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-05-18 13:55:13.652906+00:00 for kernel version 6.12.90
-# From cvelistV5 cve_2026-05-18_1300Z
+# Generated at 2026-06-01 08:57:02.066166+00:00 for kernel version 6.12.91
+# From cvelistV5 cve_2026-06-01_0700Z
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.90"
+    this_version = "6.12.91"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -6752,7 +6752,7 @@ CVE_STATUS[CVE-2023-53010] = "fixed-version: Fixed from version 6.2"
 
 CVE_STATUS[CVE-2023-53011] = "fixed-version: Fixed from version 6.2"
 
-# CVE-2023-53012 has no known resolution
+CVE_STATUS[CVE-2023-53012] = "fixed-version: Fixed from version 6.1"
 
 CVE_STATUS[CVE-2023-53013] = "fixed-version: Fixed from version 6.2"
 
@@ -7064,7 +7064,7 @@ CVE_STATUS[CVE-2023-53185] = "fixed-version: Fixed from version 6.5"
 
 CVE_STATUS[CVE-2023-53186] = "fixed-version: Fixed from version 6.3"
 
-# CVE-2023-53187 has no known resolution
+CVE_STATUS[CVE-2023-53187] = "fixed-version: Fixed from version 5.16"
 
 CVE_STATUS[CVE-2023-53188] = "fixed-version: Fixed from version 6.3"
 
@@ -12928,7 +12928,7 @@ CVE_STATUS[CVE-2024-49852] = "fixed-version: Fixed from version 6.12"
 
 CVE_STATUS[CVE-2024-49853] = "fixed-version: Fixed from version 6.12"
 
-# CVE-2024-49854 has no known resolution
+CVE_STATUS[CVE-2024-49854] = "fixed-version: Fixed from version 5.11"
 
 CVE_STATUS[CVE-2024-49855] = "fixed-version: Fixed from version 6.12"
 
@@ -16016,7 +16016,7 @@ CVE_STATUS[CVE-2025-22067] = "cpe-stable-backport: Backported in 6.12.23"
 
 CVE_STATUS[CVE-2025-22068] = "cpe-stable-backport: Backported in 6.12.23"
 
-CVE_STATUS[CVE-2025-22069] = "fixed-version: only affects 6.14 onwards"
+# CVE-2025-22069 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-22070] = "cpe-stable-backport: Backported in 6.12.23"
 
@@ -16458,7 +16458,7 @@ CVE_STATUS[CVE-2025-37869] = "cpe-stable-backport: Backported in 6.12.25"
 
 CVE_STATUS[CVE-2025-37870] = "cpe-stable-backport: Backported in 6.12.25"
 
-CVE_STATUS[CVE-2025-37871] = "cpe-stable-backport: Backported in 6.12.25"
+CVE_STATUS[CVE-2025-37871] = "fixed-version: only affects 6.13.11 onwards"
 
 CVE_STATUS[CVE-2025-37872] = "cpe-stable-backport: Backported in 6.12.25"
 
@@ -16472,7 +16472,7 @@ CVE_STATUS[CVE-2025-37876] = "cpe-stable-backport: Backported in 6.12.26"
 
 CVE_STATUS[CVE-2025-37877] = "cpe-stable-backport: Backported in 6.12.26"
 
-CVE_STATUS[CVE-2025-37878] = "cpe-stable-backport: Backported in 6.12.26"
+CVE_STATUS[CVE-2025-37878] = "fixed-version: only affects 6.13.12 onwards"
 
 CVE_STATUS[CVE-2025-37879] = "cpe-stable-backport: Backported in 6.12.26"
 
@@ -16572,7 +16572,7 @@ CVE_STATUS[CVE-2025-37927] = "cpe-stable-backport: Backported in 6.12.28"
 
 CVE_STATUS[CVE-2025-37928] = "cpe-stable-backport: Backported in 6.12.28"
 
-CVE_STATUS[CVE-2025-37929] = "cpe-stable-backport: Backported in 6.12.28"
+CVE_STATUS[CVE-2025-37929] = "fixed-version: only affects 6.13.12 onwards"
 
 CVE_STATUS[CVE-2025-37930] = "cpe-stable-backport: Backported in 6.12.28"
 
@@ -16636,7 +16636,7 @@ CVE_STATUS[CVE-2025-37960] = "cpe-stable-backport: Backported in 6.12.29"
 
 CVE_STATUS[CVE-2025-37961] = "cpe-stable-backport: Backported in 6.12.29"
 
-CVE_STATUS[CVE-2025-37962] = "cpe-stable-backport: Backported in 6.12.29"
+CVE_STATUS[CVE-2025-37962] = "fixed-version: only affects 6.13.11 onwards"
 
 CVE_STATUS[CVE-2025-37963] = "cpe-stable-backport: Backported in 6.12.29"
 
@@ -16900,7 +16900,7 @@ CVE_STATUS[CVE-2025-38097] = "cpe-stable-backport: Backported in 6.12.31"
 
 CVE_STATUS[CVE-2025-38098] = "cpe-stable-backport: Backported in 6.12.31"
 
-CVE_STATUS[CVE-2025-38099] = "cpe-stable-backport: Backported in 6.12.31"
+CVE_STATUS[CVE-2025-38099] = "fixed-version: only affects 6.13.12 onwards"
 
 CVE_STATUS[CVE-2025-38100] = "cpe-stable-backport: Backported in 6.12.34"
 
@@ -17538,7 +17538,7 @@ CVE_STATUS[CVE-2025-38419] = "cpe-stable-backport: Backported in 6.12.35"
 
 CVE_STATUS[CVE-2025-38420] = "cpe-stable-backport: Backported in 6.12.35"
 
-CVE_STATUS[CVE-2025-38421] = "fixed-version: only affects 6.14 onwards"
+# CVE-2025-38421 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-38422] = "cpe-stable-backport: Backported in 6.12.35"
 
@@ -17830,7 +17830,7 @@ CVE_STATUS[CVE-2025-38565] = "cpe-stable-backport: Backported in 6.12.42"
 
 CVE_STATUS[CVE-2025-38566] = "cpe-stable-backport: Backported in 6.12.42"
 
-CVE_STATUS[CVE-2025-38567] = "fixed-version: only affects 6.15 onwards"
+CVE_STATUS[CVE-2025-38567] = "fixed-version: only affects 6.15.3 onwards"
 
 CVE_STATUS[CVE-2025-38568] = "cpe-stable-backport: Backported in 6.12.42"
 
@@ -18004,7 +18004,7 @@ CVE_STATUS[CVE-2025-38654] = "fixed-version: only affects 6.13 onwards"
 
 CVE_STATUS[CVE-2025-38655] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2025-38656 has no known resolution
+# CVE-2025-38656 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-38657] = "fixed-version: only affects 6.16 onwards"
 
@@ -18164,7 +18164,7 @@ CVE_STATUS[CVE-2025-38734] = "cpe-stable-backport: Backported in 6.12.44"
 
 CVE_STATUS[CVE-2025-38735] = "cpe-stable-backport: Backported in 6.12.44"
 
-CVE_STATUS[CVE-2025-38736] = "cpe-stable-backport: Backported in 6.12.44"
+CVE_STATUS[CVE-2025-38736] = "fixed-version: only affects 6.15.11 onwards"
 
 CVE_STATUS[CVE-2025-38737] = "cpe-stable-backport: Backported in 6.12.44"
 
@@ -18370,7 +18370,7 @@ CVE_STATUS[CVE-2025-39773] = "cpe-stable-backport: Backported in 6.12.44"
 
 CVE_STATUS[CVE-2025-39774] = "fixed-version: only affects 6.14 onwards"
 
-CVE_STATUS[CVE-2025-39775] = "fixed-version: only affects 6.13 onwards"
+# CVE-2025-39775 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-39776] = "cpe-stable-backport: Backported in 6.12.44"
 
@@ -18744,7 +18744,7 @@ CVE_STATUS[CVE-2025-39963] = "cpe-stable-backport: Backported in 6.12.49"
 
 CVE_STATUS[CVE-2025-39964] = "cpe-stable-backport: Backported in 6.12.49"
 
-CVE_STATUS[CVE-2025-39965] = "cpe-stable-backport: Backported in 6.12.50"
+CVE_STATUS[CVE-2025-39965] = "fixed-version: only affects 6.15.11 onwards"
 
 CVE_STATUS[CVE-2025-39966] = "cpe-stable-backport: Backported in 6.12.50"
 
@@ -18808,11 +18808,11 @@ CVE_STATUS[CVE-2025-39995] = "cpe-stable-backport: Backported in 6.12.52"
 
 CVE_STATUS[CVE-2025-39996] = "cpe-stable-backport: Backported in 6.12.51"
 
-CVE_STATUS[CVE-2025-39997] = "fixed-version: only affects 6.16 onwards"
+# CVE-2025-39997 needs backporting (fixed from 6.18)
 
 CVE_STATUS[CVE-2025-39998] = "cpe-stable-backport: Backported in 6.12.51"
 
-CVE_STATUS[CVE-2025-39999] = "fixed-version: only affects 6.16 onwards"
+CVE_STATUS[CVE-2025-39999] = "fixed-version: only affects 6.16.4 onwards"
 
 CVE_STATUS[CVE-2025-40000] = "cpe-stable-backport: Backported in 6.12.52"
 
@@ -18828,7 +18828,7 @@ CVE_STATUS[CVE-2025-40005] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2025-40006] = "cpe-stable-backport: Backported in 6.12.50"
 
-CVE_STATUS[CVE-2025-40007] = "fixed-version: only affects 6.16 onwards"
+CVE_STATUS[CVE-2025-40007] = "fixed-version: only affects 6.15.3 onwards"
 
 CVE_STATUS[CVE-2025-40008] = "cpe-stable-backport: Backported in 6.12.50"
 
@@ -19074,7 +19074,7 @@ CVE_STATUS[CVE-2025-40129] = "cpe-stable-backport: Backported in 6.12.53"
 
 # CVE-2025-40130 needs backporting (fixed from 6.18)
 
-CVE_STATUS[CVE-2025-40131] = "fixed-version: only affects 6.16 onwards"
+CVE_STATUS[CVE-2025-40131] = "fixed-version: only affects 6.15.3 onwards"
 
 CVE_STATUS[CVE-2025-40132] = "cpe-stable-backport: Backported in 6.12.53"
 
@@ -19236,7 +19236,7 @@ CVE_STATUS[CVE-2025-40211] = "cpe-stable-backport: Backported in 6.12.58"
 
 CVE_STATUS[CVE-2025-40212] = "cpe-stable-backport: Backported in 6.12.59"
 
-CVE_STATUS[CVE-2025-40213] = "fixed-version: only affects 6.17 onwards"
+# CVE-2025-40213 needs backporting (fixed from 6.18)
 
 CVE_STATUS[CVE-2025-40214] = "cpe-stable-backport: Backported in 6.12.59"
 
@@ -19390,7 +19390,7 @@ CVE_STATUS[CVE-2025-40288] = "cpe-stable-backport: Backported in 6.12.59"
 
 CVE_STATUS[CVE-2025-40289] = "cpe-stable-backport: Backported in 6.12.59"
 
-CVE_STATUS[CVE-2025-40290] = "fixed-version: only affects 6.17 onwards"
+CVE_STATUS[CVE-2025-40290] = "fixed-version: only affects 6.16.8 onwards"
 
 CVE_STATUS[CVE-2025-40291] = "fixed-version: only affects 6.15 onwards"
 
@@ -19464,7 +19464,7 @@ CVE_STATUS[CVE-2025-40325] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-40326] = "fixed-version: only affects 6.14 onwards"
 
-CVE_STATUS[CVE-2025-40327] = "fixed-version: only affects 6.17 onwards"
+CVE_STATUS[CVE-2025-40327] = "fixed-version: only affects 6.16.8 onwards"
 
 CVE_STATUS[CVE-2025-40328] = "cpe-stable-backport: Backported in 6.12.58"
 
@@ -19594,7 +19594,7 @@ CVE_STATUS[CVE-2025-68192] = "cpe-stable-backport: Backported in 6.12.58"
 
 CVE_STATUS[CVE-2025-68194] = "cpe-stable-backport: Backported in 6.12.58"
 
-# CVE-2025-68195 has no known resolution
+# CVE-2025-68195 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-68196] = "fixed-version: only affects 6.17 onwards"
 
@@ -19702,7 +19702,7 @@ CVE_STATUS[CVE-2025-68249] = "cpe-stable-backport: Backported in 6.12.56"
 
 CVE_STATUS[CVE-2025-68250] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2025-68251 needs backporting (fixed from 6.18)
+CVE_STATUS[CVE-2025-68251] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2025-68252] = "cpe-stable-backport: Backported in 6.12.56"
 
@@ -19886,7 +19886,7 @@ CVE_STATUS[CVE-2025-68355] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2025-68356] = "cpe-stable-backport: Backported in 6.12.63"
 
-CVE_STATUS[CVE-2025-68357] = "fixed-version: Fixed from version 6.12.64"
+CVE_STATUS[CVE-2025-68357] = "fixed-version: only affects 6.17.13 onwards"
 
 CVE_STATUS[CVE-2025-68358] = "cpe-stable-backport: Backported in 6.12.68"
 
@@ -20142,7 +20142,7 @@ CVE_STATUS[CVE-2025-71068] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71069] = "cpe-stable-backport: Backported in 6.12.64"
 
-CVE_STATUS[CVE-2025-71070] = "fixed-version: only affects 6.15 onwards"
+CVE_STATUS[CVE-2025-71070] = "fixed-version: only affects 6.14.6 onwards"
 
 CVE_STATUS[CVE-2025-71071] = "cpe-stable-backport: Backported in 6.12.64"
 
@@ -20292,9 +20292,9 @@ CVE_STATUS[CVE-2025-71143] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71144] = "cpe-stable-backport: Backported in 6.12.65"
 
-# CVE-2025-71145 has no known resolution
+CVE_STATUS[CVE-2025-71145] = "fixed-version: Fixed from version 5.11"
 
-CVE_STATUS[CVE-2025-71146] = "cpe-stable-backport: Backported in 6.12.64"
+CVE_STATUS[CVE-2025-71146] = "fixed-version: only affects 6.17.13 onwards"
 
 CVE_STATUS[CVE-2025-71147] = "cpe-stable-backport: Backported in 6.12.64"
 
@@ -20310,7 +20310,7 @@ CVE_STATUS[CVE-2025-71153] = "cpe-stable-backport: Backported in 6.12.64"
 
 CVE_STATUS[CVE-2025-71154] = "cpe-stable-backport: Backported in 6.12.64"
 
-CVE_STATUS[CVE-2025-71155] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2025-71155] = "fixed-version: only affects 6.17.4 onwards"
 
 CVE_STATUS[CVE-2025-71156] = "cpe-stable-backport: Backported in 6.12.64"
 
@@ -20462,13 +20462,31 @@ CVE_STATUS[CVE-2025-71297] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-71298] = "fixed-version: only affects 6.16 onwards"
 
-CVE_STATUS[CVE-2025-71299] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2025-71299] = "fixed-version: only affects 6.17.11 onwards"
 
 CVE_STATUS[CVE-2025-71300] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2025-71301] = "fixed-version: only affects 6.16 onwards"
 
 # CVE-2025-71302 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2025-71303] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2025-71304] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71305] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71306] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2025-71307] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2025-71308] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2025-71309] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2025-71311] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2025-71312] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-22976] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20546,7 +20564,7 @@ CVE_STATUS[CVE-2026-23012] = "fixed-version: only affects 6.17 onwards"
 
 CVE_STATUS[CVE-2026-23013] = "cpe-stable-backport: Backported in 6.12.67"
 
-CVE_STATUS[CVE-2026-23014] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-23014] = "fixed-version: only affects 6.17.8 onwards"
 
 CVE_STATUS[CVE-2026-23015] = "fixed-version: only affects 6.13 onwards"
 
@@ -20554,7 +20572,7 @@ CVE_STATUS[CVE-2026-23016] = "fixed-version: only affects 6.18 onwards"
 
 # CVE-2026-23017 needs backporting (fixed from 6.19)
 
-CVE_STATUS[CVE-2026-23018] = "fixed-version: only affects 6.17 onwards"
+CVE_STATUS[CVE-2026-23018] = "fixed-version: only affects 6.16.9 onwards"
 
 CVE_STATUS[CVE-2026-23019] = "cpe-stable-backport: Backported in 6.12.66"
 
@@ -20676,7 +20694,7 @@ CVE_STATUS[CVE-2026-23077] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-23078] = "cpe-stable-backport: Backported in 6.12.68"
 
-CVE_STATUS[CVE-2026-23079] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-23079] = "fixed-version: only affects 6.17.10 onwards"
 
 CVE_STATUS[CVE-2026-23080] = "cpe-stable-backport: Backported in 6.12.68"
 
@@ -20804,7 +20822,7 @@ CVE_STATUS[CVE-2026-23141] = "cpe-stable-backport: Backported in 6.12.67"
 
 CVE_STATUS[CVE-2026-23142] = "cpe-stable-backport: Backported in 6.12.67"
 
-CVE_STATUS[CVE-2026-23143] = "fixed-version: only affects 6.15 onwards"
+# CVE-2026-23143 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2026-23144] = "cpe-stable-backport: Backported in 6.12.67"
 
@@ -20918,11 +20936,11 @@ CVE_STATUS[CVE-2026-23198] = "cpe-stable-backport: Backported in 6.12.70"
 
 CVE_STATUS[CVE-2026-23199] = "cpe-stable-backport: Backported in 6.12.70"
 
-CVE_STATUS[CVE-2026-23200] = "cpe-stable-backport: Backported in 6.12.70"
+CVE_STATUS[CVE-2026-23200] = "fixed-version: only affects 6.17.13 onwards"
 
 CVE_STATUS[CVE-2026-23201] = "cpe-stable-backport: Backported in 6.12.70"
 
-CVE_STATUS[CVE-2026-23202] = "cpe-stable-backport: Backported in 6.12.70"
+CVE_STATUS[CVE-2026-23202] = "fixed-version: only affects 6.17.13 onwards"
 
 CVE_STATUS[CVE-2026-23203] = "fixed-version: only affects 6.17 onwards"
 
@@ -21062,7 +21080,7 @@ CVE_STATUS[CVE-2026-23270] = "cpe-stable-backport: Backported in 6.12.77"
 
 CVE_STATUS[CVE-2026-23271] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23272 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23272] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-23273] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -21266,7 +21284,7 @@ CVE_STATUS[CVE-2026-23374] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-23375] = "cpe-stable-backport: Backported in 6.12.78"
 
-CVE_STATUS[CVE-2026-23376] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-23376] = "fixed-version: only affects 6.17.3 onwards"
 
 # CVE-2026-23377 needs backporting (fixed from 7.0)
 
@@ -21372,7 +21390,7 @@ CVE_STATUS[CVE-2026-23427] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23428] = "cpe-stable-backport: Backported in 6.12.78"
 
-CVE_STATUS[CVE-2026-23429] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-23429] = "fixed-version: only affects 6.18.7 onwards"
 
 CVE_STATUS[CVE-2026-23430] = "fixed-version: only affects 6.16 onwards"
 
@@ -21384,7 +21402,7 @@ CVE_STATUS[CVE-2026-23433] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-23434] = "cpe-stable-backport: Backported in 6.12.78"
 
-CVE_STATUS[CVE-2026-23435] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-23435] = "fixed-version: only affects 6.18.2 onwards"
 
 CVE_STATUS[CVE-2026-23436] = "fixed-version: only affects 6.13 onwards"
 
@@ -21602,7 +21620,7 @@ CVE_STATUS[CVE-2026-31457] = "fixed-version: only affects 6.17 onwards"
 
 CVE_STATUS[CVE-2026-31458] = "cpe-stable-backport: Backported in 6.12.80"
 
-CVE_STATUS[CVE-2026-31459] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-31459] = "fixed-version: only affects 6.17.6 onwards"
 
 CVE_STATUS[CVE-2026-31460] = "fixed-version: only affects 6.19 onwards"
 
@@ -21634,7 +21652,7 @@ CVE_STATUS[CVE-2026-31473] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31474] = "cpe-stable-backport: Backported in 6.12.80"
 
-CVE_STATUS[CVE-2026-31475] = "fixed-version: only affects 6.15 onwards"
+CVE_STATUS[CVE-2026-31475] = "fixed-version: only affects 6.14.9 onwards"
 
 CVE_STATUS[CVE-2026-31476] = "cpe-stable-backport: Backported in 6.12.80"
 
@@ -21816,7 +21834,7 @@ CVE_STATUS[CVE-2026-31565] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31566] = "cpe-stable-backport: Backported in 6.12.80"
 
-CVE_STATUS[CVE-2026-31567] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-31567] = "fixed-version: only affects 6.17.8 onwards"
 
 # CVE-2026-31568 needs backporting (fixed from 7.0)
 
@@ -21898,9 +21916,9 @@ CVE_STATUS[CVE-2026-31606] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-31607] = "cpe-stable-backport: Backported in 6.12.83"
 
-CVE_STATUS[CVE-2026-31608] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-31608] = "fixed-version: only affects 6.18.11 onwards"
 
-CVE_STATUS[CVE-2026-31609] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-31609] = "fixed-version: only affects 6.18.11 onwards"
 
 CVE_STATUS[CVE-2026-31610] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -21908,7 +21926,7 @@ CVE_STATUS[CVE-2026-31611] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-31612] = "cpe-stable-backport: Backported in 6.12.83"
 
-# CVE-2026-31613 needs backporting (fixed from 7.1rc1)
+CVE_STATUS[CVE-2026-31613] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-31614] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -22310,7 +22328,7 @@ CVE_STATUS[CVE-2026-43027] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-43028] = "cpe-stable-backport: Backported in 6.12.81"
 
-CVE_STATUS[CVE-2026-43029] = "fixed-version: only affects 6.18 onwards"
+# CVE-2026-43029 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2026-43030] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -22506,7 +22524,7 @@ CVE_STATUS[CVE-2026-43125] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-43126] = "cpe-stable-backport: Backported in 6.12.75"
 
-CVE_STATUS[CVE-2026-43127] = "fixed-version: only affects 6.13 onwards"
+# CVE-2026-43127 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2026-43128] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22554,7 +22572,7 @@ CVE_STATUS[CVE-2026-43149] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-43150] = "cpe-stable-backport: Backported in 6.12.75"
 
-CVE_STATUS[CVE-2026-43151] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-43151] = "fixed-version: only affects 6.18.3 onwards"
 
 CVE_STATUS[CVE-2026-43152] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22742,7 +22760,7 @@ CVE_STATUS[CVE-2026-43243] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-43244] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-43245 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-43245] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-43246] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22824,7 +22842,7 @@ CVE_STATUS[CVE-2026-43284] = "cpe-stable-backport: Backported in 6.12.87"
 
 CVE_STATUS[CVE-2026-43285] = "fixed-version: only affects 6.18 onwards"
 
-CVE_STATUS[CVE-2026-43286] = "fixed-version: only affects 6.15 onwards"
+CVE_STATUS[CVE-2026-43286] = "fixed-version: only affects 6.14.8 onwards"
 
 CVE_STATUS[CVE-2026-43287] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22944,13 +22962,13 @@ CVE_STATUS[CVE-2026-43343] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-43345] = "cpe-stable-backport: Backported in 6.12.83"
 
-CVE_STATUS[CVE-2026-43346] = "fixed-version: only affects 6.13 onwards"
+# CVE-2026-43346 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2026-43347] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-43348] = "fixed-version: only affects 6.19 onwards"
 
-CVE_STATUS[CVE-2026-43349] = "fixed-version: only affects 6.18 onwards"
+CVE_STATUS[CVE-2026-43349] = "fixed-version: only affects 6.18.13 onwards"
 
 CVE_STATUS[CVE-2026-43350] = "cpe-stable-backport: Backported in 6.12.84"
 
@@ -22968,7 +22986,7 @@ CVE_STATUS[CVE-2026-43356] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-43357] = "cpe-stable-backport: Backported in 6.12.78"
 
-CVE_STATUS[CVE-2026-43358] = "fixed-version: only affects 6.17 onwards"
+CVE_STATUS[CVE-2026-43358] = "fixed-version: only affects 6.16.4 onwards"
 
 CVE_STATUS[CVE-2026-43359] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -23180,9 +23198,9 @@ CVE_STATUS[CVE-2026-43462] = "fixed-version: only affects 6.18 onwards"
 
 # CVE-2026-43463 needs backporting (fixed from 7.0)
 
-CVE_STATUS[CVE-2026-43464] = "fixed-version: only affects 6.18 onwards"
+# CVE-2026-43464 may need backporting (fixed from 6.13)
 
-CVE_STATUS[CVE-2026-43465] = "fixed-version: only affects 6.18 onwards"
+# CVE-2026-43465 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2026-43466] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -23234,7 +23252,851 @@ CVE_STATUS[CVE-2026-43489] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-43490] = "cpe-stable-backport: Backported in 6.12.88"
 
+CVE_STATUS[CVE-2026-43491] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-43492] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43493] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-43494] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-43495] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43496] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43497] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43498] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-43499] = "cpe-stable-backport: Backported in 6.12.86"
+
 CVE_STATUS[CVE-2026-43500] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43501] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-43502] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-43503] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45834] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-45835] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-45836] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-45837] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-45838] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45839] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45840] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45841] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45842] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45843] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45844] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45845] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45846] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-45847] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45848] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45849] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-45850 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45851] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45852] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45853] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45854] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-45855] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-45856] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45857] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45858] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45859] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45860] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45861] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45862] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45863] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45864] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45865] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45866] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45867] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45868] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45869] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45870] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45871] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45872] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45873] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45874] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45875] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45876] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-45877] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45878] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45879] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45880] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45881] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45882] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45883] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45884] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45885] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45886] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45887] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-45888] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45889] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45890] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45891] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45892] = "fixed-version: Fixed from version 6.1.168"
+
+CVE_STATUS[CVE-2026-45893] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45894] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45895] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45896] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-45897 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45898] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45899] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45900] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-45901 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45902] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45903] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-45904] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45905] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45906] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45907] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-45908] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45909] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45910] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45911] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-45912] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45913] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45914] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45915] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45916] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45917] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45918] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-45919] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45920] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45921] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45922] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45923] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45924] = "cpe-stable-backport: Backported in 6.12.78"
+
+CVE_STATUS[CVE-2026-45925] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45926] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45927] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45928] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45929] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-45930 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45931] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-45932 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45933] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-45934 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45935] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45936] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45937] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-45938] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45939] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-45940 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45941] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45942] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45943] = "cpe-stable-backport: Backported in 6.12.78"
+
+# CVE-2026-45944 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45945] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-45946] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45947] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45948] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45949] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45950] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45951] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-45952] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45953] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45954] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45955] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-45956 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45957] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45958] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-45959] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-45960] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-45961 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45962] = "cpe-stable-backport: Backported in 6.12.75"
+
+# CVE-2026-45963 needs backporting (fixed from 7.0)
+
+CVE_STATUS[CVE-2026-45964] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45965] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45966] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-45967] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45968] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45969] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45970] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45971] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45972] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45973] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45974] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45975] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45976] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45977] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-45978] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45979] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45980] = "fixed-version: only affects 6.14.9 onwards"
+
+CVE_STATUS[CVE-2026-45981] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45982] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45983] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45984] = "cpe-stable-backport: Backported in 6.12.75"
+
+CVE_STATUS[CVE-2026-45985] = "cpe-stable-backport: Backported in 6.12.77"
+
+CVE_STATUS[CVE-2026-45986] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45987] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45988] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45989] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45990] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-45991] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-45992] = "fixed-version: only affects 7.1rc1 onwards"
+
+CVE_STATUS[CVE-2026-45993] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45994] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45995] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-45996] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45997] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45998] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-45999] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46000] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46001] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46002] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46003] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46004] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46005] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46006] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46007] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46008] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-46009] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46010] = "fixed-version: only affects 6.16.9 onwards"
+
+CVE_STATUS[CVE-2026-46011] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46012] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46013] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-46014 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46015] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46016] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46017 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46018] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46019] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46020] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-46021] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46022] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46023] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46024] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46025] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-46026] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46027] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46028] = "cpe-stable-backport: Backported in 6.12.85"
+
+CVE_STATUS[CVE-2026-46029] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46030] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46031] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46032 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46033] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46034] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46035] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46036] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46037] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46038] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46039] = "fixed-version: only affects 6.16.9 onwards"
+
+CVE_STATUS[CVE-2026-46040] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46041] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46042] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-46043] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46044 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46045] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46046] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46047] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46048] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46049] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46050] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46051] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46052] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46053] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46054 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46055] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-46056] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46057] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-46058] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46059 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46060] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-46061] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46062] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46063] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46064] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46065] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46066 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46067] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-46068] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46069] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46070] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46071 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46072] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46073] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46074] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46075] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46076] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46077] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46078] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46079] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46080] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46081] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-46082] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46083] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46084] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46085] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46086] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46087] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-46088] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46089] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46090] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46091] = "cpe-stable-backport: Backported in 6.12.86"
+
+# CVE-2026-46092 needs backporting (fixed from 7.1rc1)
+
+# CVE-2026-46093 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46094] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46095] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46096] = "fixed-version: only affects 6.18.3 onwards"
+
+CVE_STATUS[CVE-2026-46097] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-46098] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46099] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46100] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-46101] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46102] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46103] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-46104] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-46105] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-46106] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46107] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46108] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46109] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46110] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46111] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46112] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46113] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46114] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46115] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46116] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46117] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-46118] = "fixed-version: only affects 6.18.32 onwards"
+
+CVE_STATUS[CVE-2026-46119] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46120] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46121] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46122] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46123] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46124] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46125] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46126] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46127] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46128] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46129] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46130 may need backporting (fixed from 6.13)
+
+CVE_STATUS[CVE-2026-46131] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46132] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46133] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46134] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-46135] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46136] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46137] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-46138] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46139] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46140] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46141] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46142] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46143] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46144] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46145] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46146] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46147 needs backporting (fixed from 7.1rc2)
+
+# CVE-2026-46148 needs backporting (fixed from 7.1rc3)
+
+CVE_STATUS[CVE-2026-46149] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46150] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46151] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46152] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46153 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46154] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46155] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46156] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46157] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46158 needs backporting (fixed from 7.1rc3)
+
+CVE_STATUS[CVE-2026-46159] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46160] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-46161] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46162] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46163] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46164] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46165] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46166] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46167] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46168] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46169] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46170 needs backporting (fixed from 7.1rc3)
+
+# CVE-2026-46171 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46172] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46173] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46174] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46175 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46176] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46177] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46178] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46179] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46180] = "cpe-stable-backport: Backported in 6.12.88"
+
+# CVE-2026-46181 needs backporting (fixed from 7.1rc3)
+
+CVE_STATUS[CVE-2026-46182] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46183] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-46184] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46185] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46186] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46187] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46188] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46189] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46190] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46191] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46192] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-46193] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46194] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46195] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46196] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-46197] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46198] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46199] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46200] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46201] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46202] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-46203 needs backporting (fixed from 7.1rc2)
+
+CVE_STATUS[CVE-2026-46204] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46205] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46206] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46207] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46208] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46209] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46210] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46211] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46212] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46213] = "fixed-version: only affects 6.15.6 onwards"
+
+CVE_STATUS[CVE-2026-46214] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46215] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-46216 needs backporting (fixed from 7.1rc3)
+
+CVE_STATUS[CVE-2026-46217] = "fixed-version: only affects 7.1rc1 onwards"
+
+CVE_STATUS[CVE-2026-46218] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46219] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46220] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46221] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46222] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-46223] = "fixed-version: only affects 6.19.12 onwards"
+
+CVE_STATUS[CVE-2026-46224] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-46225] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46226] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46227] = "cpe-stable-backport: Backported in 6.12.90"
+
+# CVE-2026-46228 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46229] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46230] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46231] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46232] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46233] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46234] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46235] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46236] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46237] = "fixed-version: only affects 7.1rc1 onwards"
+
+CVE_STATUS[CVE-2026-46238] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-46239] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-46240] = "fixed-version: only affects 6.18.16 onwards"
+
+CVE_STATUS[CVE-2026-46241] = "cpe-stable-backport: Backported in 6.12.90"
+
+# CVE-2026-46242 needs backporting (fixed from 7.1rc1)
+
+CVE_STATUS[CVE-2026-46300] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-46333] = "cpe-stable-backport: Backported in 6.12.89"
 

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.91"
+LINUX_VERSION ?= "6.12.92"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "c4ffbe29c40ed851601bce640d5ead48eaaae08d"
+SRCREV_machine ?= "26deb9f9c427c0382f855546d23dba76c49e680c"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.90"
+LINUX_VERSION ?= "6.12.91"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "2538fbeff8a94ee2b54eb09d92209e24a1e650d4"
+SRCREV_machine ?= "c4ffbe29c40ed851601bce640d5ead48eaaae08d"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12


### PR DESCRIPTION
Update linux 6.12 to 6.6.92.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.92
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.91