### PR TITLE
linux-yocto-onl: update 6.12 to 6.12.99

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 08:37:53.185758+00:00 for kernel version 6.12.95
+# Generated at 2026-07-28 09:06:09.409321+00:00 for kernel version 6.12.96
 # From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.95"
+    this_version = "6.12.96"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -15502,7 +15502,7 @@ CVE_STATUS[CVE-2025-21805] = "cpe-stable-backport: Backported in 6.12.13"
 
 CVE_STATUS[CVE-2025-21806] = "cpe-stable-backport: Backported in 6.12.13"
 
-# CVE-2025-21807 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2025-21807] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2025-21808] = "cpe-stable-backport: Backported in 6.12.13"
 
@@ -15522,7 +15522,7 @@ CVE_STATUS[CVE-2025-21815] = "cpe-stable-backport: Backported in 6.12.14"
 
 CVE_STATUS[CVE-2025-21816] = "cpe-stable-backport: Backported in 6.12.14"
 
-CVE_STATUS[CVE-2025-21817] = "fixed-version: only affects 6.12.96 onwards"
+# CVE-2025-21817 may need backporting (fixed from 6.13)
 
 CVE_STATUS[CVE-2025-21819] = "cpe-stable-backport: Backported in 6.12.14"
 
@@ -23794,7 +23794,7 @@ CVE_STATUS[CVE-2026-46091] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-46092] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-46093 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-46093] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-46094] = "cpe-stable-backport: Backported in 6.12.86"
 
@@ -24518,7 +24518,7 @@ CVE_STATUS[CVE-2026-53023] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-53026] = "fixed-version: only affects 6.18.4 onwards"
 
-# CVE-2026-53027 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-53027] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-53028] = "fixed-version: only affects 6.18 onwards"
 
@@ -24914,7 +24914,7 @@ CVE_STATUS[CVE-2026-53223] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53225] = "cpe-stable-backport: Backported in 6.12.94"
 
-# CVE-2026-53226 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-53226] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-53227] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -25246,7 +25246,7 @@ CVE_STATUS[CVE-2026-53390] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53391] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53392 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-53392] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-53393] = "cpe-stable-backport: Backported in 6.12.95"
 
@@ -25260,13 +25260,13 @@ CVE_STATUS[CVE-2026-53397] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53398] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53399 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-53399] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-53400] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-53401 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-53402 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-53402] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-53403] = "cpe-stable-backport: Backported in 6.12.95"
 
@@ -25314,13 +25314,13 @@ CVE_STATUS[CVE-2026-63813] = "fixed-version: only affects 7.0 onwards"
 
 CVE_STATUS[CVE-2026-63814] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63815 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-63815] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-63816 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-63816] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-63817] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63818 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-63818] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-63819 needs backporting (fixed from 7.2rc1)
 
@@ -26058,11 +26058,11 @@ CVE_STATUS[CVE-2026-64185] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-64186] = "fixed-version: only affects 6.17 onwards"
 
-# CVE-2026-64187 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64187] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64188] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64189 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64189] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64190 needs backporting (fixed from 7.1)
 
@@ -26142,7 +26142,7 @@ CVE_STATUS[CVE-2026-64239] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-64240] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-64241 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64241] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64242] = "cpe-stable-backport: Backported in 6.12.93"
 
@@ -26172,7 +26172,7 @@ CVE_STATUS[CVE-2026-64254] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64255 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64256 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64256] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64257 needs backporting (fixed from 7.2rc4)
 
@@ -26190,35 +26190,35 @@ CVE_STATUS[CVE-2026-64263] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-64264] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64265 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64265] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64266 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64266] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64267] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-64268 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64268] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64269 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64269] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64270 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64270] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64271 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64271] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64272 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64272] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64273 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64273] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64274 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64274] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64275 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64275] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64276 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64276] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64277 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64277] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64278] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64279 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64279] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64280 needs backporting (fixed from 7.2rc1)
 
@@ -26228,7 +26228,7 @@ CVE_STATUS[CVE-2026-64282] = "fixed-version: only affects 6.16 onwards"
 
 # CVE-2026-64283 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64284 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64284] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64285] = "fixed-version: only affects 7.0 onwards"
 
@@ -26238,7 +26238,7 @@ CVE_STATUS[CVE-2026-64285] = "fixed-version: only affects 7.0 onwards"
 
 CVE_STATUS[CVE-2026-64288] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2026-64289 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64289] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64290 needs backporting (fixed from 7.2rc1)
 
@@ -26248,193 +26248,193 @@ CVE_STATUS[CVE-2026-64292] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-64293] = "fixed-version: only affects 6.15 onwards"
 
-# CVE-2026-64294 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64294] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64295] = "fixed-version: only affects 6.15 onwards"
 
-# CVE-2026-64296 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64296] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64297 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64297] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64298 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64298] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64299 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64299] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64300] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64301 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64301] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64302] = "fixed-version: only affects 6.18.7 onwards"
 
-# CVE-2026-64303 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64303] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64304 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64304] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64305 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64305] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64306 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64306] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64307 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64308 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64308] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64309 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64309] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64310 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64310] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64311] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-64312 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64312] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64313 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64313] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64314] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2026-64315 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64315] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64316 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64316] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64317 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64317] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64318 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64318] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64319 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64319] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64320 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64320] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64321 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64321] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64322 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64322] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64323 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64323] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64324 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64324] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64325] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64326 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64326] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64327 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64327] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64328 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64328] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64329 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64329] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64330 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64330] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64331 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64331] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64332 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64332] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64333 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64333] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64334 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64334] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64335 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64335] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64336 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64336] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64337 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64337] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64338 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64338] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64339] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-64340 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64340] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64341 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64342 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64342] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64343 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64343] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64344 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64344] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64345 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64345] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64346 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64346] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64347 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64347] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64348 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64348] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64349] = "fixed-version: only affects 6.18.32 onwards"
 
-# CVE-2026-64350 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64350] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64351 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64351] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64352 may need backporting (fixed from 6.12.97)
 
 CVE_STATUS[CVE-2026-64353] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64354 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64354] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64355 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64355] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64356] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2026-64357 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64357] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64358 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64358] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64359 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64359] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64360 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64360] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64361 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64362 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64362] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64363 may need backporting (fixed from 6.12.97)
 
 # CVE-2026-64364 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64365 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64365] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64366] = "fixed-version: only affects 6.15 onwards"
 
-# CVE-2026-64367 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64367] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64368 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64368] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64369 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64370 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64370] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64371 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64372 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64372] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64373 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64373] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64374 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64374] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64375 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64376 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64376] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64377 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64377] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64378 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64378] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64379 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64379] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64380 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64380] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64381 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64381] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64382 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64382] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64383 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64383] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64384 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64384] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64385 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64385] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64386 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64386] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64387 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64387] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64388 needs backporting (fixed from 7.2rc1)
 
@@ -26442,75 +26442,75 @@ CVE_STATUS[CVE-2026-64366] = "fixed-version: only affects 6.15 onwards"
 
 # CVE-2026-64390 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64391 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64391] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64392 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64392] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64393 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64393] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64394 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64394] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64395 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64395] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64396 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64396] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64397 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64397] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64398 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64398] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64399 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64399] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64400 needs backporting (fixed from 7.2rc1)
 
 # CVE-2026-64401 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64402 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64402] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64403 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64403] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64404 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64404] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64405 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64406 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64406] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64407 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64407] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64408 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64408] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64409 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64409] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64410] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-64411 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64411] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64412 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64412] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64413 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64414 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64414] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64415 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64415] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64416 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64417 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64417] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64418 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64418] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64419 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64419] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64420 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64420] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64421 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64422 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64422] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64423 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64423] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64424 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64424] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64425 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64425] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64426] = "fixed-version: only affects 6.13 onwards"
 
@@ -26518,65 +26518,65 @@ CVE_STATUS[CVE-2026-64427] = "fixed-version: only affects 7.1 onwards"
 
 # CVE-2026-64428 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64429 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64429] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64430 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64430] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64431] = "fixed-version: only affects 7.1 onwards"
 
-# CVE-2026-64432 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64432] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64433 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64433] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64434 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64435 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64435] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64436 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64436] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64437 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64437] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64438 may need backporting (fixed from 6.12.97)
 
 CVE_STATUS[CVE-2026-64439] = "fixed-version: only affects 6.15 onwards"
 
-# CVE-2026-64440 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64440] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64441 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64442 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64442] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64443 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64443] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64444 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64444] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64445 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64445] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64446 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64446] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64447] = "fixed-version: only affects 6.17 onwards"
 
