### PR TITLE
linux-yocto-onl: notify about nexthop and route deletion

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/cfg/0001-net-ipv4-notify-about-nexthop-and-route-deletion.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/cfg/0001-net-ipv4-notify-about-nexthop-and-route-deletion.patch
@@ -1,0 +1,79 @@
+From ae9a5acef3156cc7abb8689bc09542a812ac9188 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 23 Jun 2026 10:13:08 +0200
+Subject: [PATCH] net: ipv4: notify about nexthop and route deletion
+
+When an interface goes down, and has associated nexthop objects, the
+kernel will silently remove all nexthop objects without notifying
+userspace. If there are any routes via these nexthop objects, they will
+be silently deleted as well.
+
+This is an issue for baseboxd / libnl trying to keep track of all
+routes, as route deletions will not be noticed.
+
+Work around this by making the kernel send out notifications in these
+cases.
+
+Upstream-Status: Inappropriate
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ net/ipv4/fib_trie.c | 6 +++---
+ net/ipv4/nexthop.c  | 8 +++++---
+ 2 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/net/ipv4/fib_trie.c b/net/ipv4/fib_trie.c
+index ee47b67a0870..3e06689509d4 100644
+--- a/net/ipv4/fib_trie.c
++++ b/net/ipv4/fib_trie.c
+@@ -2070,9 +2070,9 @@ int fib_table_flush(struct net *net, struct fib_table *tb, bool flush_all)
+ 
+ 			fib_notify_alias_delete(net, n->key, &n->leaf, fa,
+ 						NULL);
+-			if (fi->pfsrc_removed)
+-				rtmsg_fib(RTM_DELROUTE, htonl(n->key), fa,
+-					  KEYLENGTH - fa->fa_slen, tb->tb_id, &info, 0);
++
++			rtmsg_fib(RTM_DELROUTE, htonl(n->key), fa,
++				  KEYLENGTH - fa->fa_slen, tb->tb_id, &info, 0);
+ 			hlist_del_rcu(&fa->fa_list);
+ 			fib_release_info(fa->fa_info);
+ 			alias_free_mem_rcu(fa);
+diff --git a/net/ipv4/nexthop.c b/net/ipv4/nexthop.c
+index 52d4890be83e..57e9363868c6 100644
+--- a/net/ipv4/nexthop.c
++++ b/net/ipv4/nexthop.c
+@@ -2180,10 +2180,9 @@ static void remove_nexthop(struct net *net, struct nexthop *nh,
+ 	/* remove from the tree */
+ 	rb_erase(&nh->rb_node, &net->nexthop.rb_root);
+ 
++	__remove_nexthop(net, nh, nlinfo);
+ 	if (nlinfo)
+ 		nexthop_notify(RTM_DELNEXTHOP, nh, nlinfo);
+-
+-	__remove_nexthop(net, nh, nlinfo);
+ 	nh_base_seq_inc(net);
+ 
+ 	nexthop_put(nh);
+@@ -2677,6 +2676,9 @@ static void nexthop_flush_dev(struct net_device *dev, unsigned long event)
+ 	struct hlist_head *head = &net->nexthop.devhash[hash];
+ 	struct hlist_node *n;
+ 	struct nh_info *nhi;
++	struct nl_info nlinfo = {
++		.nl_net = dev_net(dev),
++	};
+ 
+ 	hlist_for_each_entry_safe(nhi, n, head, dev_hash) {
+ 		if (nhi->fib_nhc.nhc_dev != dev)
+@@ -2686,7 +2688,7 @@ static void nexthop_flush_dev(struct net_device *dev, unsigned long event)
+ 		    (event == NETDEV_DOWN || event == NETDEV_CHANGE))
+ 			continue;
+ 
+-		remove_nexthop(net, nhi->nh_parent, NULL);
++		remove_nexthop(net, nhi->nh_parent, &nlinfo);
+ 	}
+ }
+ 
+-- 
+2.54.0
+

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/cfg/bisdn-linux.scc
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/cfg/bisdn-linux.scc
@@ -4,6 +4,7 @@ patch 0001-net-rtnetlink-send-BONDING_INFO-events-down-to-users.patch
 patch 0001-net-ipv6-apply-IFLA_INET6_ADDR_GEN_MODE-immediately.patch
 patch 0001-tun-allow-setting-hwaddr-on-tap-interface-creation.patch
 patch 0001-net-bridge-ensure-that-link-local-traffic-cannot-unl.patch
+patch 0001-net-ipv4-notify-about-nexthop-and-route-deletion.patch
 
 # https://git.yoctoproject.org/yocto-kernel-cache/tree/
 include features/bpf/bpf.scc


### PR DESCRIPTION
When an interface goes down, and has associated nexthop objects, the kernel will silently remove all nexthop objects without notifying userspace. If there are any routes via these nexthop objects, they will be silently deleted as well.

This is an issue for baseboxd / libnl trying to keep track of all routes, as route deletions will not be noticed.

Work around this by making the kernel send out notifications in these cases.