### PR TITLE
onl: allow reading uppoer pages of QSFP EEPROMs

### DIFF
--- a/recipes-extended/onl/files/accton-as4610/0004-accton-as4610-implement-onlp_sfpi_eeprom_page_read.patch
+++ b/recipes-extended/onl/files/accton-as4610/0004-accton-as4610-implement-onlp_sfpi_eeprom_page_read.patch
@@ -1,0 +1,111 @@
+From 0bcb30b84c861de0bc8cacd3515903bbfc4086df Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 22 May 2026 15:33:48 +0200
+Subject: [PATCH] accton-as4610: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../arm_accton_as4610/module/src/sfpi.c       | 50 ++++++++++---------
+ 1 file changed, 26 insertions(+), 24 deletions(-)
+
+diff --git a/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/sfpi.c b/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/sfpi.c
+index de01502c7209..c80735e52ee3 100644
+--- a/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/sfpi.c
++++ b/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/sfpi.c
+@@ -203,8 +203,8 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-int
+-onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int
++as4610_eeprom_read(int port, int offset, int len uint8_t *data)
+ {
+     /*
+      * Read the SFP eeprom into data[]
+@@ -212,28 +212,12 @@ onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
++    char file[64] = {0};
+     int size = 0;
+-    memset(data, 0, 256);
+-
+-	if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, front_port_bus_index(port)) != ONLP_STATUS_OK) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
+-
+-    if (size != 256) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
++    FILE* fp;
+ 
+-    return ONLP_STATUS_OK;
+-}
++    memset(data, 0, 256);
+ 
+-int
+-onlp_sfpi_dom_read(int port, uint8_t data[256])
+-{
+-    FILE* fp;
+-    char file[64] = {0};
+-    
+     sprintf(file, PORT_EEPROM_FORMAT, front_port_bus_index(port));
+     fp = fopen(file, "r");
+     if(fp == NULL) {
+@@ -241,15 +225,15 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    if (fseek(fp, 256, SEEK_CUR) != 0) {
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
+         fclose(fp);
+         AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    int ret = fread(data, 1, 256, fp);
++    size = fread(data, 1, len, fp);
+     fclose(fp);
+-    if (ret != 256) {
++    if (size != len) {
+         AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+@@ -257,6 +241,24 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ONLP_STATUS_OK;
+ }
+ 
++int
++onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return as4610_eeprom_read(port, 0, 256, data);
++}
++
++int
++onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return as4610_eeprom_read(port, 256, 256, data);
++}
++
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return as4610_eeprom_read(port, (page + 1), 128, data);
++}
++
+ int
+ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
+ {
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/accton-as4630-54pe/0002-accton-a4630-54pe-implement-onlp_sfpi_eeprom_page_re.patch
+++ b/recipes-extended/onl/files/accton-as4630-54pe/0002-accton-a4630-54pe-implement-onlp_sfpi_eeprom_page_re.patch
@@ -1,0 +1,119 @@
+From 044020281793e6fad24a48a47403c1ec3d5d760e Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 13 Apr 2026 09:49:23 +0200
+Subject: [PATCH] accton-a4630-54pe: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../module/src/sfpi.c                         | 55 +++++++++----------
+ 1 file changed, 27 insertions(+), 28 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+index 805820594555..f688a675d67a 100755
+--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
++++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+@@ -138,8 +138,7 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-int
+-onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int as4630_54pe_eeprom_read(int port, int offset, int len, uint8_t *data)
+ {
+     /*
+      * Read the SFP eeprom into data[]
+@@ -147,35 +146,17 @@ onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
++    char file[64] = {0};
++    FILE* fp;
+     int size = 0;
+-    if(port <0 || port >= 54)
++
++    if(port < 0 || port >= 54)
+         return ONLP_STATUS_E_INTERNAL;
+     if(port < 48)
+         return ONLP_STATUS_E_UNSUPPORTED;
+-    
+-    memset(data, 0, 256);
+-
+-	if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port-48)) != ONLP_STATUS_OK) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
+ 
+-    if (size != 256) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
+-
+-    return ONLP_STATUS_OK;
+-}
++    memset(data, 0, len);
+ 
+-int
+-onlp_sfpi_dom_read(int port, uint8_t data[256])
+-{
+-    FILE* fp;
+-    char file[64] = {0};
+-    
+-    if(port < 48)
+-        return ONLP_STATUS_E_UNSUPPORTED;
+     sprintf(file, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port-48));
+     fp = fopen(file, "r");
+     if(fp == NULL) {
+@@ -183,15 +164,15 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    if (fseek(fp, 256, SEEK_CUR) != 0) {
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
+         fclose(fp);
+         AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    int ret = fread(data, 1, 256, fp);
++    size = fread(data, 1, len, fp);
+     fclose(fp);
+-    if (ret != 256) {
++    if (size != len) {
+         AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+@@ -199,6 +180,24 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ONLP_STATUS_OK;
+ }
+ 
++int
++onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return as4630_54pe_eeprom_read(port, 0, 256, data);
++}
++
++int
++onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return as4630_54pe_eeprom_read(port, 256, 256, data);
++}
++
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return as4630_54pe_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int
+ onlp_sfpi_dev_readb(int port, uint8_t devaddr, uint8_t addr)
+ {
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/accton-as4630-54te/0002-accton-a4630-54te-implement-onlp_sfpi_eeprom_page_re.patch
+++ b/recipes-extended/onl/files/accton-as4630-54te/0002-accton-a4630-54te-implement-onlp_sfpi_eeprom_page_re.patch
@@ -1,0 +1,114 @@
+From 92f05bbe2e8b955dca47ebe8acf1be34546d86ac Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 22 May 2026 13:00:46 +0200
+Subject: [PATCH] accton-a4630-54te: implement  onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../module/src/sfpi.c                         | 53 +++++++++----------
+ 1 file changed, 25 insertions(+), 28 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+index afe966704286..a0a7b7b50cca 100644
+--- a/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
++++ b/packages/platforms/accton/x86-64/as4630-54te/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+@@ -195,8 +195,7 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-int
+-onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int as4630_54te_eeprom_read(int port, int offset, int len, uint8_t *data)
+ {
+     /*
+      * Read the SFP eeprom into data[]
+@@ -204,33 +203,14 @@ onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
++    char file[64] = {0};
+     int size = 0;
+-    VALIDATE(port);
+-
+-    memset(data, 0, 256);
+-
+-    if (onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT,
+-                       PORT_BUS_INDEX(port)) != ONLP_STATUS_OK) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
++    FILE* fp;
+ 
+-    if (size != 256) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
++    VALIDATE(port);
+ 
+-    return ONLP_STATUS_OK;
+-}
++    memset(data, 0, len);
+ 
+-int
+-onlp_sfpi_dom_read(int port, uint8_t data[256])
+-{
+-    FILE* fp;
+-    char file[64] = {0};
+-
+-    if(port < 48)
+-        return ONLP_STATUS_E_UNSUPPORTED;
+     sprintf(file, PORT_EEPROM_FORMAT, PORT_BUS_INDEX(port));
+     fp = fopen(file, "r");
+     if(fp == NULL) {
+@@ -238,21 +218,38 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    if (fseek(fp, 256, SEEK_CUR) != 0) {
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
+         fclose(fp);
+         AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    int ret = fread(data, 1, 256, fp);
++    size = fread(data, 1, len, fp);
+     fclose(fp);
+-    if (ret != 256) {
++    if (size != len) {
+         AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+     return ONLP_STATUS_OK;
+ }
++int
++onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return as4630_54te_eeprom_read(port, 0, 256, data);
++}
++
++int
++onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return as4630_54te_eeprom_read(port, 256, 256, data);
++}
++
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return as4630_54te_eeprom_read(port, (page + 1) * 128, 128, data);
++}
+ 
+ int
+ onlp_sfpi_dev_readb(int port, uint8_t devaddr, uint8_t addr)
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/accton-as5835-54x/0003-accton-as5835-54x-implement-onlp_sfpi_eeprom_page_re.patch
+++ b/recipes-extended/onl/files/accton-as5835-54x/0003-accton-as5835-54x-implement-onlp_sfpi_eeprom_page_re.patch
@@ -1,0 +1,110 @@
+From 46549c827cb41f7e43ac76fd5792277290241b7e Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 22 May 2026 13:02:52 +0200
+Subject: [PATCH] accton-as5835-54x: implement  onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../module/src/sfpi.c                         | 49 ++++++++++---------
+ 1 file changed, 25 insertions(+), 24 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/sfpi.c b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/sfpi.c
+index 8053f9f8db84..a79ade03f0bd 100644
+--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/sfpi.c
++++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/sfpi.c
+@@ -237,8 +237,7 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-int
+-onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int as5835_54x_eeprom_read(int port, int offset, int len, uint8_t *data)
+ {
+     /*
+      * Read the SFP eeprom into data[]
+@@ -246,28 +245,12 @@ onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
++    char file[64] = {0};
+     int size = 0;
+-    memset(data, 0, 256);
+-
+-	if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, PORT_BUS_INDEX(port)) != ONLP_STATUS_OK) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
+-
+-    if (size != 256) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
++    FILE* fp;
+ 
+-    return ONLP_STATUS_OK;
+-}
++    memset(data, 0, len);
+ 
+-int
+-onlp_sfpi_dom_read(int port, uint8_t data[256])
+-{
+-    FILE* fp;
+-    char file[64] = {0};
+-    
+     sprintf(file, PORT_EEPROM_FORMAT, PORT_BUS_INDEX(port));
+     fp = fopen(file, "r");
+     if(fp == NULL) {
+@@ -275,15 +258,15 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    if (fseek(fp, 256, SEEK_CUR) != 0) {
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
+         fclose(fp);
+         AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    int ret = fread(data, 1, 256, fp);
++    size = fread(data, 1, len, fp);
+     fclose(fp);
+-    if (ret != 256) {
++    if (size != len) {
+         AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+@@ -291,6 +274,24 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ONLP_STATUS_OK;
+ }
+ 
++int
++onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return as5835_54x_eeprom_read(port, 0, 256, data);
++}
++
++int
++onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return as5835_54x_eeprom_read(port, 256, 256, data);
++}
++
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return as5835_54x_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int
+ onlp_sfpi_dev_readb(int port, uint8_t devaddr, uint8_t addr)
+ {
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/accton-as7726-32x/0001-accton-as7726-32x-implement-onlp_sfpi_eeprom_page_re.patch
+++ b/recipes-extended/onl/files/accton-as7726-32x/0001-accton-as7726-32x-implement-onlp_sfpi_eeprom_page_re.patch
@@ -1,0 +1,113 @@
+From f3d66271569adb085903336974e0822330836437 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 22 May 2026 15:33:35 +0200
+Subject: [PATCH] accton-as7726-32x: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../module/src/sfpi.c                         | 51 ++++++++++---------
+ 1 file changed, 27 insertions(+), 24 deletions(-)
+
+diff --git a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
+index 45909907e68d..6f40d0f2045f 100755
+--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
++++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
+@@ -189,8 +189,8 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-int
+-onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int
++as7726_32x_eeprom_read(int port, int offset, int len, uint8_t *data)
+ {
+     /*
+      * Read the SFP eeprom into data[]
+@@ -198,29 +198,14 @@ onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
++    char file[64] = {0};
+     int size = 0;
+-    if(port <0 || port > 34)
+-        return ONLP_STATUS_E_INTERNAL;
+-    memset(data, 0, 256);
+-
+-	if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port)) != ONLP_STATUS_OK) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+-        return ONLP_STATUS_E_INTERNAL;
+-    }
++    FILE* fp;
+ 
+-    if (size != 256) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
++    if(port < 0 || port > 34)
+         return ONLP_STATUS_E_INTERNAL;
+-    }
+-
+-    return ONLP_STATUS_OK;
+-}
+ 
+-int
+-onlp_sfpi_dom_read(int port, uint8_t data[256])
+-{
+-    FILE* fp;
+-    char file[64] = {0};
++    memset(data, 0, len);
+ 
+     sprintf(file, PORT_EEPROM_FORMAT, onlp_sfpi_map_bus_index(port));
+     fp = fopen(file, "r");
+@@ -229,15 +214,15 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    if (fseek(fp, 256, SEEK_CUR) != 0) {
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
+         fclose(fp);
+         AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+-    int ret = fread(data, 1, 256, fp);
++    size = fread(data, 1, len, fp);
+     fclose(fp);
+-    if (ret != 256) {
++    if (size != len) {
+         AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+@@ -245,6 +230,24 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ONLP_STATUS_OK;
+ }
+ 
++int
++onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return as7726_32x_eeprom_read(port, 0, 256, data);
++}
++
++int
++onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return as7726_32x_eeprom_read(port, 256, 256, data);
++}
++
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return as7726_32x_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int
+ onlp_sfpi_dev_readb(int port, uint8_t devaddr, uint8_t addr)
+ {
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/cel-questone-2a/0011-cel-questone-2a-implement-reading-DOM-EEPROM.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0011-cel-questone-2a-implement-reading-DOM-EEPROM.patch
@@ -1,0 +1,86 @@
+From 9c585f197df7cd1965fd7abaf75bea0dfddaa73c Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 28 May 2026 15:14:36 +0200
+Subject: [PATCH] cel-questone-2a: implement reading DOM EEPROM
+
+Implement reading DOM EEPROM, which is exposed by the optoe driver as
+bytes 256 - 511 of the eeprom.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../x86_64_cel_questone_2a/module/src/sfpi.c  | 42 +++++++++++++++----
+ 1 file changed, 34 insertions(+), 8 deletions(-)
+
+diff --git a/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c b/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
+index b54ada96ce8e..de2008bc6e2e 100644
+--- a/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
++++ b/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
+@@ -161,13 +161,10 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t *dst)
+     return ONLP_STATUS_OK;
+ }
+ 
+-/*
+- * This function reads the SFPs idrom and returns in
+- * in the data buffer provided.
+- */
+-int onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++static int questone_2a_eeprom_read(int port, int offset, int len, uint8_t *data)
+ {
+     char *path;
++    FILE *fp;
+ 
+     path = cel_questone_2a_sfp_qsfp_get_eeprom_path(port + 1, "eeprom");
+ 
+@@ -177,15 +174,44 @@ int onlp_sfpi_eeprom_read(int port, uint8_t data[256])
+      * Return MISSING if SFP is missing.
+      * Return OK if eeprom is read
+      */
+-    memset(data, 0, 256);
+-    if (read_device_node_binary(path, (char*)data, 256, 256) != 0) {
+-        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
++    memset(data, 0, len);
++
++    fp = fopen(path, "r");
++    if(fp == NULL) {
++        AIM_LOG_ERROR("Unable to open the eeprom device file of port(%d)", port);
++        return ONLP_STATUS_E_INTERNAL;
++    }
++
++    if (fseek(fp, offset, SEEK_CUR) != 0) {
++        fclose(fp);
++        AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
++        return ONLP_STATUS_E_INTERNAL;
++    }
++
++    int ret = fread(data, 1, len, fp);
++    fclose(fp);
++    if (ret != len) {
++        AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d)", port);
+         return ONLP_STATUS_E_INTERNAL;
+     }
+ 
+     return ONLP_STATUS_OK;
+ }
+ 
++/*
++ * This function reads the SFPs idrom and returns in
++ * in the data buffer provided.
++ */
++int onlp_sfpi_eeprom_read(int port, uint8_t data[256])
++{
++    return questone_2a_eeprom_read(port, 0, 256, data);
++}
++
++int onlp_sfpi_dom_read(int port, uint8_t data[256])
++{
++    return questone_2a_eeprom_read(port, 256, 256, data);
++}
++
+ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t *dst)
+ {
+     return ONLP_STATUS_OK;
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/cel-questone-2a/0012-cel-questone-2a-implement-onlp_sfpi_eeprom_page_read.patch
+++ b/recipes-extended/onl/files/cel-questone-2a/0012-cel-questone-2a-implement-onlp_sfpi_eeprom_page_read.patch
@@ -1,0 +1,36 @@
+From 7f3055343302be4448ce527c1e260aaff27c971e Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 28 May 2026 15:21:38 +0200
+Subject: [PATCH] cel-questone-2a: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c     | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c b/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
+index de2008bc6e2e..58668b2e382b 100644
+--- a/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
++++ b/packages/platforms/celestica/x86-64/questone-2a/onlp/builds/x86_64_cel_questone_2a/module/src/sfpi.c
+@@ -212,6 +212,11 @@ int onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return questone_2a_eeprom_read(port, 256, 256, data);
+ }
+ 
++int onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return questone_2a_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t *dst)
+ {
+     return ONLP_STATUS_OK;
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/delta-ag5648/0006-delta-ag5648-implement-onlp_sfpi_eeprom_page_read.patch
+++ b/recipes-extended/onl/files/delta-ag5648/0006-delta-ag5648-implement-onlp_sfpi_eeprom_page_read.patch
@@ -1,0 +1,37 @@
+From 7441fafa1330fb33460e9a8db94c20af1d15496a Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Thu, 28 May 2026 11:08:02 +0200
+Subject: [PATCH] delta-ag5648: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../onlp/builds/x86_64_delta_ag5648/module/src/sfpi.c       | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/packages/platforms/delta/x86-64/ag5648/onlp/builds/x86_64_delta_ag5648/module/src/sfpi.c b/packages/platforms/delta/x86-64/ag5648/onlp/builds/x86_64_delta_ag5648/module/src/sfpi.c
+index 76ec8ae9695a..78adf46e1c9b 100755
+--- a/packages/platforms/delta/x86-64/ag5648/onlp/builds/x86_64_delta_ag5648/module/src/sfpi.c
++++ b/packages/platforms/delta/x86-64/ag5648/onlp/builds/x86_64_delta_ag5648/module/src/sfpi.c
+@@ -224,6 +224,12 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ag5648_eeprom_read(port, 256, 256, data);
+ }
+ 
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return ag5648_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int onlp_sfpi_port_map(int port, int* rport)
+ {
+     *rport = port;
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/delta-ag7648/0018-delta-ag7648-implement-onlp_sfpi_eeprom_page_read.patch
+++ b/recipes-extended/onl/files/delta-ag7648/0018-delta-ag7648-implement-onlp_sfpi_eeprom_page_read.patch
@@ -1,0 +1,37 @@
+From d1901b84df32f2b445d333a52963e960ff2008b4 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 22 May 2026 15:58:01 +0200
+Subject: [PATCH] delta-ag7648: implement onlp_sfpi_eeprom_page_read()
+
+The optoe driver exposes QSFP pages via offsets, with offset 0 the lower
+page, offset 128 page 0, offset 256 page 1 etc.
+
+So implement reading pages by reading from appropriate offsets.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../onlp/builds/x86_64_delta_ag7648/module/src/sfpi.c       | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/packages/platforms/delta/x86-64/ag7648/onlp/builds/x86_64_delta_ag7648/module/src/sfpi.c b/packages/platforms/delta/x86-64/ag7648/onlp/builds/x86_64_delta_ag7648/module/src/sfpi.c
+index f23f244ac99c..9ff832ca4c84 100755
+--- a/packages/platforms/delta/x86-64/ag7648/onlp/builds/x86_64_delta_ag7648/module/src/sfpi.c
++++ b/packages/platforms/delta/x86-64/ag7648/onlp/builds/x86_64_delta_ag7648/module/src/sfpi.c
+@@ -366,6 +366,12 @@ onlp_sfpi_dom_read(int port, uint8_t data[256])
+     return ag7648_eeprom_read(port, 256, 256, data);
+ }
+ 
++int
++onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128])
++{
++    return ag7648_eeprom_read(port, (page + 1) * 128, 128, data);
++}
++
+ int
+ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
+ {
+-- 
+2.54.0
+

--- a/recipes-extended/onl/files/onl/0023-onlp-add-sfp-eeprom-page-read-operation.patch
+++ b/recipes-extended/onl/files/onl/0023-onlp-add-sfp-eeprom-page-read-operation.patch
@@ -1,0 +1,117 @@
+From 10ed9f1b85896909d5b27ed828672fa779a26f53 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 13 Apr 2026 09:43:26 +0200
+Subject: [PATCH] onlp: add sfp eeprom page read operation
+
+In order to access the QSFP diagnostics page 3, add a read operation for
+accessing arbitrary pages.
+
+Upstream-Status: Inactive-Upstream [lastcommit: 2024-09-21]
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ .../src/onlp/module/inc/onlp/platformi/sfpi.h   |  7 +++++++
+ .../any/onlp/src/onlp/module/inc/onlp/sfp.h     | 12 ++++++++++++
+ .../onlp/module/python/onlp/onlp/__init__.py    |  3 +++
+ .../base/any/onlp/src/onlp/module/src/sfp.c     | 17 +++++++++++++++++
+ .../onlp_platform_defaults/module/src/sfpi.c    |  1 +
+ 5 files changed, 40 insertions(+)
+
+diff --git a/packages/base/any/onlp/src/onlp/module/inc/onlp/platformi/sfpi.h b/packages/base/any/onlp/src/onlp/module/inc/onlp/platformi/sfpi.h
+index cc2bfcac6b27..f0fd9fc2f8b9 100644
+--- a/packages/base/any/onlp/src/onlp/module/inc/onlp/platformi/sfpi.h
++++ b/packages/base/any/onlp/src/onlp/module/inc/onlp/platformi/sfpi.h
+@@ -118,6 +118,13 @@ int onlp_sfpi_dev_write(int port, uint8_t devaddr, uint8_t addr, uint8_t* data,
+  * @param data Receives the SFP data.
+  */
+ int onlp_sfpi_dom_read(int port, uint8_t data[256]);
++/**
++ * @brief Read the SFP EEPROM page.
++ * @param port The port number.
++ * @param page The page number.
++ * @param data Receives the SFP data.
++ */
++int onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128]);
+ 
+ /**
+  * @brief Perform any actions required after an SFP is inserted.
+diff --git a/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h b/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h
+index 1652cad22702..36de67e7045b 100644
+--- a/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h
++++ b/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h
+@@ -132,6 +132,18 @@ int onlp_sfp_eeprom_read(int port, uint8_t** rv);
+  * has advertised DOM support.
+  */
+ int onlp_sfp_dom_read(int port, uint8_t** rv);
++/**
++ * @brief Read an upper page from the given port.
++ * @param port The SFP Port
++ * @param page The page
++ * @param rv Receives a buffer containing the EEPROM data.
++ * @notes The buffer must be freed after use.
++ * @returns The size of the eeprom data, if successful
++ * @returns -1 on error.
++ * @note This should only be called if the SFP
++ * has advertised pages support.
++ */
++int onlp_sfp_eeprom_read_page(int port, uint8_t page, uint8_t** rv);
+ 
+ /**
+  * @brief Deinitialize the SFP subsystem.
+diff --git a/packages/base/any/onlp/src/onlp/module/python/onlp/onlp/__init__.py b/packages/base/any/onlp/src/onlp/module/python/onlp/onlp/__init__.py
+index d32ce721cdc8..611d43d038f2 100644
+--- a/packages/base/any/onlp/src/onlp/module/python/onlp/onlp/__init__.py
++++ b/packages/base/any/onlp/src/onlp/module/python/onlp/onlp/__init__.py
+@@ -602,6 +602,9 @@ def onlp_sfp_init_prototypes():
+     libonlp.onlp_sfp_dom_read.restype = ctypes.c_int
+     libonlp.onlp_sfp_dom_read.argtypes = (ctypes.c_int, ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte)),)
+ 
++    libonlp.onlp_sfp_eeprom_read_page.restype = ctypes.c_int
++    libonlp.onlp_sfp_eeprom_read_page.argtypes = (ctypes.c_int,, ctypes.c_ubyte, ctypes.POINTER(ctypes.POINTER(ctypes.c_ubyte,)),)
++
+     libonlp.onlp_sfp_denit.restype = ctypes.c_int
+ 
+     libonlp.onlp_sfp_rx_los_bitmap_get.restype = ctypes.c_int
+diff --git a/packages/base/any/onlp/src/onlp/module/src/sfp.c b/packages/base/any/onlp/src/onlp/module/src/sfp.c
+index 8dc75d8c9a8d..52b16ccd634c 100644
+--- a/packages/base/any/onlp/src/onlp/module/src/sfp.c
++++ b/packages/base/any/onlp/src/onlp/module/src/sfp.c
+@@ -173,6 +173,23 @@ onlp_sfp_dom_read_locked__(int port, uint8_t** datap)
+ }
+ ONLP_LOCKED_API2(onlp_sfp_dom_read, int, port, uint8_t**, rv);
+ 
++static int
++onlp_sfp_eeprom_read_page_locked__(int port, uint8_t page, uint8_t** datap)
++{
++    int rv;
++    uint8_t* data;
++    ONLP_SFP_PORT_VALIDATE_AND_MAP(port);
++
++    data = aim_zmalloc(128);
++    if((rv = onlp_sfpi_eeprom_read_page(port, page, data)) < 0) {
++        aim_free(data);
++        data = NULL;
++    }
++    *datap = data;
++    return rv;
++}
++ONLP_LOCKED_API3(onlp_sfp_eeprom_read_page, int, port, uint8_t, page, uint8_t**, rv);
++
+ void
+ onlp_sfp_dump(aim_pvs_t* pvs)
+ {
+diff --git a/packages/base/any/onlp/src/onlp_platform_defaults/module/src/sfpi.c b/packages/base/any/onlp/src/onlp_platform_defaults/module/src/sfpi.c
+index ecb0ee6d87dc..8feed1af7d52 100644
+--- a/packages/base/any/onlp/src/onlp_platform_defaults/module/src/sfpi.c
++++ b/packages/base/any/onlp/src/onlp_platform_defaults/module/src/sfpi.c
+@@ -32,6 +32,7 @@ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t*
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst));
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_eeprom_read(int port, uint8_t data[256]));
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_dom_read(int port, uint8_t data[256]));
++__ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_eeprom_read_page(int port, uint8_t page, uint8_t data[128]));
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_post_insert(int port, sff_info_t* sff_info));
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_port_map(int port, int* rport));
+ __ONLP_DEFAULTI_IMPLEMENTATION(onlp_sfpi_denit(void));
+-- 
+2.54.0
+

--- a/recipes-extended/onl/onl_git.bb
+++ b/recipes-extended/onl/onl_git.bb
@@ -37,6 +37,7 @@ SRC_URI += " \
            file://onl/0020-modules-update-platform_drivers-with-6.11-compatibil.patch \
            file://onl/0021-packages-switch-to-external-cjson-library.patch \
            file://onl/0022-modules-don-t-use-legacy-paths-for-accessing-EEPROM.patch \
+           file://onl/0023-onlp-add-sfp-eeprom-page-read-operation.patch \
            file://bigcode/0001-WIP-convert-to-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0002-dynamically-determine-location-of-python3.patch;patchdir=${SUBMODULE_BIGCODE} \
            file://bigcode/0003-avoid-multiple-global-definitions-for-not_empty.patch;patchdir=${SUBMODULE_BIGCODE} \
@@ -51,10 +52,15 @@ SRC_URI += " \
            file://accton-as4610/0001-accton-as4610-do-not-enable-v_out-i_out-p_out-caps.patch \
            file://accton-as4610/0002-accton_as4610_cpld-add-of-device-match-table.patch \
            file://accton-as4610/0003-accton_as4610_psu-add-of-device-match-table.patch \
+           file://accton-as4610/0004-accton-as4610-implement-onlp_sfpi_eeprom_page_read.patch \
            file://accton-as4630-54pe/0001-accton-as4630-54pe-Avoid-undefined-behaviour.patch \
+           file://accton-as4630-54pe/0002-accton-a4630-54pe-implement-onlp_sfpi_eeprom_page_re.patch \
            file://accton-as4630-54te/0001-accton-as4630-54te-do-not-acccess-PSU-via-pmbus.patch \
+           file://accton-as4630-54te/0002-accton-a4630-54te-implement-onlp_sfpi_eeprom_page_re.patch \
            file://accton-as5835-54x/0001-Support-psu_fan_dir-sysfs-for-YM-1401A-PSU.patch \
            file://accton-as5835-54x/0002-as5835-rename-psu_serial_numer-psu_serial_number.patch \
+           file://accton-as5835-54x/0003-accton-as5835-54x-implement-onlp_sfpi_eeprom_page_re.patch \
+           file://accton-as7726-32x/0001-accton-as7726-32x-implement-onlp_sfpi_eeprom_page_re.patch \
            file://cel-questone-2a/0001-add-celestica-questone-2a.patch \
            file://cel-questone-2a/0002-questone-2a-fix-ignoring-unused-result-warnings.patch \
            file://cel-questone-2a/0003-cel-questone-2a-delete-unused-global-variables.patch \
@@ -65,11 +71,14 @@ SRC_URI += " \
            file://cel-questone-2a/0008-cel-questone-2a-update-class_create-usage-for-6.4.patch \
            file://cel-questone-2a/0009-cel-questone-2a-adapt-i2c-adapter-class-usage-for-6..patch \
            file://cel-questone-2a/0010-cel-questone-2a-update-platform_drivers-with-6.11-co.patch \
+           file://cel-questone-2a/0011-cel-questone-2a-implement-reading-DOM-EEPROM.patch \
+           file://cel-questone-2a/0012-cel-questone-2a-implement-onlp_sfpi_eeprom_page_read.patch \
            file://delta-ag5648/0001-delta-ag5648-avoid-multiple-definitions-of-mutex-mut.patch \
            file://delta-ag5648/0002-ag5648-update-modules-to-compile-and-work-on-recent-.patch \
            file://delta-ag5648/0003-delta-modules-update-i2c_mux_add_adapter-usage-for-6.patch \
            file://delta-ag5648/0004-delta-ag5648-convert-to-I2C-mux-and-use-optoe.patch \
            file://delta-ag5648/0005-delta-ag5648-implement-reading-DOM-EEPROM.patch \
+           file://delta-ag5648/0006-delta-ag5648-implement-onlp_sfpi_eeprom_page_read.patch \
            file://delta-ag7648/0001-agema-ag7648-fix-buffer-overflow-while-reading-therm.patch \
            file://delta-ag7648/0002-agema-ag7648-don-t-create-random-rx_los-bitmap-value.patch \
            file://delta-ag7648/0003-bump-kernel-to-4.9.patch \
@@ -87,6 +96,7 @@ SRC_URI += " \
            file://delta-ag7648/0015-delta-ag7648-update-platform_drivers-with-6.11-compa.patch \
            file://delta-ag7648/0016-delta-ag7648-convert-to-optoe-driver.patch \
            file://delta-ag7648/0017-delta-ag7648-fix-reading-DOM-EEPROM.patch \
+           file://delta-ag7648/0018-delta-ag7648-implement-onlp_sfpi_eeprom_page_read.patch \
 "
 
 FILES:${PN} = " \


### PR DESCRIPTION
In order to expose paged QSFP EEPROM pages 1+, we need a way to retrieve them. Luckily the optoe driver exposes them already at offset (page + 1)
+ 128.

So add a new function prototype to libonlp to read out a certain page, and implement the function for all supported platforms.