-# CVE-2026-64448 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64448] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64449 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64449] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64450 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64450] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64451] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-64452 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64452] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64453] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-64454 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64454] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64455 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64455] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64456 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64456] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64457 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64457] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64458 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64458] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64459] = "fixed-version: only affects 6.18 onwards"
 
@@ -26586,61 +26586,61 @@ CVE_STATUS[CVE-2026-64460] = "fixed-version: only affects 6.17 onwards"
 
 # CVE-2026-64462 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64463 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64463] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64464] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2026-64465 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64465] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64466] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-64467] = "fixed-version: only affects 6.18 onwards"
 
-# CVE-2026-64468 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64468] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64469 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64469] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64470 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64470] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64471 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64471] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64472 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64473 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64473] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64474 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64474] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64475 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64475] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64476 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64476] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64477 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64477] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64478 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64478] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64479 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64479] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64480 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64480] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64481 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64482 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64482] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64483 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64483] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64484 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64484] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64485] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2026-64486 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64486] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64487 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64487] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64488 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64489 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64489] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64490 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64490] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64491] = "fixed-version: only affects 6.18 onwards"
 
@@ -26648,29 +26648,29 @@ CVE_STATUS[CVE-2026-64492] = "fixed-version: only affects 6.13 onwards"
 
 # CVE-2026-64493 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64494 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64494] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64495 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64495] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64496 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64496] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64497 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64497] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64498] = "fixed-version: only affects 7.1 onwards"
 
-# CVE-2026-64499 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64499] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64500 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64500] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64501] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-64502] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-64503 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64503] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64504 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64504] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64505 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64505] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64506] = "fixed-version: only affects 7.1 onwards"
 
@@ -26682,13 +26682,13 @@ CVE_STATUS[CVE-2026-64506] = "fixed-version: only affects 7.1 onwards"
 
 # CVE-2026-64510 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64511 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64511] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64512 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64512] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64513 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64514 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64514] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64515] = "cpe-stable-backport: Backported in 6.12.92"
 
@@ -26732,7 +26732,7 @@ CVE_STATUS[CVE-2026-64529] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64535 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64536 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64536] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64537 may need backporting (fixed from 6.12.97)
 
@@ -26772,5 +26772,5 @@ CVE_STATUS[CVE-2026-64529] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64555 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-64600 may need backporting (fixed from 6.12.96)
+CVE_STATUS[CVE-2026-64600] = "cpe-stable-backport: Backported in 6.12.96"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-30 07:36:51.826443+00:00 for kernel version 6.12.99
-# From cvelistV5 cve_2026-07-30_0600Z-1-g8c5cb801566
+# Generated at 2026-07-31 07:48:27.166704+00:00 for kernel version 6.12.100
+# From cvelistV5 cve_2026-07-31_0700Z-1-g4586eab1cb7
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.99"
+    this_version = "6.12.100"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -4197,6 +4197,8 @@ CVE_STATUS[CVE-2022-49997] = "fixed-version: Fixed from version 6.0"
 CVE_STATUS[CVE-2022-49998] = "fixed-version: Fixed from version 6.0"
 
 CVE_STATUS[CVE-2022-49999] = "fixed-version: Fixed from version 6.0"
+
+CVE_STATUS[CVE-2022-4994] = "fixed-version: Fixed from version 6.0"
 
 CVE_STATUS[CVE-2022-50000] = "fixed-version: Fixed from version 6.0"
 
@@ -26780,7 +26782,7 @@ CVE_STATUS[CVE-2026-64558] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64559] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64560 needs backporting (fixed from 7.2rc3)
+CVE_STATUS[CVE-2026-64560] = "cpe-stable-backport: Backported in 6.12.100"
 
 CVE_STATUS[CVE-2026-64600] = "cpe-stable-backport: Backported in 6.12.96"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,16 +1,18 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-06-16 12:30:26.572651+00:00 for kernel version 6.12.93
-# From cvelistV5 cve_2026-06-16_1100Z
+# Generated at 2026-07-28 08:13:58.867232+00:00 for kernel version 6.12.94
+# From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.93"
+    this_version = "6.12.94"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
 }
 do_cve_check[prefuncs] += "check_kernel_cve_status_version"
+
+# CVE-2018-10902 has no known resolution
 
 CVE_STATUS[CVE-2019-25160] = "fixed-version: Fixed from version 5.0"
 
@@ -9032,6 +9034,8 @@ CVE_STATUS[CVE-2023-7324] = "fixed-version: Fixed from version 6.3"
 
 CVE_STATUS[CVE-2024-14027] = "cpe-stable-backport: Backported in 6.12.77"
 
+CVE_STATUS[CVE-2024-14040] = "fixed-version: Fixed from version 6.12"
+
 CVE_STATUS[CVE-2024-26581] = "fixed-version: Fixed from version 6.8"
 
 CVE_STATUS[CVE-2024-26582] = "fixed-version: Fixed from version 6.8"
@@ -15130,7 +15134,7 @@ CVE_STATUS[CVE-2024-58091] = "cpe-stable-backport: Backported in 6.12.36"
 
 CVE_STATUS[CVE-2024-58092] = "cpe-stable-backport: Backported in 6.12.22"
 
-# CVE-2024-58093 needs backporting (fixed from 6.15)
+CVE_STATUS[CVE-2024-58093] = "cpe-stable-backport: Backported in 6.12.23"
 
 # CVE-2024-58094 needs backporting (fixed from 6.15)
 
@@ -15498,7 +15502,7 @@ CVE_STATUS[CVE-2025-21805] = "cpe-stable-backport: Backported in 6.12.13"
 
 CVE_STATUS[CVE-2025-21806] = "cpe-stable-backport: Backported in 6.12.13"
 
-# CVE-2025-21807 needs backporting (fixed from 6.14)
+# CVE-2025-21807 may need backporting (fixed from 6.12.96)
 
 CVE_STATUS[CVE-2025-21808] = "cpe-stable-backport: Backported in 6.12.13"
 
@@ -15518,7 +15522,7 @@ CVE_STATUS[CVE-2025-21815] = "cpe-stable-backport: Backported in 6.12.14"
 
 CVE_STATUS[CVE-2025-21816] = "cpe-stable-backport: Backported in 6.12.14"
 
-CVE_STATUS[CVE-2025-21817] = "fixed-version: only affects 6.13.2 onwards"
+CVE_STATUS[CVE-2025-21817] = "fixed-version: only affects 6.12.96 onwards"
 
 CVE_STATUS[CVE-2025-21819] = "cpe-stable-backport: Backported in 6.12.14"
 
@@ -16140,7 +16144,7 @@ CVE_STATUS[CVE-2025-23129] = "cpe-stable-backport: Backported in 6.12.59"
 
 CVE_STATUS[CVE-2025-23130] = "cpe-stable-backport: Backported in 6.12.57"
 
-# CVE-2025-23131 needs backporting (fixed from 6.15)
+# CVE-2025-23131 may need backporting (fixed from 6.12.95)
 
 # CVE-2025-23132 needs backporting (fixed from 6.15)
 
@@ -17801,8 +17805,6 @@ CVE_STATUS[CVE-2025-38550] = "cpe-stable-backport: Backported in 6.12.40"
 CVE_STATUS[CVE-2025-38551] = "cpe-stable-backport: Backported in 6.12.40"
 
 CVE_STATUS[CVE-2025-38552] = "cpe-stable-backport: Backported in 6.12.40"
-
-CVE_STATUS[CVE-2025-38553] = "cpe-stable-backport: Backported in 6.12.42"
 
 CVE_STATUS[CVE-2025-38554] = "fixed-version: only affects 6.15 onwards"
 
@@ -21036,7 +21038,7 @@ CVE_STATUS[CVE-2026-23245] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-23246] = "cpe-stable-backport: Backported in 6.12.77"
 
-# CVE-2026-23247 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-23247] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-23248] = "fixed-version: only affects 6.14 onwards"
 
@@ -21546,7 +21548,7 @@ CVE_STATUS[CVE-2026-31417] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31418] = "cpe-stable-backport: Backported in 6.12.81"
 
-CVE_STATUS[CVE-2026-31419] = "cpe-stable-backport: Backported in 6.12.86"
+# CVE-2026-31419 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-31420] = "cpe-stable-backport: Backported in 6.12.92"
 
@@ -21620,7 +21622,7 @@ CVE_STATUS[CVE-2026-31454] = "cpe-stable-backport: Backported in 6.12.80"
 
 CVE_STATUS[CVE-2026-31455] = "cpe-stable-backport: Backported in 6.12.80"
 
-# CVE-2026-31456 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31456] = "cpe-stable-backport: Backported in 6.12.84"
 
 CVE_STATUS[CVE-2026-31457] = "fixed-version: only affects 6.17 onwards"
 
