### PR TITLE
v5.x: linux-yocto-onl: armel-iproc: implement i2c bus recovery

### DIFF
--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/09-02-i2c-iproc-also-clear-the-bus-on-transfer-timeouts.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/09-02-i2c-iproc-also-clear-the-bus-on-transfer-timeouts.patch
@@ -1,0 +1,170 @@
+From a7ca1393a04b5f956275925f49b321a429feb6d3 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 30 Jun 2026 12:45:07 +0200
+Subject: [PATCH] i2c: iproc: also clear the bus on transfer timeouts
+
+Just resetting the controller is not always enough to recover from a
+timed out transfer, and the bus needs to be cleared as well.
+
+So add support for generic scl recovery by switching to bit-banged mode
+for manual control of scl and sda signals, and using it when sda is
+still low after a timeout.
+
+Regardless of clearing sda, the controller might still need to be
+reset as well.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ drivers/i2c/busses/i2c-bcm-iproc.c | 101 +++++++++++++++++++++++++++++
+ 1 file changed, 101 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-bcm-iproc.c b/drivers/i2c/busses/i2c-bcm-iproc.c
+index dd3006f1598d..580412e899b8 100644
+--- a/drivers/i2c/busses/i2c-bcm-iproc.c
++++ b/drivers/i2c/busses/i2c-bcm-iproc.c
+@@ -15,6 +15,7 @@
+ #define CFG_OFFSET                   0x00
+ #define CFG_RESET_SHIFT              31
+ #define CFG_EN_SHIFT                 30
++#define CFG_BITBANG_EN_SHIFT         29
+ #define CFG_SLAVE_ADDR_0_SHIFT       28
+ #define CFG_M_RETRY_CNT_SHIFT        16
+ #define CFG_M_RETRY_CNT_MASK         0x0f
+@@ -56,6 +57,12 @@
+ #define S_FIFO_RX_THLD_SHIFT         8
+ #define S_FIFO_RX_THLD_MASK          0x3f
+ 
++#define BITBANG_CTRL_OFFSET		0x14
++#define BITBANG_CLK_IN_SHIFT		31
++#define BITBANG_CLK_OUT_EN_SHIFT	30
++#define BITBANG_DATA_IN_SHIFT		29
++#define BITBANG_DATA_OUT_EN_SHIFT	28
++
+ #define M_CMD_OFFSET                 0x30
+ #define M_CMD_START_BUSY_SHIFT       31
+ #define M_CMD_STATUS_SHIFT           25
+@@ -706,6 +713,86 @@ static void bcm_iproc_i2c_enable_disable(struct bcm_iproc_i2c_dev *iproc_i2c,
+ 	iproc_i2c_wr_reg(iproc_i2c, CFG_OFFSET, val);
+ }
+ 
++static void bcm_iproc_i2c_prepare_recovery(struct i2c_adapter *adapter)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	/* enable bit-bang mode to allow manually driving sda/scl */
++	val = iproc_i2c_rd_reg(iproc_i2c, CFG_OFFSET);
++	val |= BIT(CFG_BITBANG_EN_SHIFT);
++	iproc_i2c_wr_reg(iproc_i2c, CFG_OFFSET, val);
++	udelay(50);
++}
++
++static void bcm_iproc_i2c_unprepare_recovery(struct i2c_adapter *adapter)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	/* disable bit-bang mode again */
++	val = iproc_i2c_rd_reg(iproc_i2c, CFG_OFFSET);
++	val &= ~BIT(CFG_BITBANG_EN_SHIFT);
++	iproc_i2c_wr_reg(iproc_i2c, CFG_OFFSET, val);
++	udelay(10);
++}
++
++static int bcm_iproc_i2c_get_bus_free(struct i2c_adapter *adapter)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	val = iproc_i2c_rd_reg(iproc_i2c, M_CMD_OFFSET);
++
++	return !!(val & BIT(M_CMD_START_BUSY_SHIFT));
++}
++
++static int bcm_iproc_i2c_get_scl(struct i2c_adapter *adapter)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	val = iproc_i2c_rd_reg(iproc_i2c, BITBANG_CTRL_OFFSET);
++
++	return !!(val & BIT(BITBANG_CLK_IN_SHIFT));
++}
++
++static void bcm_iproc_i2c_set_scl(struct i2c_adapter *adapter, int scl)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	val = iproc_i2c_rd_reg(iproc_i2c, BITBANG_CTRL_OFFSET);
++	if (scl)
++		val |= BIT(BITBANG_CLK_OUT_EN_SHIFT);
++	else
++		val &= ~BIT(BITBANG_CLK_OUT_EN_SHIFT);
++	iproc_i2c_wr_reg(iproc_i2c, BITBANG_CTRL_OFFSET, val);
++}
++
++static int bcm_iproc_i2c_get_sda(struct i2c_adapter *adapter)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	val = iproc_i2c_rd_reg(iproc_i2c, BITBANG_CTRL_OFFSET);
++
++	return !!(val & BIT(BITBANG_DATA_IN_SHIFT));
++}
++
++static void bcm_iproc_i2c_set_sda(struct i2c_adapter *adapter, int sda)
++{
++	struct bcm_iproc_i2c_dev *iproc_i2c = i2c_get_adapdata(adapter);
++	u32 val;
++
++	val = iproc_i2c_rd_reg(iproc_i2c, BITBANG_CTRL_OFFSET);
++	if (sda)
++		val |= BIT(BITBANG_DATA_OUT_EN_SHIFT);
++	else
++		val &= ~BIT(BITBANG_DATA_OUT_EN_SHIFT);
++	iproc_i2c_wr_reg(iproc_i2c, BITBANG_CTRL_OFFSET, val);
++}
++
+ static int bcm_iproc_i2c_check_status(struct bcm_iproc_i2c_dev *iproc_i2c,
+ 				      struct i2c_msg *msg)
+ {
+@@ -796,6 +883,9 @@ static int bcm_iproc_i2c_xfer_wait(struct bcm_iproc_i2c_dev *iproc_i2c,
+ 	if (!time_left && !iproc_i2c->xfer_is_done) {
+ 		dev_err(iproc_i2c->device, "transaction timed out\n");
+ 
++		if (bcm_iproc_i2c_get_sda(&iproc_i2c->adapter) == 0)
++			i2c_generic_scl_recovery(&iproc_i2c->adapter);
++
+ 		if (!!(iproc_i2c_rd_reg(iproc_i2c,
+ 				M_CMD_OFFSET) & BIT(M_CMD_START_BUSY_SHIFT))) {
+ 			/* re-initialize i2c for recovery */
+@@ -997,6 +1087,16 @@ static const struct i2c_adapter_quirks bcm_iproc_i2c_quirks = {
+ 	.max_read_len = M_RX_MAX_READ_LEN,
+ };
+ 
++static struct i2c_bus_recovery_info bcm_iproc_i2c_recovery_info = {
++	.recover_bus = i2c_generic_scl_recovery,
++	.get_scl = bcm_iproc_i2c_get_scl,
++	.set_scl = bcm_iproc_i2c_set_scl,
++	.get_sda = bcm_iproc_i2c_get_sda,
++	.set_sda = bcm_iproc_i2c_set_sda,
++	.prepare_recovery = bcm_iproc_i2c_prepare_recovery,
++	.unprepare_recovery = bcm_iproc_i2c_unprepare_recovery,
++};
++
+ static int bcm_iproc_i2c_cfg_speed(struct bcm_iproc_i2c_dev *iproc_i2c)
+ {
+ 	unsigned int bus_speed;
+@@ -1108,6 +1208,7 @@ static int bcm_iproc_i2c_probe(struct platform_device *pdev)
+ 		of_node_full_name(iproc_i2c->device->of_node));
+ 	adap->algo = &bcm_iproc_algo;
+ 	adap->quirks = &bcm_iproc_i2c_quirks;
++	adap->bus_recovery_info = &bcm_iproc_i2c_recovery_info;
+ 	adap->dev.parent = &pdev->dev;
+ 	adap->dev.of_node = pdev->dev.of_node;
+ 
+-- 
+2.55.0
+

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/armel-iproc.scc
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/armel-iproc.scc
@@ -5,6 +5,7 @@ define KARCH arm
 # submitted upstream
 
 patch 09-01-i2c-iproc-reset-bus-after-timeout-if-START_BUSY-is-s.patch
+patch 09-02-i2c-iproc-also-clear-the-bus-on-transfer-timeouts.patch
 
 # platform support
 


### PR DESCRIPTION
Just resetting the controller is not always enough to recover from a timed out transfer, and the bus needs to be cleared as well.

So add support for generic scl recovery by switching to bit-banged mode for manual control of scl and sda signals, and using it when sda is still low after a timeout.

Regardless of clearing sda, the controller might still need to be reset as well.


(cherry picked from commit 66b39b890a9a17a8d05525ace1904affa182c7dd)