@@ -22032,7 +22034,7 @@ CVE_STATUS[CVE-2026-31661] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-31662] = "cpe-stable-backport: Backported in 6.12.82"
 
-# CVE-2026-31663 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-31663] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-31664] = "cpe-stable-backport: Backported in 6.12.82"
 
@@ -22082,8 +22084,6 @@ CVE_STATUS[CVE-2026-31686] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-31687] = "cpe-stable-backport: Backported in 6.12.73"
 
-# CVE-2026-31688 needs backporting (fixed from 7.0)
-
 CVE_STATUS[CVE-2026-31689] = "cpe-stable-backport: Backported in 6.12.82"
 
 CVE_STATUS[CVE-2026-31690] = "fixed-version: only affects 6.15 onwards"
@@ -22094,7 +22094,7 @@ CVE_STATUS[CVE-2026-31691] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-31693] = "cpe-stable-backport: Backported in 6.12.75"
 
-CVE_STATUS[CVE-2026-31694] = "cpe-stable-backport: Backported in 6.12.84"
+CVE_STATUS[CVE-2026-31694] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-31695] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -22170,7 +22170,7 @@ CVE_STATUS[CVE-2026-31730] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31731] = "cpe-stable-backport: Backported in 6.12.83"
 
-# CVE-2026-31732 needs backporting (fixed from 7.0)
+# CVE-2026-31732 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-31733] = "cpe-stable-backport: Backported in 6.12.82"
 
@@ -22296,7 +22296,7 @@ CVE_STATUS[CVE-2026-43008] = "fixed-version: only affects 6.19 onwards"
 
 # CVE-2026-43009 needs backporting (fixed from 7.0)
 
-# CVE-2026-43010 needs backporting (fixed from 7.0)
+# CVE-2026-43010 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-43011] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -22508,7 +22508,7 @@ CVE_STATUS[CVE-2026-43114] = "cpe-stable-backport: Backported in 6.12.83"
 
 # CVE-2026-43115 needs backporting (fixed from 7.0)
 
-# CVE-2026-43116 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-43116] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-43117] = "cpe-stable-backport: Backported in 6.12.83"
 
@@ -22519,8 +22519,6 @@ CVE_STATUS[CVE-2026-43119] = "cpe-stable-backport: Backported in 6.12.83"
 CVE_STATUS[CVE-2026-43120] = "cpe-stable-backport: Backported in 6.12.83"
 
 CVE_STATUS[CVE-2026-43121] = "fixed-version: only affects 6.15 onwards"
-
-CVE_STATUS[CVE-2026-43122] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-43123] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -22708,7 +22706,7 @@ CVE_STATUS[CVE-2026-43214] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-43215] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-43216 needs backporting (fixed from 7.0)
+# CVE-2026-43216 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-43217] = "fixed-version: only affects 6.15 onwards"
 
@@ -22986,7 +22984,7 @@ CVE_STATUS[CVE-2026-43351] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-43354] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-43355 needs backporting (fixed from 7.0)
+# CVE-2026-43355 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-43356] = "fixed-version: only affects 6.15 onwards"
 
@@ -23119,10 +23117,6 @@ CVE_STATUS[CVE-2026-43419] = "cpe-stable-backport: Backported in 6.12.78"
 CVE_STATUS[CVE-2026-43420] = "cpe-stable-backport: Backported in 6.12.78"
 
 CVE_STATUS[CVE-2026-43421] = "cpe-stable-backport: Backported in 6.12.78"
-
-CVE_STATUS[CVE-2026-43422] = "fixed-version: only affects 6.18.17 onwards"
-
-CVE_STATUS[CVE-2026-43423] = "fixed-version: only affects 6.18.17 onwards"
 
 CVE_STATUS[CVE-2026-43424] = "cpe-stable-backport: Backported in 6.12.78"
 
@@ -23316,7 +23310,7 @@ CVE_STATUS[CVE-2026-45848] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-45849] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-45850 needs backporting (fixed from 7.0)
+CVE_STATUS[CVE-2026-45850] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-45851] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -23504,7 +23498,7 @@ CVE_STATUS[CVE-2026-45942] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-45943] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-45944 needs backporting (fixed from 7.0)
+# CVE-2026-45944 may need backporting (fixed from 6.12.97)
 
 CVE_STATUS[CVE-2026-45945] = "fixed-version: only affects 6.13 onwards"
 
@@ -23722,7 +23716,7 @@ CVE_STATUS[CVE-2026-46052] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-46053] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-46054 needs backporting (fixed from 7.1)
+# CVE-2026-46054 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-46055] = "fixed-version: only affects 7.0 onwards"
 
@@ -23798,9 +23792,9 @@ CVE_STATUS[CVE-2026-46090] = "cpe-stable-backport: Backported in 6.12.88"
 
 CVE_STATUS[CVE-2026-46091] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-46092 needs backporting (fixed from 7.1)
+CVE_STATUS[CVE-2026-46092] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-46093 needs backporting (fixed from 7.1)
+# CVE-2026-46093 may need backporting (fixed from 6.12.96)
 
 CVE_STATUS[CVE-2026-46094] = "cpe-stable-backport: Backported in 6.12.86"
 
@@ -24020,7 +24014,7 @@ CVE_STATUS[CVE-2026-46201] = "cpe-stable-backport: Backported in 6.12.90"
 
 CVE_STATUS[CVE-2026-46202] = "fixed-version: only affects 6.15 onwards"
 
-# CVE-2026-46203 needs backporting (fixed from 7.1)
+CVE_STATUS[CVE-2026-46203] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-46204] = "cpe-stable-backport: Backported in 6.12.90"
 
@@ -24094,7 +24088,7 @@ CVE_STATUS[CVE-2026-46240] = "fixed-version: only affects 6.18.16 onwards"
 
 CVE_STATUS[CVE-2026-46241] = "cpe-stable-backport: Backported in 6.12.90"
 
-# CVE-2026-46242 needs backporting (fixed from 7.1)
+# CVE-2026-46242 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-46243] = "cpe-stable-backport: Backported in 6.12.92"
 
@@ -24114,7 +24108,7 @@ CVE_STATUS[CVE-2026-46250] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-46251] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-46252 needs backporting (fixed from 7.0)
+# CVE-2026-46252 may need backporting (fixed from 6.12.95)
 
 CVE_STATUS[CVE-2026-46253] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -24250,7 +24244,7 @@ CVE_STATUS[CVE-2026-46318] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-46319] = "cpe-stable-backport: Backported in 6.12.91"
 
-# CVE-2026-46320 needs backporting (fixed from 7.1)
+CVE_STATUS[CVE-2026-46320] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-46321] = "cpe-stable-backport: Backported in 6.12.93"
 
@@ -24272,7 +24266,7 @@ CVE_STATUS[CVE-2026-46329] = "cpe-stable-backport: Backported in 6.12.75"
 
 # CVE-2026-46330 needs backporting (fixed from 7.0)
 
-# CVE-2026-46331 needs backporting (fixed from 7.1)
+CVE_STATUS[CVE-2026-46331] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-46332] = "cpe-stable-backport: Backported in 6.12.86"
 
@@ -24285,4 +24279,2498 @@ CVE_STATUS[CVE-2026-52905] = "fixed-version: only affects 6.18 onwards"
 CVE_STATUS[CVE-2026-52906] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-52907] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-52908] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-52909 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-52910] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52911] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52912] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52913] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-52914] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52915] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52916] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52917] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52918] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52919] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52920] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52921] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52922] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52923] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-52924] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52925] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52926] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52927] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-52928] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-52929] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52930] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52931] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52932] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-52933] = "cpe-stable-backport: Backported in 6.12.86"
+
+CVE_STATUS[CVE-2026-52934] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-52935] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52936] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52937 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52938] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-52939] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52940] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-52941] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-52942] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52943] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-52944 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52945] = "fixed-version: only affects 6.15.3 onwards"
+
+CVE_STATUS[CVE-2026-52946] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52947] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52948] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-52949] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-52950] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-52951] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52952] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-52953 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52954] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52955] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52956 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52957] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52958] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52959] = "fixed-version: only affects 6.13.8 onwards"
+
+CVE_STATUS[CVE-2026-52960] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-52961] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52962] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52963] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52964] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52965] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-52966] = "fixed-version: only affects 6.18.32 onwards"
+
+CVE_STATUS[CVE-2026-52967] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52968] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52969] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52970] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52971] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-52972] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52973] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-52974] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52975 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-52976] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52977] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52978] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-52979] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-52980] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52981] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52982] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52983 may need backporting (fixed from 6.13)
+
+CVE_STATUS[CVE-2026-52984] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52985] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52986] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52987] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-52988 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52989] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52990] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52991 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52992] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52993] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-52994 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-52995] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52996] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52997] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-52998] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-52999] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53000 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53001] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53002] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53003] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53004] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53005 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-53006] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53007] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53008] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-53009 needs backporting (fixed from 7.1)
+
+# CVE-2026-53010 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53011] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53012] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53013] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53014] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53015] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53016] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53017 needs backporting (fixed from 7.1)
+
+# CVE-2026-53018 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53019] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53020] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53021] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53022] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53023] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53024 needs backporting (fixed from 7.1)
+
+# CVE-2026-53025 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53026] = "fixed-version: only affects 6.18.4 onwards"
+
+# CVE-2026-53027 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-53028] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53029] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53030] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53031] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53032] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53033] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53034] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53035] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53036] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53037] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53038] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53039] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53040] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53041] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53042] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53043] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53044] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53045] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53046] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53047] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53048] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53049] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53050] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53051] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53052] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53053] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53054] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53055] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53056] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53057] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-53058] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53059] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53060] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53061] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53062] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53063] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53064] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53065] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53066] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53067] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53068] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53069] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53070 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53071] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53072] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53073] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53074] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53075] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53076] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53077] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53078 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53079] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53080] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-53081] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53082] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53083] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53084] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53085] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53086] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53087] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53088] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53089 needs backporting (fixed from 7.1)
+
+# CVE-2026-53090 needs backporting (fixed from 7.1)
+
+# CVE-2026-53091 needs backporting (fixed from 7.1)
+
+# CVE-2026-53092 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53093] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53094] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53095] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53096] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53097] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53098] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53099] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53100] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-53101 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53102 needs backporting (fixed from 7.1)
+
+# CVE-2026-53103 needs backporting (fixed from 7.1)
+
+# CVE-2026-53104 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53105] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53106 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53107] = "fixed-version: only affects 6.18.16 onwards"
+
+# CVE-2026-53108 needs backporting (fixed from 7.1)
+
+# CVE-2026-53109 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53110] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53111] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53112] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53113 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53114] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53115] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53116] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53117] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53118 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53119] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53120] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53121] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53122] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53123] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53124] = "fixed-version: only affects 6.14.6 onwards"
+
+CVE_STATUS[CVE-2026-53125] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53126] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53127] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53128] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53129] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53130] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53131] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53132] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53133] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53134] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53135] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53136] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53137] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53138] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53139 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53140] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53141] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-53142 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53143] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53144] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53145] = "fixed-version: only affects 6.18.32 onwards"
+
+CVE_STATUS[CVE-2026-53146] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53147] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53148] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53149] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53150] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53151 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53152] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53153] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-53154] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53155] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53156] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53157 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53158] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53159] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53160] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53161] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53162] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-53163 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53164] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53165] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-53167 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53168] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53169] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53170] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53171] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53172] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53173] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53174] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53175] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53176] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53177] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53178 needs backporting (fixed from 7.1)
+
+# CVE-2026-53179 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53180] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53181] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53182] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53183] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53184] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53185] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53186] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53187] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53188] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53189] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53190] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53191] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53192] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53193] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53194] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53195] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53196] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53197] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53198] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53199] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53200] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53201] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53202] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53203] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53204] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53205] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53206] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53207] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53208] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53209] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53210] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53211] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53212] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53213] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53214] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53215] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53216] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53217] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53218] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53219] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53220] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53221] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53222] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53223] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53224 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53225] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53226 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-53227] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53228] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53229] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53230] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53231] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53232] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53233] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53234] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53235] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53236] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53237] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53238] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53239] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53240] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53241] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53242] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53243] = "fixed-version: only affects 7.0.10 onwards"
+
+CVE_STATUS[CVE-2026-53244] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53245] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53246 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53247] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53248] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53249] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53250 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53251] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53252] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53253] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53254] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53255] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53256] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53257] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-53258 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53259] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-53260 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-53261] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53262] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53263] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53264] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53265] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53266] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53267] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53268] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53269] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53270] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53271] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53272] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53273] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53274] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53275] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53276] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-53277 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53278] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53279] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53280] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-53281 may need backporting (fixed from 6.13)
+
+CVE_STATUS[CVE-2026-53282] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53283] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-53284 needs backporting (fixed from 7.1)
+
+# CVE-2026-53285 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53286] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53287] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53288] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53289] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53290] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53291] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53292 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53293] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53294] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53295] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53296] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53297 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53298] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53299] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53300] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53301] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-53302] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53303] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53304] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53305] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53306] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53307] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53308] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53309] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53310] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-53311] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53312] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-53313 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53314] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53315] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53316] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53317] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53318] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-53319] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53320] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-53321 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53322] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53323] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-53324] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-53325 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53326] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-53327 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53328] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53329] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-53330 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53331] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53332] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53333] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53334] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53335] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53336] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53337] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53338] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53339] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53340] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-53341 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53342] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53343] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53344] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53345] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53346] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53347] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53348] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53349] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53350] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53351] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53352] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53353] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53354] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53355] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53356] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-53357] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-53358] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-53359 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53360] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-53361 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53362 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53363] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-53364] = "fixed-version: only affects 6.16.4 onwards"
+
+# CVE-2026-53365 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-53366 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53367] = "fixed-version: only affects 6.17.10 onwards"
+
+# CVE-2026-53368 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53369] = "cpe-stable-backport: Backported in 6.12.88"
+
+CVE_STATUS[CVE-2026-53370] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-53371] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-53372] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-53373] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53374] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-53375] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-53376] = "cpe-stable-backport: Backported in 6.12.90"
+
+# CVE-2026-53377 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-53378] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-53379] = "cpe-stable-backport: Backported in 6.12.90"
+
+CVE_STATUS[CVE-2026-53380] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-53381 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53382 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53383 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53384 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53385 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53386 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53387 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53388 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53389 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53390 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53391 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53392 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-53393 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53394 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-53395] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-53396] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-53397 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53398 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53399 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-53400 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-53401 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-53402 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-53403 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-63793] = "fixed-version: only affects 7.1 onwards"
+
+# CVE-2026-63794 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63795 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63796 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63797 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63798 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-63799] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-63800 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63801 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63802 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63803 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63804 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63805 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63806 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63807 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63808 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63809 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63810 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63811 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63812 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-63813] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-63814 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63815 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-63816 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-63817 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63818 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-63819 needs backporting (fixed from 7.2rc1)
+
+CVE_STATUS[CVE-2026-63820] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-63821 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63822 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63823 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63824 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63825 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63826 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63827 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63828 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63829 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63830 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63831 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63832 may need backporting (fixed from 6.13)
+
+# CVE-2026-63833 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63834 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63835 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63836 may need backporting (fixed from 6.12.95)
+
+CVE_STATUS[CVE-2026-63837] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-63838] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63839] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-63840] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-63841] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-63842] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63843] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63844] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63845] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63846] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63847] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63848] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63849] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-63850] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63851] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63852] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-63853 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63854] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63855] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63856] = "cpe-stable-backport: Backported in 6.12.91"
+
+# CVE-2026-63857 needs backporting (fixed from 7.1)
+
+# CVE-2026-63858 needs backporting (fixed from 7.1)
+
+# CVE-2026-63859 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63860] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63861] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63862] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63863] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-63864] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63865] = "cpe-stable-backport: Backported in 6.12.91"
+
+CVE_STATUS[CVE-2026-63866] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63867] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-63868] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-63869] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-63870] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-63871] = "cpe-stable-backport: Backported in 6.12.94"
+
+# CVE-2026-63872 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63873] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-63874] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63875] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63876] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63877] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63878] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-63879 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63880] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-63881] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63882] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63883] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63884] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63885] = "fixed-version: only affects 6.18.32 onwards"
+
+CVE_STATUS[CVE-2026-63886] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63887] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63888] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63889] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63890] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63891] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63892] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63893] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63894] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63895] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63896] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63897] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63898] = "cpe-stable-backport: Backported in 6.12.94"
+
+CVE_STATUS[CVE-2026-63899] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63900] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63901] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63902] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63903] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63904] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63905] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63906] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63907] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63908] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63909] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63910] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-63911] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-63912] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63913] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63914] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63915] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63916] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63917] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63918] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63919] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63920] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63921] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63922] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63923] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-63924] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63925] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63926] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63927] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63928] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63929] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63930] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63931] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63932] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-63933] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63934] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63935] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-63936] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63937] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63938] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63939] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-63940 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-63941 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63942] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63943] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63944] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63945] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63946] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63947] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63948] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63949] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63950] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63951] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63952] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63953] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63954] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63955] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63956] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63957] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63958] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63959] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63960] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63961] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63962] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63963] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63964] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63965] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-63966] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63967] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63968] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63969] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-63970 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-63971] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63972] = "fixed-version: only affects 6.18.33 onwards"
+
+CVE_STATUS[CVE-2026-63973] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63974] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63975] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63976] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63977] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-63978] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-63979 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-63980] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63981] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63982] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-63983] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63984] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63985] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63986] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-63987] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63988] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63989] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-63990] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63991] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63992] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63993] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63994] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63995] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63996] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-63997] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-63998 needs backporting (fixed from 7.1)
+
+# CVE-2026-63999 may need backporting (fixed from 6.13)
+
+CVE_STATUS[CVE-2026-64000] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64001] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64002] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64003] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64004] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64005] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-64006 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64007] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64008] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64009] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64010] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64011] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64012] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64013] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64014] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64015] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64016] = "fixed-version: only affects 6.18.33 onwards"
+
+# CVE-2026-64017 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64018] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64019] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64020] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64021] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64022] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64023] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64024 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64025] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64026] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64027] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64028] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64029] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64030] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64031] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64032] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64033] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64034] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64035] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64036 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64037] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64038 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64039] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64040] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64041] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64042] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64043] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64044] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64045] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64046] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64047] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64048] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64049] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64050] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64051] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64052] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64053] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64054] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64055] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64056] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64057] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64058 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64059] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64060 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64061] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64062] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64063] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64064] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64065] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64066 needs backporting (fixed from 7.1)
+
+# CVE-2026-64067 needs backporting (fixed from 7.1)
+
+# CVE-2026-64068 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64069] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64070 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64071] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64072] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64073] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64074] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64075] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64076 needs backporting (fixed from 7.1)
+
+# CVE-2026-64077 needs backporting (fixed from 7.1)
+
+# CVE-2026-64078 needs backporting (fixed from 7.1)
+
+# CVE-2026-64079 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64080] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64081] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64082 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64083] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64084] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64085] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64086] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64087] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64088] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64089] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64090] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64091] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64092] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64093] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64094] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64095] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64096] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64097] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64098] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64099] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64100] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64101] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64102] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64103] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64104] = "fixed-version: only affects 6.13.8 onwards"
+
+CVE_STATUS[CVE-2026-64105] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64106] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64107] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64108] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64109] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64110] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64111] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64112] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64113] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64114] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64115] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64116] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64117 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64118] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64119] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64120] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64121] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64122] = "fixed-version: only affects 6.18.14 onwards"
+
+CVE_STATUS[CVE-2026-64123] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64124] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64125] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64126] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64127] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64128] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64129] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64130] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64131] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64132] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64133] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64134] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64135] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64136] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64137] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64138] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64139] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64140] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-64141] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64142] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64143] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64144] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64145] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-64146 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64147] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64148] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64149] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64150] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64151] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64152] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-64153] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64154 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64155] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64156] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64157] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64158] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64159 needs backporting (fixed from 7.1)
+
+# CVE-2026-64160 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64161] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64162] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64163] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64164] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64165] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64166] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64167] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64168] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64169] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64170] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64171] = "fixed-version: only affects 7.0 onwards"
+
+CVE_STATUS[CVE-2026-64172] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64173] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64174] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64175] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64176] = "fixed-version: only affects 6.17.9 onwards"
+
+CVE_STATUS[CVE-2026-64177] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64178] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64179] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64180] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64181] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64182] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64183] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64184] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64185] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64186] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-64187 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64188 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64189 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64190 needs backporting (fixed from 7.1)
+
+# CVE-2026-64191 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64192 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64205 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64206 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-64207] = "fixed-version: only affects 6.17 onwards"
+
+CVE_STATUS[CVE-2026-64208] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64209] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-64210 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64211] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-64212 needs backporting (fixed from 7.1)
+
+# CVE-2026-64213 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64214] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64215] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-64216 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64217] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64218] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64219] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64220] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64221] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64222] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64223] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64224] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64225] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64226] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64227 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-64228] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64229] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64230] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64231] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64232] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64233] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64234] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64235] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64236] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64237] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64238] = "fixed-version: only affects 6.19.12 onwards"
+
+CVE_STATUS[CVE-2026-64239] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64240] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-64241 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64242] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64243] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-64244 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64245 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64246 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64247 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64248 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64249 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64250 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64251 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64252 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64253 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64254 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64255 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64256 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64257 needs backporting (fixed from 7.2rc4)
+
+CVE_STATUS[CVE-2026-64258] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64259] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64260] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64261] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64262] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64263] = "fixed-version: only affects 6.16 onwards"
+
+CVE_STATUS[CVE-2026-64264] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64265 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64266 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64267] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-64268 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64269 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64270 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64271 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64272 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64273 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64274 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64275 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64276 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64277 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64278] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64279 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64280 needs backporting (fixed from 7.2rc1)
+
+CVE_STATUS[CVE-2026-64281] = "fixed-version: only affects 7.1 onwards"
+
+CVE_STATUS[CVE-2026-64282] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64283 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64284 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64285] = "fixed-version: only affects 7.0 onwards"
+
+# CVE-2026-64286 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64287 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-64288] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64289 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64290 needs backporting (fixed from 7.2rc1)
+
+CVE_STATUS[CVE-2026-64291] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64292] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64293] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64294 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64295] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64296 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64297 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64298 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64299 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64300] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64301 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64302] = "fixed-version: only affects 6.18.7 onwards"
+
+# CVE-2026-64303 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64304 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64305 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64306 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64307 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64308 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64309 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64310 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64311] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-64312 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64313 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64314] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64315 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64316 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64317 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64318 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64319 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64320 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64321 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64322 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64323 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64324 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64325] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64326 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64327 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64328 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64329 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64330 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64331 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64332 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64333 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64334 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64335 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64336 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64337 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64338 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64339] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-64340 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64341 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64342 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64343 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64344 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64345 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64346 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64347 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64348 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64349] = "fixed-version: only affects 6.18.32 onwards"
+
+# CVE-2026-64350 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64351 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64352 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-64353] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64354 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64355 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64356] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-64357 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64358 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64359 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64360 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64361 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64362 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64363 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64364 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64365 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64366] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64367 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64368 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64369 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64370 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64371 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64372 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64373 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64374 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64375 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64376 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64377 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64378 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64379 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64380 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64381 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64382 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64383 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64384 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64385 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64386 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64387 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64388 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64389 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64390 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64391 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64392 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64393 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64394 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64395 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64396 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64397 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64398 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64399 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64400 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64401 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64402 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64403 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64404 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64405 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64406 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64407 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64408 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64409 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64410] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-64411 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64412 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64413 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64414 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64415 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64416 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64417 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64418 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64419 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64420 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64421 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64422 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64423 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64424 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64425 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64426] = "fixed-version: only affects 6.13 onwards"
+
+CVE_STATUS[CVE-2026-64427] = "fixed-version: only affects 7.1 onwards"
+
+# CVE-2026-64428 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64429 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64430 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64431] = "fixed-version: only affects 7.1 onwards"
+
+# CVE-2026-64432 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64433 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64434 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64435 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64436 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64437 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64438 may need backporting (fixed from 6.12.97)
+
+CVE_STATUS[CVE-2026-64439] = "fixed-version: only affects 6.15 onwards"
+
+# CVE-2026-64440 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64441 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64442 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64443 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64444 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64445 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64446 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64447] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-64448 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64449 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64450 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64451] = "fixed-version: only affects 6.19 onwards"
+
+# CVE-2026-64452 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64453] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-64454 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64455 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64456 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64457 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64458 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64459] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64460] = "fixed-version: only affects 6.17 onwards"
+
+# CVE-2026-64461 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64462 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64463 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64464] = "fixed-version: only affects 6.16 onwards"
+
+# CVE-2026-64465 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64466] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64467] = "fixed-version: only affects 6.18 onwards"
+
+# CVE-2026-64468 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64469 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64470 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64471 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64472 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64473 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64474 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64475 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64476 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64477 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64478 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64479 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64480 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64481 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64482 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64483 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64484 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64485] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-64486 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64487 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64488 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64489 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64490 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64491] = "fixed-version: only affects 6.18 onwards"
+
+CVE_STATUS[CVE-2026-64492] = "fixed-version: only affects 6.13 onwards"
+
+# CVE-2026-64493 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64494 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64495 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64496 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64497 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64498] = "fixed-version: only affects 7.1 onwards"
+
+# CVE-2026-64499 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64500 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64501] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64502] = "fixed-version: only affects 6.14 onwards"
+
+# CVE-2026-64503 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64504 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64505 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64506] = "fixed-version: only affects 7.1 onwards"
+
+# CVE-2026-64507 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64508 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64509 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64510 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64511 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64512 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64513 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64514 may need backporting (fixed from 6.12.96)
+
+CVE_STATUS[CVE-2026-64515] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64516] = "fixed-version: only affects 6.19 onwards"
+
+CVE_STATUS[CVE-2026-64517] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64518] = "cpe-stable-backport: Backported in 6.12.92"
+
+CVE_STATUS[CVE-2026-64519] = "cpe-stable-backport: Backported in 6.12.92"
+
+# CVE-2026-64520 needs backporting (fixed from 7.1)
+
+CVE_STATUS[CVE-2026-64521] = "fixed-version: only affects 6.15 onwards"
+
+CVE_STATUS[CVE-2026-64522] = "fixed-version: only affects 6.17.4 onwards"
+
+CVE_STATUS[CVE-2026-64523] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64524] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64525] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64526] = "fixed-version: only affects 6.14 onwards"
+
+CVE_STATUS[CVE-2026-64527] = "cpe-stable-backport: Backported in 6.12.93"
+
+CVE_STATUS[CVE-2026-64528] = "cpe-stable-backport: Backported in 6.12.93"
+
+# CVE-2026-64529 may need backporting (fixed from 6.12.95)
+
+# CVE-2026-64530 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64531 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64532 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64533 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64534 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64535 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64536 may need backporting (fixed from 6.12.96)
+
+# CVE-2026-64537 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64538 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64539 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64540 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64541 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64542 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64543 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64544 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64545 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64546 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64547 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64548 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64549 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64550 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64551 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64552 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64553 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64554 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64555 may need backporting (fixed from 6.12.97)
+
+# CVE-2026-64600 may need backporting (fixed from 6.12.96)
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 09:26:42.469474+00:00 for kernel version 6.12.98
-# From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
+# Generated at 2026-07-30 07:36:51.826443+00:00 for kernel version 6.12.99
+# From cvelistV5 cve_2026-07-30_0600Z-1-g8c5cb801566
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.98"
+    this_version = "6.12.99"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -26771,6 +26771,16 @@ CVE_STATUS[CVE-2026-64553] = "cpe-stable-backport: Backported in 6.12.97"
 CVE_STATUS[CVE-2026-64554] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64555] = "cpe-stable-backport: Backported in 6.12.97"
+
+CVE_STATUS[CVE-2026-64556] = "cpe-stable-backport: Backported in 6.12.96"
+
+CVE_STATUS[CVE-2026-64557] = "cpe-stable-backport: Backported in 6.12.97"
+
+CVE_STATUS[CVE-2026-64558] = "cpe-stable-backport: Backported in 6.12.97"
+
+CVE_STATUS[CVE-2026-64559] = "cpe-stable-backport: Backported in 6.12.97"
+
+# CVE-2026-64560 needs backporting (fixed from 7.2rc3)
 
 CVE_STATUS[CVE-2026-64600] = "cpe-stable-backport: Backported in 6.12.96"
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 08:13:58.867232+00:00 for kernel version 6.12.94
+# Generated at 2026-07-28 08:37:53.185758+00:00 for kernel version 6.12.95
 # From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.94"
+    this_version = "6.12.95"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -16144,7 +16144,7 @@ CVE_STATUS[CVE-2025-23129] = "cpe-stable-backport: Backported in 6.12.59"
 
 CVE_STATUS[CVE-2025-23130] = "cpe-stable-backport: Backported in 6.12.57"
 
-# CVE-2025-23131 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2025-23131] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2025-23132 needs backporting (fixed from 6.15)
 
@@ -21548,7 +21548,7 @@ CVE_STATUS[CVE-2026-31417] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31418] = "cpe-stable-backport: Backported in 6.12.81"
 
-# CVE-2026-31419 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-31419] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-31420] = "cpe-stable-backport: Backported in 6.12.92"
 
@@ -22170,7 +22170,7 @@ CVE_STATUS[CVE-2026-31730] = "cpe-stable-backport: Backported in 6.12.81"
 
 CVE_STATUS[CVE-2026-31731] = "cpe-stable-backport: Backported in 6.12.83"
 
-# CVE-2026-31732 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-31732] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-31733] = "cpe-stable-backport: Backported in 6.12.82"
 
@@ -22296,7 +22296,7 @@ CVE_STATUS[CVE-2026-43008] = "fixed-version: only affects 6.19 onwards"
 
 # CVE-2026-43009 needs backporting (fixed from 7.0)
 
-# CVE-2026-43010 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-43010] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-43011] = "cpe-stable-backport: Backported in 6.12.81"
 
@@ -22706,7 +22706,7 @@ CVE_STATUS[CVE-2026-43214] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-43215] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-43216 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-43216] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-43217] = "fixed-version: only affects 6.15 onwards"
 
@@ -22984,7 +22984,7 @@ CVE_STATUS[CVE-2026-43351] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-43354] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-43355 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-43355] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-43356] = "fixed-version: only affects 6.15 onwards"
 
@@ -23716,7 +23716,7 @@ CVE_STATUS[CVE-2026-46052] = "cpe-stable-backport: Backported in 6.12.86"
 
 CVE_STATUS[CVE-2026-46053] = "cpe-stable-backport: Backported in 6.12.86"
 
-# CVE-2026-46054 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-46054] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-46055] = "fixed-version: only affects 7.0 onwards"
 
@@ -24088,7 +24088,7 @@ CVE_STATUS[CVE-2026-46240] = "fixed-version: only affects 6.18.16 onwards"
 
 CVE_STATUS[CVE-2026-46241] = "cpe-stable-backport: Backported in 6.12.90"
 
-# CVE-2026-46242 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-46242] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-46243] = "cpe-stable-backport: Backported in 6.12.92"
 
@@ -24108,7 +24108,7 @@ CVE_STATUS[CVE-2026-46250] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-46251] = "cpe-stable-backport: Backported in 6.12.75"
 
-# CVE-2026-46252 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-46252] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-46253] = "cpe-stable-backport: Backported in 6.12.75"
 
@@ -24282,7 +24282,7 @@ CVE_STATUS[CVE-2026-52907] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-52908] = "cpe-stable-backport: Backported in 6.12.94"
 
-# CVE-2026-52909 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-52909] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-52910] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -24414,7 +24414,7 @@ CVE_STATUS[CVE-2026-52973] = "fixed-version: only affects 6.17 onwards"
 
 CVE_STATUS[CVE-2026-52974] = "cpe-stable-backport: Backported in 6.12.91"
 
-# CVE-2026-52975 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-52975] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-52976] = "cpe-stable-backport: Backported in 6.12.91"
 
@@ -24604,7 +24604,7 @@ CVE_STATUS[CVE-2026-53068] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-53069] = "cpe-stable-backport: Backported in 6.12.91"
 
-# CVE-2026-53070 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53070] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53071] = "cpe-stable-backport: Backported in 6.12.91"
 
@@ -24666,7 +24666,7 @@ CVE_STATUS[CVE-2026-53099] = "fixed-version: only affects 7.0 onwards"
 
 CVE_STATUS[CVE-2026-53100] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-53101 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53101] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-53102 needs backporting (fixed from 7.1)
 
@@ -24742,13 +24742,13 @@ CVE_STATUS[CVE-2026-53137] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53138] = "cpe-stable-backport: Backported in 6.12.94"
 
-# CVE-2026-53139 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53139] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53140] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53141] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-53142 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53142] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53143] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -24766,7 +24766,7 @@ CVE_STATUS[CVE-2026-53149] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53150] = "cpe-stable-backport: Backported in 6.12.94"
 
-# CVE-2026-53151 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53151] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53152] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -24778,7 +24778,7 @@ CVE_STATUS[CVE-2026-53155] = "fixed-version: only affects 6.19 onwards"
 
 CVE_STATUS[CVE-2026-53156] = "cpe-stable-backport: Backported in 6.12.94"
 
-# CVE-2026-53157 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53157] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53158] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -24790,13 +24790,13 @@ CVE_STATUS[CVE-2026-53161] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53162] = "fixed-version: only affects 6.16 onwards"
 
-# CVE-2026-53163 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53163] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53164] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-53165] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-53167 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53167] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53168] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -24820,7 +24820,7 @@ CVE_STATUS[CVE-2026-53177] = "cpe-stable-backport: Backported in 6.12.94"
 
 # CVE-2026-53178 needs backporting (fixed from 7.1)
 
-# CVE-2026-53179 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53179] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53180] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -25112,11 +25112,11 @@ CVE_STATUS[CVE-2026-53323] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-53324] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2026-53325 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53325] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53326] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-53327 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53327] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53328] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -25144,7 +25144,7 @@ CVE_STATUS[CVE-2026-53339] = "cpe-stable-backport: Backported in 6.12.94"
 
 CVE_STATUS[CVE-2026-53340] = "fixed-version: only affects 6.14 onwards"
 
-# CVE-2026-53341 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53341] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53342] = "fixed-version: only affects 6.16 onwards"
 
@@ -25180,13 +25180,13 @@ CVE_STATUS[CVE-2026-53357] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-53358] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-53359 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53359] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53360] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-53361 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53361] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53362 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53362] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53363] = "fixed-version: only affects 6.14 onwards"
 
@@ -25194,7 +25194,7 @@ CVE_STATUS[CVE-2026-53364] = "fixed-version: only affects 6.16.4 onwards"
 
 # CVE-2026-53365 may need backporting (fixed from 6.12.97)
 
-# CVE-2026-53366 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53366] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53367] = "fixed-version: only affects 6.17.10 onwards"
 
@@ -25224,101 +25224,101 @@ CVE_STATUS[CVE-2026-53379] = "cpe-stable-backport: Backported in 6.12.90"
 
 CVE_STATUS[CVE-2026-53380] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-53381 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53381] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53382 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53382] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53383 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53383] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53384 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53384] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53385 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53385] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53386 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53386] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53387 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53387] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53388 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53388] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53389 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53389] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53390 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53390] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53391 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53391] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-53392 may need backporting (fixed from 6.12.96)
 
-# CVE-2026-53393 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53393] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53394 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53394] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-53395] = "fixed-version: only affects 7.0 onwards"
 
 CVE_STATUS[CVE-2026-53396] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-53397 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53397] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-53398 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53398] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-53399 may need backporting (fixed from 6.12.96)
 
-# CVE-2026-53400 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53400] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-53401 needs backporting (fixed from 7.2rc1)
 
 # CVE-2026-53402 may need backporting (fixed from 6.12.96)
 
-# CVE-2026-53403 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-53403] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-63793] = "fixed-version: only affects 7.1 onwards"
 
-# CVE-2026-63794 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63794] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63795 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63795] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63796 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63796] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63797 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63797] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63798 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63798] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-63799] = "fixed-version: only affects 6.19 onwards"
 
-# CVE-2026-63800 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63800] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63801 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63801] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63802 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63802] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63803 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63803] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63804 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63804] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63805 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63806 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63806] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63807 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63807] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63808 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63808] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63809 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63809] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63810 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63810] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63811 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63812 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63812] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-63813] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-63814 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63814] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63815 may need backporting (fixed from 6.12.96)
 
 # CVE-2026-63816 may need backporting (fixed from 6.12.96)
 
-# CVE-2026-63817 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63817] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63818 may need backporting (fixed from 6.12.96)
 
@@ -25326,37 +25326,37 @@ CVE_STATUS[CVE-2026-63813] = "fixed-version: only affects 7.0 onwards"
 
 CVE_STATUS[CVE-2026-63820] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-63821 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63821] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63822 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63822] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63823 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63823] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63824 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63824] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63825 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63826 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63826] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63827 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63827] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63828 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63828] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63829 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63829] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63830 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63830] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63831 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63831] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63832 may need backporting (fixed from 6.13)
 
-# CVE-2026-63833 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63833] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63834 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63834] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63835 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63835] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-63836 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63836] = "cpe-stable-backport: Backported in 6.12.95"
 
 CVE_STATUS[CVE-2026-63837] = "fixed-version: only affects 6.17 onwards"
 
@@ -25564,7 +25564,7 @@ CVE_STATUS[CVE-2026-63938] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-63939] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-63940 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-63940] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-63941 needs backporting (fixed from 7.1)
 
@@ -26060,13 +26060,13 @@ CVE_STATUS[CVE-2026-64186] = "fixed-version: only affects 6.17 onwards"
 
 # CVE-2026-64187 may need backporting (fixed from 6.12.96)
 
-# CVE-2026-64188 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64188] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64189 may need backporting (fixed from 6.12.96)
 
 # CVE-2026-64190 needs backporting (fixed from 7.1)
 
-# CVE-2026-64191 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64191] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64192 may need backporting (fixed from 6.12.97)
 
@@ -26148,27 +26148,27 @@ CVE_STATUS[CVE-2026-64242] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-64243] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-64244 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64244] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64245 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64245] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64246 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64246] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64247 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64247] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64248 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64248] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64249 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64249] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64250 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64250] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64251 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64251] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64252 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64252] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64253 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64253] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64254 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64254] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64255 needs backporting (fixed from 7.2rc1)
 
@@ -26718,7 +26718,7 @@ CVE_STATUS[CVE-2026-64527] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-64528] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-64529 may need backporting (fixed from 6.12.95)
+CVE_STATUS[CVE-2026-64529] = "cpe-stable-backport: Backported in 6.12.95"
 
 # CVE-2026-64530 may need backporting (fixed from 6.12.97)
 

--- a/recipes-kernel/linux/cve-exclusion_6.12.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.12.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 09:06:09.409321+00:00 for kernel version 6.12.96
+# Generated at 2026-07-28 09:26:42.469474+00:00 for kernel version 6.12.98
 # From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.12.96"
+    this_version = "6.12.98"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -23498,7 +23498,7 @@ CVE_STATUS[CVE-2026-45942] = "cpe-stable-backport: Backported in 6.12.75"
 
 CVE_STATUS[CVE-2026-45943] = "cpe-stable-backport: Backported in 6.12.78"
 
-# CVE-2026-45944 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-45944] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-45945] = "fixed-version: only affects 6.13 onwards"
 
@@ -24474,7 +24474,7 @@ CVE_STATUS[CVE-2026-53003] = "cpe-stable-backport: Backported in 6.12.91"
 
 CVE_STATUS[CVE-2026-53004] = "cpe-stable-backport: Backported in 6.12.91"
 
-# CVE-2026-53005 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-53005] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-53006] = "cpe-stable-backport: Backported in 6.12.91"
 
@@ -24982,7 +24982,7 @@ CVE_STATUS[CVE-2026-53257] = "fixed-version: only affects 6.16 onwards"
 
 CVE_STATUS[CVE-2026-53259] = "fixed-version: only affects 6.17 onwards"
 
-# CVE-2026-53260 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-53260] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-53261] = "cpe-stable-backport: Backported in 6.12.94"
 
@@ -25192,7 +25192,7 @@ CVE_STATUS[CVE-2026-53363] = "fixed-version: only affects 6.14 onwards"
 
 CVE_STATUS[CVE-2026-53364] = "fixed-version: only affects 6.16.4 onwards"
 
-# CVE-2026-53365 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-53365] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-53366] = "cpe-stable-backport: Backported in 6.12.95"
 
@@ -25624,7 +25624,7 @@ CVE_STATUS[CVE-2026-63968] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-63969] = "cpe-stable-backport: Backported in 6.12.93"
 
-# CVE-2026-63970 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-63970] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-63971] = "cpe-stable-backport: Backported in 6.12.93"
 
@@ -26068,11 +26068,11 @@ CVE_STATUS[CVE-2026-64189] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64191] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64192 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64192] = "cpe-stable-backport: Backported in 6.12.97"
 
 # CVE-2026-64205 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64206 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64206] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64207] = "fixed-version: only affects 6.17 onwards"
 
@@ -26114,7 +26114,7 @@ CVE_STATUS[CVE-2026-64225] = "cpe-stable-backport: Backported in 6.12.92"
 
 CVE_STATUS[CVE-2026-64226] = "cpe-stable-backport: Backported in 6.12.92"
 
-# CVE-2026-64227 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64227] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64228] = "fixed-version: only affects 6.16 onwards"
 
@@ -26232,9 +26232,9 @@ CVE_STATUS[CVE-2026-64284] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64285] = "fixed-version: only affects 7.0 onwards"
 
-# CVE-2026-64286 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64286] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64287 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64287] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64288] = "fixed-version: only affects 6.16 onwards"
 
@@ -26274,7 +26274,7 @@ CVE_STATUS[CVE-2026-64305] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64306] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64307 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64307] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64308] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26342,7 +26342,7 @@ CVE_STATUS[CVE-2026-64339] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-64340] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64341 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64341] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64342] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26364,7 +26364,7 @@ CVE_STATUS[CVE-2026-64350] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64351] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64352 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64352] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64353] = "fixed-version: only affects 6.14 onwards"
 
@@ -26382,13 +26382,13 @@ CVE_STATUS[CVE-2026-64359] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64360] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64361 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64361] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64362] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64363 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64363] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64364 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64364] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64365] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26398,11 +26398,11 @@ CVE_STATUS[CVE-2026-64367] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64368] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64369 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64369] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64370] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64371 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64371] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64372] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26410,7 +26410,7 @@ CVE_STATUS[CVE-2026-64373] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64374] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64375 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64375] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64376] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26440,7 +26440,7 @@ CVE_STATUS[CVE-2026-64387] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64389 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64390 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64390] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64391] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26462,7 +26462,7 @@ CVE_STATUS[CVE-2026-64399] = "cpe-stable-backport: Backported in 6.12.96"
 
 # CVE-2026-64400 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64401 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64401] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64402] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26470,7 +26470,7 @@ CVE_STATUS[CVE-2026-64403] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64404] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64405 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64405] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64406] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26486,13 +26486,13 @@ CVE_STATUS[CVE-2026-64411] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64412] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64413 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64413] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64414] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64415] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64416 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64416] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64417] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26502,7 +26502,7 @@ CVE_STATUS[CVE-2026-64419] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64420] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64421 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64421] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64422] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26516,7 +26516,7 @@ CVE_STATUS[CVE-2026-64426] = "fixed-version: only affects 6.13 onwards"
 
 CVE_STATUS[CVE-2026-64427] = "fixed-version: only affects 7.1 onwards"
 
-# CVE-2026-64428 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64428] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64429] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26528,7 +26528,7 @@ CVE_STATUS[CVE-2026-64432] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64433] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64434 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64434] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64435] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26536,13 +26536,13 @@ CVE_STATUS[CVE-2026-64436] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64437] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64438 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64438] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64439] = "fixed-version: only affects 6.15 onwards"
 
 CVE_STATUS[CVE-2026-64440] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64441 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64441] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64442] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26582,9 +26582,9 @@ CVE_STATUS[CVE-2026-64459] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-64460] = "fixed-version: only affects 6.17 onwards"
 
-# CVE-2026-64461 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64461] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64462 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64462] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64463] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26604,7 +26604,7 @@ CVE_STATUS[CVE-2026-64470] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64471] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64472 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64472] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64473] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26622,7 +26622,7 @@ CVE_STATUS[CVE-2026-64479] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64480] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64481 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64481] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64482] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26636,7 +26636,7 @@ CVE_STATUS[CVE-2026-64486] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64487] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64488 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64488] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64489] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26646,7 +26646,7 @@ CVE_STATUS[CVE-2026-64491] = "fixed-version: only affects 6.18 onwards"
 
 CVE_STATUS[CVE-2026-64492] = "fixed-version: only affects 6.13 onwards"
 
-# CVE-2026-64493 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64493] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64494] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26674,13 +26674,13 @@ CVE_STATUS[CVE-2026-64505] = "cpe-stable-backport: Backported in 6.12.96"
 
 CVE_STATUS[CVE-2026-64506] = "fixed-version: only affects 7.1 onwards"
 
-# CVE-2026-64507 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64507] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64508 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64508] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64509 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64509] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64510 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64510] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64511] = "cpe-stable-backport: Backported in 6.12.96"
 
@@ -26720,57 +26720,57 @@ CVE_STATUS[CVE-2026-64528] = "cpe-stable-backport: Backported in 6.12.93"
 
 CVE_STATUS[CVE-2026-64529] = "cpe-stable-backport: Backported in 6.12.95"
 
-# CVE-2026-64530 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64530] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64531 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64531] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64532 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64532] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64533 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64533] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64534 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64534] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64535 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64535] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64536] = "cpe-stable-backport: Backported in 6.12.96"
 
-# CVE-2026-64537 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64537] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64538 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64538] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64539 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64539] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64540 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64540] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64541 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64541] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64542 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64542] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64543 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64543] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64544 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64544] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64545 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64545] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64546 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64546] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64547 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64547] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64548 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64548] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64549 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64549] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64550 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64550] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64551 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64551] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64552 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64552] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64553 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64553] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64554 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64554] = "cpe-stable-backport: Backported in 6.12.97"
 
-# CVE-2026-64555 may need backporting (fixed from 6.12.97)
+CVE_STATUS[CVE-2026-64555] = "cpe-stable-backport: Backported in 6.12.97"
 
 CVE_STATUS[CVE-2026-64600] = "cpe-stable-backport: Backported in 6.12.96"
 

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/bsp/armel-iproc/10-14-pci-pcie-xgs-iproc.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.12.y/bisdn-kmeta/bsp/armel-iproc/10-14-pci-pcie-xgs-iproc.patch
@@ -56,17 +56,17 @@ diff --git a/drivers/pci/controller/pcie-iproc.h b/drivers/pci/controller/pcie-i
 index 969ded03b8c2..c6eef4e61a19 100644
 --- a/drivers/pci/controller/pcie-iproc.h
 +++ b/drivers/pci/controller/pcie-iproc.h
-@@ -91,6 +91,9 @@ struct iproc_pcie {
+@@ -90,6 +90,9 @@ struct iproc_pcie {
  	phys_addr_t base_addr;
  	struct resource mem;
  	struct phy *phy;
 +#ifdef CONFIG_PCIE_XGS_IPROC
 +	struct phy_device *mdio_phy;
 +#endif
- 	int (*map_irq)(const struct pci_dev *, u8, u8);
  	bool ep_is_internal;
  	bool iproc_cfg_read;
-@@ -110,9 +113,11 @@ struct iproc_pcie {
+ 	bool rej_unconfig_pf;
+@@ -109,9 +112,11 @@ struct iproc_pcie {
  	struct iproc_msi *msi;
  };
  
@@ -83,7 +83,7 @@ new file mode 100644
 index 000000000000..0168f24fbb19
 --- /dev/null
 +++ b/drivers/pci/controller/pcie-xgs-iproc.c
-@@ -0,0 +1,499 @@
+@@ -0,0 +1,497 @@
 +/*
 + * Copyright (C) 2014 Hauke Mehrtens <hauke@hauke-m.de>
 + * Copyright (C) 2015 Broadcom Corporation
@@ -470,7 +470,7 @@ index 000000000000..0168f24fbb19
 +	host->dev.parent = dev;
 +	host->ops = &iproc_pcie_ops;
 +	host->sysdata = pcie;
-+	host->map_irq = pcie->map_irq;
++	host->map_irq = of_irq_parse_and_map_pci;
 +	host->swizzle_irq = pci_common_swizzle;
 +
 +	ret = pci_host_probe(host);
@@ -537,8 +537,6 @@ index 000000000000..0168f24fbb19
 +
 +	/* HX4/KT2/HR2 */
 +	pcie_sw_wa_func("pcie_wrong_gen2", pcie);
-+
-+	pcie->map_irq = of_irq_parse_and_map_pci;
 +
 +	ret = iproc_pcie_setup(pcie, &bridge->windows);
 +	if (ret)

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.95"
+LINUX_VERSION ?= "6.12.96"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "296aabce459470a4c1b68ffd0c0c0920e563aaad"
+SRCREV_machine ?= "6d15a1029d425b15c59463910ebdccc4afe760d6"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.93"
+LINUX_VERSION ?= "6.12.94"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "1d3a00d3bacff25652c96e1527610c69e91f7c38"
+SRCREV_machine ?= "0b8f247169e487eff2d4c2dd531bc43f7efda2cb"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.94"
+LINUX_VERSION ?= "6.12.95"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "0b8f247169e487eff2d4c2dd531bc43f7efda2cb"
+SRCREV_machine ?= "296aabce459470a4c1b68ffd0c0c0920e563aaad"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.99"
+LINUX_VERSION ?= "6.12.100"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "720e8bcaa674dfa40b989207d6cdb44b3aaa8db6"
+SRCREV_machine ?= "52a355b23cd2dd77b683ed1a1bbe2b7408bd9c74"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.98"
+LINUX_VERSION ?= "6.12.99"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "588b2d2beb4b3d1878a7fd9cdc876bab53326476"
+SRCREV_machine ?= "720e8bcaa674dfa40b989207d6cdb44b3aaa8db6"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12

--- a/recipes-kernel/linux/linux-yocto-onl_6.12.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.12.bb
@@ -7,9 +7,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.12.96"
+LINUX_VERSION ?= "6.12.98"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.12.y
-SRCREV_machine ?= "6d15a1029d425b15c59463910ebdccc4afe760d6"
+SRCREV_machine ?= "588b2d2beb4b3d1878a7fd9cdc876bab53326476"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.12


### PR DESCRIPTION
Update linux 6.12 to 6.12.99. .98 is a hotfix for .97, so .97 was skipped.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.99
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.98
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.97
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.96
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.95
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.12.94