### PR TITLE
v5.x: linux-yocto-onl: update 6.6 to 6.6.146

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 09:39:21.706468+00:00 for kernel version 6.6.143
+# Generated at 2026-07-28 12:33:04.854781+00:00 for kernel version 6.6.144
 # From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.143"
+    this_version = "6.6.144"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -24035,7 +24035,8 @@ CVE_CHECK_IGNORE += "CVE-2025-22128"
 
 # CVE-2025-23130 needs backporting (fixed from 6.15)
 
-# CVE-2025-23131 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2025-23131"
 
 # CVE-2025-23132 needs backporting (fixed from 6.15)
 
@@ -31304,7 +31305,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23275"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23277"
 
-# CVE-2026-23278 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-23278"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23279"
@@ -33055,7 +33057,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43008"
 
 # CVE-2026-43009 needs backporting (fixed from 7.0)
 
-# CVE-2026-43010 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-43010"
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43011"
@@ -35112,7 +35115,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46052"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46053"
 
-# CVE-2026-46054 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46054"
 
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46055"
@@ -35348,7 +35352,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46133"
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46134"
 
-# CVE-2026-46135 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46135"
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46136"
@@ -35362,7 +35367,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46138"
 # fixed-version: only affects 6.12.23 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46139"
 
-# CVE-2026-46140 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46140"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46141"
@@ -35652,7 +35658,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46240"
 
 # CVE-2026-46241 needs backporting (fixed from 7.1)
 
-# CVE-2026-46242 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46242"
 
 # cpe-stable-backport: Backported in 6.6.142
 CVE_CHECK_IGNORE += "CVE-2026-46243"
@@ -35680,7 +35687,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46250"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-46251"
 
-# CVE-2026-46252 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46252"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-46253"
@@ -35908,7 +35916,8 @@ CVE_CHECK_IGNORE += "CVE-2026-46329"
 
 # CVE-2026-46330 needs backporting (fixed from 7.0)
 
-# CVE-2026-46331 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-46331"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46332"
@@ -35931,7 +35940,8 @@ CVE_CHECK_IGNORE += "CVE-2026-52907"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-52908"
 
-# CVE-2026-52909 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-52909"
 
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-52910"
@@ -35987,7 +35997,8 @@ CVE_CHECK_IGNORE += "CVE-2026-52926"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-52927"
 
-# CVE-2026-52928 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-52928"
 
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-52929"
@@ -36581,9 +36592,11 @@ CVE_CHECK_IGNORE += "CVE-2026-53136"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53137"
 
-# CVE-2026-53138 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53138"
 
-# CVE-2026-53139 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53139"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53140"
@@ -36618,7 +36631,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53149"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53150"
 
-# CVE-2026-53151 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53151"
 
 # fixed-version: only affects 6.12.78 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53152"
@@ -36634,7 +36648,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53155"
 
 # CVE-2026-53156 needs backporting (fixed from 7.1)
 
-# CVE-2026-53157 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53157"
 
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53158"
@@ -36651,7 +36666,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53161"
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53162"
 
-# CVE-2026-53163 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53163"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53164"
@@ -36659,7 +36675,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53164"
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53165"
 
-# CVE-2026-53167 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53167"
 
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53168"
@@ -37116,12 +37133,14 @@ CVE_CHECK_IGNORE += "CVE-2026-53323"
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53324"
 
-# CVE-2026-53325 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53325"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53326"
 
-# CVE-2026-53327 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53327"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53328"
@@ -37214,14 +37233,17 @@ CVE_CHECK_IGNORE += "CVE-2026-53357"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53358"
 
-# CVE-2026-53359 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53359"
 
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53360"
 
-# CVE-2026-53361 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53361"
 
-# CVE-2026-53362 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53362"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53363"
@@ -37232,7 +37254,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53364"
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53365"
 
-# CVE-2026-53366 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53366"
 
 # fixed-version: only affects 6.17.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53367"
@@ -37274,15 +37297,20 @@ CVE_CHECK_IGNORE += "CVE-2026-53379"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53380"
 
-# CVE-2026-53381 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53381"
 
-# CVE-2026-53382 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53382"
 
-# CVE-2026-53383 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53383"
 
-# CVE-2026-53384 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53384"
 
-# CVE-2026-53385 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53385"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53386"
@@ -37290,14 +37318,17 @@ CVE_CHECK_IGNORE += "CVE-2026-53386"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53387"
 
-# CVE-2026-53388 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53388"
 
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53389"
 
-# CVE-2026-53390 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53390"
 
-# CVE-2026-53391 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53391"
 
 # CVE-2026-53392 may need backporting (fixed from 6.6.145)
 
@@ -37312,9 +37343,11 @@ CVE_CHECK_IGNORE += "CVE-2026-53395"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53396"
 
-# CVE-2026-53397 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53397"
 
-# CVE-2026-53398 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53398"
 
 # CVE-2026-53399 may need backporting (fixed from 6.6.145)
 
@@ -37324,60 +37357,77 @@ CVE_CHECK_IGNORE += "CVE-2026-53396"
 
 # CVE-2026-53402 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-53403 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-53403"
 
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63793"
 
-# CVE-2026-63794 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63794"
 
-# CVE-2026-63795 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63795"
 
-# CVE-2026-63796 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63796"
 
-# CVE-2026-63797 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63797"
 
-# CVE-2026-63798 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63798"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63799"
 
-# CVE-2026-63800 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63800"
 
-# CVE-2026-63801 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63801"
 
-# CVE-2026-63802 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63802"
 
-# CVE-2026-63803 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63803"
 
-# CVE-2026-63804 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63804"
 
 # CVE-2026-63805 needs backporting (fixed from 7.2rc1)
 
 # CVE-2026-63806 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-63807 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63807"
 
-# CVE-2026-63808 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63808"
 
-# CVE-2026-63809 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63809"
 
 # CVE-2026-63810 may need backporting (fixed from 6.6.145)
 
 # CVE-2026-63811 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63812 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63812"
 
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63813"
 
-# CVE-2026-63814 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63814"
 
 # CVE-2026-63815 may need backporting (fixed from 6.6.145)
 
 # CVE-2026-63816 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-63817 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63817"
 
 # CVE-2026-63818 may need backporting (fixed from 6.6.145)
 
@@ -37386,38 +37436,51 @@ CVE_CHECK_IGNORE += "CVE-2026-63813"
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63820"
 
-# CVE-2026-63821 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63821"
 
-# CVE-2026-63822 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63822"
 
-# CVE-2026-63823 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63823"
 
-# CVE-2026-63824 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63824"
 
 # CVE-2026-63825 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63826 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63826"
 
-# CVE-2026-63827 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63827"
 
-# CVE-2026-63828 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63828"
 
 # CVE-2026-63829 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-63830 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63830"
 
-# CVE-2026-63831 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63831"
 
 # fixed-version: only affects 6.12.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63832"
 
-# CVE-2026-63833 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63833"
 
-# CVE-2026-63834 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63834"
 
-# CVE-2026-63835 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63835"
 
-# CVE-2026-63836 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-63836"
 
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2026-63837"
@@ -38441,13 +38504,15 @@ CVE_CHECK_IGNORE += "CVE-2026-64186"
 
 # CVE-2026-64187 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-64188 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64188"
 
 # CVE-2026-64189 may need backporting (fixed from 6.6.145)
 
 # CVE-2026-64190 needs backporting (fixed from 7.1)
 
-# CVE-2026-64191 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64191"
 
 # CVE-2026-64192 needs backporting (fixed from 7.2rc2)
 
@@ -38562,29 +38627,36 @@ CVE_CHECK_IGNORE += "CVE-2026-64242"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-64243"
 
-# CVE-2026-64244 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64244"
 
-# CVE-2026-64245 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64245"
 
-# CVE-2026-64246 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64246"
 
-# CVE-2026-64247 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64247"
 
 # CVE-2026-64248 may need backporting (fixed from 6.6.145)
 
-# CVE-2026-64249 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64249"
 
 # CVE-2026-64250 may need backporting (fixed from 6.6.145)
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64251"
 
-# CVE-2026-64252 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64252"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64253"
 
-# CVE-2026-64254 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64254"
 
 # CVE-2026-64255 needs backporting (fixed from 7.2rc1)
 
@@ -39222,7 +39294,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64527"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-64528"
 
-# CVE-2026-64529 may need backporting (fixed from 6.6.144)
+# cpe-stable-backport: Backported in 6.6.144
+CVE_CHECK_IGNORE += "CVE-2026-64529"
 
 # CVE-2026-64530 may need backporting (fixed from 6.6.145)
 

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 12:33:04.854781+00:00 for kernel version 6.6.144
+# Generated at 2026-07-28 12:34:49.179092+00:00 for kernel version 6.6.145
 # From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.144"
+    this_version = "6.6.145"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -30339,7 +30339,8 @@ CVE_CHECK_IGNORE += "CVE-2025-71287"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2025-71288"
 
-# CVE-2025-71289 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2025-71289"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2025-71290"
@@ -32213,7 +32214,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31500"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31501"
 
-# CVE-2026-31502 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-31502"
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31503"
@@ -33371,7 +33373,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43117"
 
 # CVE-2026-43118 needs backporting (fixed from 7.0)
 
-# CVE-2026-43119 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-43119"
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43120"
@@ -33646,7 +33649,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43214"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43215"
 
-# CVE-2026-43216 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-43216"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43217"
@@ -34338,7 +34342,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43454"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43455"
 
-# CVE-2026-43456 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-43456"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43457"
@@ -36278,7 +36283,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53023"
 # fixed-version: only affects 6.18.4 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53026"
 
-# CVE-2026-53027 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53027"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53028"
@@ -37153,7 +37159,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53329"
 # cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-53331"
 
-# CVE-2026-53332 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53332"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53333"
@@ -37330,9 +37337,11 @@ CVE_CHECK_IGNORE += "CVE-2026-53390"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-53391"
 
-# CVE-2026-53392 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53392"
 
-# CVE-2026-53393 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53393"
 
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-53394"
@@ -37349,13 +37358,16 @@ CVE_CHECK_IGNORE += "CVE-2026-53397"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-53398"
 
-# CVE-2026-53399 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53399"
 
-# CVE-2026-53400 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53400"
 
 # CVE-2026-53401 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-53402 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-53402"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-53403"
@@ -37398,7 +37410,8 @@ CVE_CHECK_IGNORE += "CVE-2026-63804"
 
 # CVE-2026-63805 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-63806 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63806"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63807"
@@ -37409,7 +37422,8 @@ CVE_CHECK_IGNORE += "CVE-2026-63808"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63809"
 
-# CVE-2026-63810 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63810"
 
 # CVE-2026-63811 needs backporting (fixed from 7.2rc1)
 
@@ -37422,14 +37436,17 @@ CVE_CHECK_IGNORE += "CVE-2026-63813"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63814"
 
-# CVE-2026-63815 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63815"
 
-# CVE-2026-63816 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63816"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63817"
 
-# CVE-2026-63818 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63818"
 
 # CVE-2026-63819 needs backporting (fixed from 7.2rc1)
 
@@ -37459,7 +37476,8 @@ CVE_CHECK_IGNORE += "CVE-2026-63827"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63828"
 
-# CVE-2026-63829 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-63829"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-63830"
@@ -38502,12 +38520,14 @@ CVE_CHECK_IGNORE += "CVE-2026-64185"
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64186"
 
-# CVE-2026-64187 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64187"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-64188"
 
-# CVE-2026-64189 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64189"
 
 # CVE-2026-64190 needs backporting (fixed from 7.1)
 
@@ -38518,7 +38538,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64191"
 
 # CVE-2026-64205 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64206 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64206"
 
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64207"
@@ -38639,12 +38660,14 @@ CVE_CHECK_IGNORE += "CVE-2026-64246"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-64247"
 
-# CVE-2026-64248 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64248"
 
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-64249"
 
-# CVE-2026-64250 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64250"
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64251"
@@ -38689,35 +38712,47 @@ CVE_CHECK_IGNORE += "CVE-2026-64264"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64265"
 
-# CVE-2026-64266 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64266"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64267"
 
-# CVE-2026-64268 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64268"
 
-# CVE-2026-64269 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64269"
 
-# CVE-2026-64270 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64270"
 
-# CVE-2026-64271 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64271"
 
-# CVE-2026-64272 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64272"
 
-# CVE-2026-64273 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64273"
 
-# CVE-2026-64274 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64274"
 
-# CVE-2026-64275 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64275"
 
-# CVE-2026-64276 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64276"
 
-# CVE-2026-64277 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64277"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64278"
 
-# CVE-2026-64279 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64279"
 
 # CVE-2026-64280 needs backporting (fixed from 7.2rc1)
 
@@ -38736,9 +38771,11 @@ CVE_CHECK_IGNORE += "CVE-2026-64284"
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64285"
 
-# CVE-2026-64286 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64286"
 
-# CVE-2026-64287 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64287"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64288"
@@ -38758,34 +38795,43 @@ CVE_CHECK_IGNORE += "CVE-2026-64292"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64293"
 
-# CVE-2026-64294 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64294"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64295"
 
-# CVE-2026-64296 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64296"
 
-# CVE-2026-64297 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64297"
 
-# CVE-2026-64298 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64298"
 
-# CVE-2026-64299 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64299"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64300"
 
-# CVE-2026-64301 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64301"
 
 # fixed-version: only affects 6.18.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64302"
 
-# CVE-2026-64303 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64303"
 
-# CVE-2026-64304 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64304"
 
 # CVE-2026-64305 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64306 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64306"
 
 # fixed-version: only affects 6.12.75 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64307"
@@ -38802,38 +38848,49 @@ CVE_CHECK_IGNORE += "CVE-2026-64310"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64311"
 
-# CVE-2026-64312 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64312"
 
-# CVE-2026-64313 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64313"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64314"
 
-# CVE-2026-64315 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64315"
 
-# CVE-2026-64316 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64316"
 
-# CVE-2026-64317 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64317"
 
-# CVE-2026-64318 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64318"
 
-# CVE-2026-64319 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64319"
 
 # CVE-2026-64320 needs backporting (fixed from 7.2rc1)
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64321"
 
-# CVE-2026-64322 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64322"
 
-# CVE-2026-64323 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64323"
 
-# CVE-2026-64324 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64324"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64325"
 
-# CVE-2026-64326 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64326"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64327"
@@ -38841,55 +38898,76 @@ CVE_CHECK_IGNORE += "CVE-2026-64327"
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64328"
 
-# CVE-2026-64329 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64329"
 
-# CVE-2026-64330 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64330"
 
-# CVE-2026-64331 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64331"
 
-# CVE-2026-64332 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64332"
 
-# CVE-2026-64333 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64333"
 
-# CVE-2026-64334 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64334"
 
-# CVE-2026-64335 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64335"
 
-# CVE-2026-64336 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64336"
 
-# CVE-2026-64337 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64337"
 
-# CVE-2026-64338 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64338"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64339"
 
-# CVE-2026-64340 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64340"
 
 # CVE-2026-64341 needs backporting (fixed from 7.2rc3)
 
-# CVE-2026-64342 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64342"
 
-# CVE-2026-64343 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64343"
 
-# CVE-2026-64344 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64344"
 
-# CVE-2026-64345 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64345"
 
-# CVE-2026-64346 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64346"
 
-# CVE-2026-64347 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64347"
 
-# CVE-2026-64348 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64348"
 
 # fixed-version: only affects 6.18.32 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64349"
 
-# CVE-2026-64350 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64350"
 
-# CVE-2026-64351 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64351"
 
-# CVE-2026-64352 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64352"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64353"
@@ -38897,7 +38975,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64353"
 # fixed-version: only affects 6.11.6 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64354"
 
-# CVE-2026-64355 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64355"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64356"
@@ -38905,21 +38984,29 @@ CVE_CHECK_IGNORE += "CVE-2026-64356"
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64357"
 
-# CVE-2026-64358 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64358"
 
-# CVE-2026-64359 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64359"
 
-# CVE-2026-64360 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64360"
 
-# CVE-2026-64361 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64361"
 
-# CVE-2026-64362 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64362"
 
-# CVE-2026-64363 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64363"
 
-# CVE-2026-64364 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64364"
 
-# CVE-2026-64365 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64365"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64366"
@@ -38927,100 +39014,138 @@ CVE_CHECK_IGNORE += "CVE-2026-64366"
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64367"
 
-# CVE-2026-64368 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64368"
 
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64369"
 
-# CVE-2026-64370 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64370"
 
-# CVE-2026-64371 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64371"
 
-# CVE-2026-64372 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64372"
 
-# CVE-2026-64373 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64373"
 
-# CVE-2026-64374 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64374"
 
-# CVE-2026-64375 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64375"
 
-# CVE-2026-64376 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64376"
 
 # CVE-2026-64377 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64378 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64378"
 
-# CVE-2026-64379 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64379"
 
-# CVE-2026-64380 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64380"
 
-# CVE-2026-64381 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64381"
 
-# CVE-2026-64382 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64382"
 
-# CVE-2026-64383 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64383"
 
-# CVE-2026-64384 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64384"
 
-# CVE-2026-64385 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64385"
 
-# CVE-2026-64386 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64386"
 
-# CVE-2026-64387 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64387"
 
 # CVE-2026-64388 needs backporting (fixed from 7.2rc1)
 
 # CVE-2026-64389 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64390 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64390"
 
 # CVE-2026-64391 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64392 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64392"
 
-# CVE-2026-64393 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64393"
 
-# CVE-2026-64394 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64394"
 
-# CVE-2026-64395 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64395"
 
-# CVE-2026-64396 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64396"
 
-# CVE-2026-64397 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64397"
 
-# CVE-2026-64398 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64398"
 
-# CVE-2026-64399 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64399"
 
 # CVE-2026-64400 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64401 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64401"
 
-# CVE-2026-64402 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64402"
 
-# CVE-2026-64403 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64403"
 
 # fixed-version: only affects 6.12.6 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64404"
 
-# CVE-2026-64405 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64405"
 
-# CVE-2026-64406 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64406"
 
-# CVE-2026-64407 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64407"
 
-# CVE-2026-64408 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64408"
 
-# CVE-2026-64409 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64409"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64410"
 
-# CVE-2026-64411 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64411"
 
-# CVE-2026-64412 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64412"
 
-# CVE-2026-64413 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64413"
 
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64414"
@@ -39031,24 +39156,31 @@ CVE_CHECK_IGNORE += "CVE-2026-64415"
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64416"
 
-# CVE-2026-64417 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64417"
 
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64418"
 
-# CVE-2026-64419 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64419"
 
-# CVE-2026-64420 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64420"
 
-# CVE-2026-64421 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64421"
 
-# CVE-2026-64422 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64422"
 
-# CVE-2026-64423 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64423"
 
 # CVE-2026-64424 needs backporting (fixed from 7.2rc2)
 
-# CVE-2026-64425 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64425"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64426"
@@ -39056,73 +39188,98 @@ CVE_CHECK_IGNORE += "CVE-2026-64426"
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64427"
 
-# CVE-2026-64428 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64428"
 
-# CVE-2026-64429 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64429"
 
-# CVE-2026-64430 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64430"
 
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64431"
 
-# CVE-2026-64432 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64432"
 
-# CVE-2026-64433 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64433"
 
-# CVE-2026-64434 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64434"
 
-# CVE-2026-64435 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64435"
 
-# CVE-2026-64436 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64436"
 
-# CVE-2026-64437 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64437"
 
-# CVE-2026-64438 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64438"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64439"
 
-# CVE-2026-64440 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64440"
 
-# CVE-2026-64441 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64441"
 
-# CVE-2026-64442 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64442"
 
-# CVE-2026-64443 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64443"
 
-# CVE-2026-64444 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64444"
 
-# CVE-2026-64445 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64445"
 
-# CVE-2026-64446 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64446"
 
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64447"
 
-# CVE-2026-64448 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64448"
 
-# CVE-2026-64449 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64449"
 
-# CVE-2026-64450 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64450"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64451"
 
-# CVE-2026-64452 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64452"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64453"
 
-# CVE-2026-64454 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64454"
 
-# CVE-2026-64455 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64455"
 
-# CVE-2026-64456 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64456"
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64457"
 
-# CVE-2026-64458 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64458"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64459"
@@ -39130,16 +39287,20 @@ CVE_CHECK_IGNORE += "CVE-2026-64459"
 # fixed-version: only affects 6.17 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64460"
 
-# CVE-2026-64461 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64461"
 
-# CVE-2026-64462 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64462"
 
-# CVE-2026-64463 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64463"
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64464"
 
-# CVE-2026-64465 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64465"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64466"
@@ -39147,52 +39308,70 @@ CVE_CHECK_IGNORE += "CVE-2026-64466"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64467"
 
-# CVE-2026-64468 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64468"
 
-# CVE-2026-64469 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64469"
 
-# CVE-2026-64470 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64470"
 
-# CVE-2026-64471 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64471"
 
-# CVE-2026-64472 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64472"
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64473"
 
-# CVE-2026-64474 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64474"
 
-# CVE-2026-64475 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64475"
 
-# CVE-2026-64476 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64476"
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64477"
 
-# CVE-2026-64478 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64478"
 
-# CVE-2026-64479 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64479"
 
-# CVE-2026-64480 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64480"
 
 # CVE-2026-64481 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64482 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64482"
 
-# CVE-2026-64483 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64483"
 
-# CVE-2026-64484 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64484"
 
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64485"
 
-# CVE-2026-64486 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64486"
 
-# CVE-2026-64487 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64487"
 
-# CVE-2026-64488 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64488"
 
-# CVE-2026-64489 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64489"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64490"
@@ -39203,15 +39382,20 @@ CVE_CHECK_IGNORE += "CVE-2026-64491"
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64492"
 
-# CVE-2026-64493 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64493"
 
-# CVE-2026-64494 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64494"
 
-# CVE-2026-64495 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64495"
 
-# CVE-2026-64496 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64496"
 
-# CVE-2026-64497 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64497"
 
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64498"
@@ -39219,7 +39403,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64498"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64499"
 
-# CVE-2026-64500 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64500"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64501"
@@ -39227,31 +39412,40 @@ CVE_CHECK_IGNORE += "CVE-2026-64501"
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64502"
 
-# CVE-2026-64503 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64503"
 
-# CVE-2026-64504 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64504"
 
-# CVE-2026-64505 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64505"
 
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64506"
 
-# CVE-2026-64507 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64507"
 
-# CVE-2026-64508 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64508"
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64509"
 
-# CVE-2026-64510 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64510"
 
-# CVE-2026-64511 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64511"
 
-# CVE-2026-64512 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64512"
 
 # CVE-2026-64513 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64514 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64514"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64515"
@@ -39297,58 +39491,82 @@ CVE_CHECK_IGNORE += "CVE-2026-64528"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-64529"
 
-# CVE-2026-64530 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64530"
 
-# CVE-2026-64531 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64531"
 
-# CVE-2026-64532 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64532"
 
-# CVE-2026-64533 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64533"
 
-# CVE-2026-64534 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64534"
 
-# CVE-2026-64535 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64535"
 
-# CVE-2026-64536 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64536"
 
-# CVE-2026-64537 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64537"
 
-# CVE-2026-64538 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64538"
 
 # CVE-2026-64539 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64540 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64540"
 
-# CVE-2026-64541 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64541"
 
 # CVE-2026-64542 needs backporting (fixed from 7.2rc1)
 
-# CVE-2026-64543 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64543"
 
-# CVE-2026-64544 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64544"
 
-# CVE-2026-64545 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64545"
 
-# CVE-2026-64546 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64546"
 
-# CVE-2026-64547 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64547"
 
-# CVE-2026-64548 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64548"
 
-# CVE-2026-64549 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64549"
 
-# CVE-2026-64550 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64550"
 
-# CVE-2026-64551 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64551"
 
-# CVE-2026-64552 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64552"
 
-# CVE-2026-64553 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64553"
 
-# CVE-2026-64554 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64554"
 
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64555"
 
-# CVE-2026-64600 may need backporting (fixed from 6.6.145)
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64600"
 

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,16 +1,18 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-06-02 08:09:43.342190+00:00 for kernel version 6.6.142
-# From cvelistV5 cve_2026-06-02_0700Z
+# Generated at 2026-07-28 09:39:21.706468+00:00 for kernel version 6.6.143
+# From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.142"
+    this_version = "6.6.143"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
 }
 do_cve_check[prefuncs] += "check_kernel_cve_status_version"
+
+# CVE-2018-10902 has no known resolution
 
 # fixed-version: Fixed from version 5.0
 CVE_CHECK_IGNORE += "CVE-2019-25160"
@@ -13516,6 +13518,8 @@ CVE_CHECK_IGNORE += "CVE-2023-7324"
 # cpe-stable-backport: Backported in 6.6.133
 CVE_CHECK_IGNORE += "CVE-2024-14027"
 
+# CVE-2024-14040 needs backporting (fixed from 6.12)
+
 # cpe-stable-backport: Backported in 6.6.17
 CVE_CHECK_IGNORE += "CVE-2024-26581"
 
@@ -22558,7 +22562,8 @@ CVE_CHECK_IGNORE += "CVE-2024-58091"
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2024-58092"
 
-# CVE-2024-58093 needs backporting (fixed from 6.15)
+# cpe-stable-backport: Backported in 6.6.87
+CVE_CHECK_IGNORE += "CVE-2024-58093"
 
 # CVE-2024-58094 needs backporting (fixed from 6.15)
 
@@ -23121,7 +23126,7 @@ CVE_CHECK_IGNORE += "CVE-2025-21815"
 # cpe-stable-backport: Backported in 6.6.93
 CVE_CHECK_IGNORE += "CVE-2025-21816"
 
-# fixed-version: only affects 6.13.2 onwards
+# fixed-version: only affects 6.12.96 onwards
 CVE_CHECK_IGNORE += "CVE-2025-21817"
 
 # cpe-stable-backport: Backported in 6.6.78
@@ -24030,7 +24035,7 @@ CVE_CHECK_IGNORE += "CVE-2025-22128"
 
 # CVE-2025-23130 needs backporting (fixed from 6.15)
 
-# CVE-2025-23131 needs backporting (fixed from 6.15)
+# CVE-2025-23131 may need backporting (fixed from 6.6.144)
 
 # CVE-2025-23132 needs backporting (fixed from 6.15)
 
@@ -26473,9 +26478,6 @@ CVE_CHECK_IGNORE += "CVE-2025-38551"
 
 # cpe-stable-backport: Backported in 6.6.101
 CVE_CHECK_IGNORE += "CVE-2025-38552"
-
-# cpe-stable-backport: Backported in 6.6.102
-CVE_CHECK_IGNORE += "CVE-2025-38553"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2025-38554"
@@ -29341,7 +29343,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68294"
 # cpe-stable-backport: Backported in 6.6.119
 CVE_CHECK_IGNORE += "CVE-2025-68295"
 
-# CVE-2025-68296 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2025-68296"
 
 # cpe-stable-backport: Backported in 6.6.119
 CVE_CHECK_IGNORE += "CVE-2025-68297"
@@ -29621,7 +29624,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68734"
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68735"
 
-# CVE-2025-68736 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2025-68736"
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2025-68737"
@@ -29715,7 +29719,8 @@ CVE_CHECK_IGNORE += "CVE-2025-68766"
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-68767"
 
-# CVE-2025-68768 needs backporting (fixed from 6.19)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2025-68768"
 
 # cpe-stable-backport: Backported in 6.6.120
 CVE_CHECK_IGNORE += "CVE-2025-68769"
@@ -30333,7 +30338,7 @@ CVE_CHECK_IGNORE += "CVE-2025-71287"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2025-71288"
 
-# CVE-2025-71289 needs backporting (fixed from 7.0)
+# CVE-2025-71289 may need backporting (fixed from 6.6.145)
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2025-71290"
@@ -30400,6 +30405,13 @@ CVE_CHECK_IGNORE += "CVE-2025-71311"
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2025-71312"
+
+# CVE-2025-71313 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2025-71314"
+
+# CVE-2025-71315 needs backporting (fixed from 6.19)
 
 # cpe-stable-backport: Backported in 6.6.121
 CVE_CHECK_IGNORE += "CVE-2026-22976"
@@ -31292,7 +31304,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23275"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23277"
 
-# CVE-2026-23278 needs backporting (fixed from 7.0)
+# CVE-2026-23278 may need backporting (fixed from 6.6.144)
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23279"
@@ -31488,7 +31500,8 @@ CVE_CHECK_IGNORE += "CVE-2026-23344"
 # fixed-version: only affects 6.13 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23345"
 
-# CVE-2026-23346 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-23346"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23347"
@@ -31953,7 +31966,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31417"
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-31418"
 
-# CVE-2026-31419 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-31419"
 
 # CVE-2026-31420 needs backporting (fixed from 7.0)
 
@@ -31990,7 +32004,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31430"
 # cpe-stable-backport: Backported in 6.6.137
 CVE_CHECK_IGNORE += "CVE-2026-31431"
 
-# CVE-2026-31432 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-31432"
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31433"
@@ -32150,7 +32165,8 @@ CVE_CHECK_IGNORE += "CVE-2026-31484"
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31485"
 
-# CVE-2026-31486 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-31486"
 
 # CVE-2026-31487 needs backporting (fixed from 7.0)
 
@@ -32195,7 +32211,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31500"
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31501"
 
-# CVE-2026-31502 needs backporting (fixed from 7.0)
+# CVE-2026-31502 may need backporting (fixed from 6.6.145)
 
 # cpe-stable-backport: Backported in 6.6.131
 CVE_CHECK_IGNORE += "CVE-2026-31503"
@@ -32412,7 +32428,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31577"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31578"
 
-# CVE-2026-31579 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31579 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31580"
@@ -32450,7 +32466,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31590"
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31591"
 
-# CVE-2026-31592 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31592 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.11 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31593"
@@ -32491,7 +32507,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31604"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31605"
 
-# CVE-2026-31606 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31606 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31607"
@@ -32732,8 +32748,6 @@ CVE_CHECK_IGNORE += "CVE-2026-31686"
 # cpe-stable-backport: Backported in 6.6.126
 CVE_CHECK_IGNORE += "CVE-2026-31687"
 
-# CVE-2026-31688 needs backporting (fixed from 7.0)
-
 # cpe-stable-backport: Backported in 6.6.135
 CVE_CHECK_IGNORE += "CVE-2026-31689"
 
@@ -32748,7 +32762,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31691"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-31693"
 
-# cpe-stable-backport: Backported in 6.6.136
+# fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-31694"
 
 # cpe-stable-backport: Backported in 6.6.134
@@ -32784,7 +32798,7 @@ CVE_CHECK_IGNORE += "CVE-2026-31704"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-31705"
 
-# CVE-2026-31706 needs backporting (fixed from 7.1rc1)
+# CVE-2026-31706 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.141
 CVE_CHECK_IGNORE += "CVE-2026-31707"
@@ -33041,7 +33055,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43008"
 
 # CVE-2026-43009 needs backporting (fixed from 7.0)
 
-# CVE-2026-43010 needs backporting (fixed from 7.0)
+# CVE-2026-43010 may need backporting (fixed from 6.6.144)
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43011"
@@ -33067,7 +33081,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43017"
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43018"
 
-# CVE-2026-43019 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43019"
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43020"
@@ -33221,7 +33236,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43071"
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43072"
 
-# CVE-2026-43073 needs backporting (fixed from 7.1rc1)
+# CVE-2026-43073 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43074"
@@ -33264,7 +33279,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43086"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43087"
 
-# CVE-2026-43088 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43088"
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43089"
@@ -33344,23 +33360,21 @@ CVE_CHECK_IGNORE += "CVE-2026-43114"
 
 # CVE-2026-43115 needs backporting (fixed from 7.0)
 
-# CVE-2026-43116 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43116"
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43117"
 
 # CVE-2026-43118 needs backporting (fixed from 7.0)
 
-# CVE-2026-43119 needs backporting (fixed from 7.0)
+# CVE-2026-43119 may need backporting (fixed from 6.6.145)
 
 # cpe-stable-backport: Backported in 6.6.136
 CVE_CHECK_IGNORE += "CVE-2026-43120"
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43121"
-
-# fixed-version: only affects 6.18 onwards
-CVE_CHECK_IGNORE += "CVE-2026-43122"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43123"
@@ -33377,7 +33391,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43124"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43128"
 
-# CVE-2026-43129 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43129"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43130"
@@ -33628,7 +33643,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43214"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43215"
 
-# CVE-2026-43216 needs backporting (fixed from 7.0)
+# CVE-2026-43216 may need backporting (fixed from 6.6.145)
 
 # fixed-version: only affects 6.15 onwards
 CVE_CHECK_IGNORE += "CVE-2026-43217"
@@ -33636,7 +33651,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43217"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43218"
 
-# CVE-2026-43219 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43219"
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-43220"
@@ -33697,7 +33713,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43238"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43239"
 
-# cpe-stable-backport: Backported in 6.6.128
+# cpe-stable-backport: Backported in 6.6.143
 CVE_CHECK_IGNORE += "CVE-2026-43240"
 
 # cpe-stable-backport: Backported in 6.6.128
@@ -33878,7 +33894,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43301"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43302"
 
-# CVE-2026-43303 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43303"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43304"
@@ -33898,7 +33915,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43307"
 
 # CVE-2026-43310 needs backporting (fixed from 7.0)
 
-# CVE-2026-43311 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43311"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-43312"
@@ -33955,7 +33973,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43329"
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43330"
 
-# CVE-2026-43331 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43331"
 
 # cpe-stable-backport: Backported in 6.6.134
 CVE_CHECK_IGNORE += "CVE-2026-43332"
@@ -34218,13 +34237,8 @@ CVE_CHECK_IGNORE += "CVE-2026-43419"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43420"
 
-# CVE-2026-43421 needs backporting (fixed from 7.0)
-
-# fixed-version: only affects 6.18.17 onwards
-CVE_CHECK_IGNORE += "CVE-2026-43422"
-
-# fixed-version: only affects 6.18.17 onwards
-CVE_CHECK_IGNORE += "CVE-2026-43423"
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-43421"
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43424"
@@ -34321,7 +34335,7 @@ CVE_CHECK_IGNORE += "CVE-2026-43454"
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43455"
 
-# CVE-2026-43456 needs backporting (fixed from 7.0)
+# CVE-2026-43456 may need backporting (fixed from 6.6.145)
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-43457"
@@ -34510,7 +34524,8 @@ CVE_CHECK_IGNORE += "CVE-2026-45848"
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-45849"
 
-# CVE-2026-45850 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-45850"
 
 # cpe-stable-backport: Backported in 6.6.128
 CVE_CHECK_IGNORE += "CVE-2026-45851"
@@ -34740,7 +34755,8 @@ CVE_CHECK_IGNORE += "CVE-2026-45928"
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-45929"
 
-# CVE-2026-45930 needs backporting (fixed from 7.0)
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-45930"
 
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-45931"
@@ -34917,9 +34933,6 @@ CVE_CHECK_IGNORE += "CVE-2026-45990"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-45991"
 
-# fixed-version: only affects 7.1rc1 onwards
-CVE_CHECK_IGNORE += "CVE-2026-45992"
-
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-45993"
 
@@ -34983,7 +34996,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46012"
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46013"
 
-# CVE-2026-46014 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46014 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46015"
@@ -34991,7 +35004,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46015"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46016"
 
-# CVE-2026-46017 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46017 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46018"
@@ -35035,7 +35048,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46030"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46031"
 
-# CVE-2026-46032 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46032 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46033"
@@ -35070,7 +35083,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46042"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46043"
 
-# CVE-2026-46044 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46044 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46045"
@@ -35099,7 +35112,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46052"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46053"
 
-# CVE-2026-46054 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46054 may need backporting (fixed from 6.6.144)
 
 # fixed-version: only affects 7.0 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46055"
@@ -35113,7 +35126,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46057"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46058"
 
-# CVE-2026-46059 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46059 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46060"
@@ -35133,7 +35146,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46064"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46065"
 
-# CVE-2026-46066 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46066 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.19 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46067"
@@ -35147,7 +35160,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46069"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46070"
 
-# CVE-2026-46071 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46071 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46072"
@@ -35161,7 +35174,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46074"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46075"
 
-# CVE-2026-46076 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46076 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46077"
@@ -35202,12 +35215,13 @@ CVE_CHECK_IGNORE += "CVE-2026-46088"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46089"
 
-# CVE-2026-46090 needs backporting (fixed from 7.1rc2)
+# CVE-2026-46090 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46091"
 
-# CVE-2026-46092 needs backporting (fixed from 7.1rc1)
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46092"
 
 # fixed-version: only affects 6.9 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46093"
@@ -35334,7 +35348,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46133"
 # fixed-version: only affects 6.14 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46134"
 
-# CVE-2026-46135 needs backporting (fixed from 7.1rc2)
+# CVE-2026-46135 may need backporting (fixed from 6.6.144)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46136"
@@ -35348,7 +35362,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46138"
 # fixed-version: only affects 6.12.23 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46139"
 
-# CVE-2026-46140 may need backporting (fixed from 6.7)
+# CVE-2026-46140 may need backporting (fixed from 6.6.144)
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46141"
@@ -35368,9 +35382,9 @@ CVE_CHECK_IGNORE += "CVE-2026-46145"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46146"
 
-# CVE-2026-46147 needs backporting (fixed from 7.1rc2)
+# CVE-2026-46147 needs backporting (fixed from 7.1)
 
-# CVE-2026-46148 needs backporting (fixed from 7.1rc3)
+# CVE-2026-46148 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46149"
@@ -35384,7 +35398,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46151"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46152"
 
-# CVE-2026-46153 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46153 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46154"
@@ -35395,7 +35409,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46155"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46156"
 
-# CVE-2026-46157 needs backporting (fixed from 7.1rc2)
+# CVE-2026-46157 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.142
 CVE_CHECK_IGNORE += "CVE-2026-46158"
@@ -35436,7 +35450,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46169"
 # cpe-stable-backport: Backported in 6.6.142
 CVE_CHECK_IGNORE += "CVE-2026-46170"
 
-# CVE-2026-46171 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46171 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46172"
@@ -35447,7 +35461,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46173"
 # cpe-stable-backport: Backported in 6.6.139
 CVE_CHECK_IGNORE += "CVE-2026-46174"
 
-# CVE-2026-46175 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46175 needs backporting (fixed from 7.1)
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46176"
@@ -35464,7 +35478,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46179"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46180"
 
-# CVE-2026-46181 needs backporting (fixed from 7.1rc3)
+# CVE-2026-46181 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46182"
@@ -35520,7 +35534,7 @@ CVE_CHECK_IGNORE += "CVE-2026-46198"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46199"
 
-# CVE-2026-46200 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46200 needs backporting (fixed from 7.1)
 
 # fixed-version: only affects 6.8 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46201"
@@ -35569,9 +35583,6 @@ CVE_CHECK_IGNORE += "CVE-2026-46215"
 
 # fixed-version: only affects 6.10 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46216"
-
-# fixed-version: only affects 7.1rc1 onwards
-CVE_CHECK_IGNORE += "CVE-2026-46217"
 
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46218"
@@ -35630,9 +35641,6 @@ CVE_CHECK_IGNORE += "CVE-2026-46235"
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46236"
 
-# fixed-version: only affects 7.1rc1 onwards
-CVE_CHECK_IGNORE += "CVE-2026-46237"
-
 # cpe-stable-backport: Backported in 6.6.140
 CVE_CHECK_IGNORE += "CVE-2026-46238"
 
@@ -35642,16 +35650,3632 @@ CVE_CHECK_IGNORE += "CVE-2026-46239"
 # fixed-version: only affects 6.18.16 onwards
 CVE_CHECK_IGNORE += "CVE-2026-46240"
 
-# CVE-2026-46241 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46241 needs backporting (fixed from 7.1)
 
-# CVE-2026-46242 needs backporting (fixed from 7.1rc1)
+# CVE-2026-46242 may need backporting (fixed from 6.6.144)
 
 # cpe-stable-backport: Backported in 6.6.142
 CVE_CHECK_IGNORE += "CVE-2026-46243"
 
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-46244"
+
+# CVE-2026-46245 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46246"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46247"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46248"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46249"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46250"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46251"
+
+# CVE-2026-46252 may need backporting (fixed from 6.6.144)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46253"
+
+# CVE-2026-46254 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46255"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46256"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46257"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46258"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46259"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46260"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46261"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46262"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46263"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46264"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46265"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46266"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46267"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46268"
+
+# fixed-version: only affects 6.15.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46269"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46270"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46271"
+
+# CVE-2026-46272 needs backporting (fixed from 7.0)
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46273"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-46274"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-46275"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46276"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46277"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46278"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46279"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46280"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46281"
+
+# CVE-2026-46282 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46283"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46284"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46285"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46286"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46287"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46288"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46289"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46290"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46291"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-46292"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46293"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46294"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46295"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46296"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46297"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46298"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46299"
+
 # cpe-stable-backport: Backported in 6.6.141
 CVE_CHECK_IGNORE += "CVE-2026-46300"
 
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46301"
+
+# CVE-2026-46302 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46303"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46304"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46305"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46306"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46307"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46308"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46309"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46310"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46311"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-46312"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46313"
+
+# CVE-2026-46314 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46315"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46316"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46317"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46318"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-46319"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-46320"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-46321"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-46322"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-46323"
+
+# CVE-2026-46324 needs backporting (fixed from 7.1)
+
+# CVE-2026-46325 needs backporting (fixed from 7.0)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46326"
+
+# fixed-version: only affects 6.12.34 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46327"
+
+# cpe-stable-backport: Backported in 6.6.128
+CVE_CHECK_IGNORE += "CVE-2026-46328"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46329"
+
+# CVE-2026-46330 needs backporting (fixed from 7.0)
+
+# CVE-2026-46331 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-46332"
+
 # cpe-stable-backport: Backported in 6.6.139
 CVE_CHECK_IGNORE += "CVE-2026-46333"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52904"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52905"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52906"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52907"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52908"
+
+# CVE-2026-52909 may need backporting (fixed from 6.6.144)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52910"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52911"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52912"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52913"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52914"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52915"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52916"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52917"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52918"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52919"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52920"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52921"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52922"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52923"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52924"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52925"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52926"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52927"
+
+# CVE-2026-52928 may need backporting (fixed from 6.6.144)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52929"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52930"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52931"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52932"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-52933"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52934"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52935"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52936"
+
+# CVE-2026-52937 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52938"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52939"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52940"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-52941"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52942"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52943"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52944"
+
+# fixed-version: only affects 6.15.3 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52945"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52946"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52947"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-52948"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52949"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52950"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52951"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52952"
+
+# CVE-2026-52953 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52954"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52955"
+
+# CVE-2026-52956 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52957"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52958"
+
+# fixed-version: only affects 6.13.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52959"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52960"
+
+# CVE-2026-52961 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52962"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52963"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52964"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52965"
+
+# fixed-version: only affects 6.18.32 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52966"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52967"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52968"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52969"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52970"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52971"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52972"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52973"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52974"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52975"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52976"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52977"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52978"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52979"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52980"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52981"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52982"
+
+# fixed-version: only affects 6.12.91 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52983"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52984"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52985"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52986"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52987"
+
+# CVE-2026-52988 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52989"
+
+# CVE-2026-52990 needs backporting (fixed from 7.1)
+
+# CVE-2026-52991 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52992"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52993"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52994"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52995"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52996"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-52997"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52998"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-52999"
+
+# CVE-2026-53000 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53001"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53002"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53003"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53004"
+
+# CVE-2026-53005 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53006"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53007"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53008"
+
+# CVE-2026-53009 needs backporting (fixed from 7.1)
+
+# CVE-2026-53010 may need backporting (fixed from 6.7)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53011"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53012"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53013"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53014"
+
+# CVE-2026-53015 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53016"
+
+# CVE-2026-53017 needs backporting (fixed from 7.1)
+
+# CVE-2026-53018 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53019"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53020"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53021"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53022"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53023"
+
+# CVE-2026-53024 needs backporting (fixed from 7.1)
+
+# CVE-2026-53025 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.18.4 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53026"
+
+# CVE-2026-53027 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53028"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53029"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53030"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53031"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53032"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53033"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53034"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53035"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53036"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53037"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53038"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53039"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53040"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53041"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53042"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53043"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53044"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53045"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53046"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53047"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53048"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53049"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53050"
+
+# fixed-version: only affects 6.12.2 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53051"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53052"
+
+# CVE-2026-53053 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53054"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53055"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53056"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53057"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53058"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53059"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53060"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53061"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53062"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53063"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53064"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53065"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53066"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53067"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53068"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53069"
+
+# CVE-2026-53070 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53071"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53072"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53073"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53074"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53075"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53076"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53077"
+
+# CVE-2026-53078 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53079"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53080"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53081"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53082"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53083"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53084"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53085"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53086"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53087"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53088"
+
+# CVE-2026-53089 needs backporting (fixed from 7.1)
+
+# CVE-2026-53090 needs backporting (fixed from 7.1)
+
+# CVE-2026-53091 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53092"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53093"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53094"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53095"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53096"
+
+# CVE-2026-53097 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53098"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53099"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53100"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53101"
+
+# CVE-2026-53102 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11.2 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53103"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53104"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53105"
+
+# CVE-2026-53106 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.18.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53107"
+
+# CVE-2026-53108 needs backporting (fixed from 7.1)
+
+# CVE-2026-53109 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53110"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53111"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53112"
+
+# CVE-2026-53113 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53114"
+
+# CVE-2026-53115 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53116"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53117"
+
+# CVE-2026-53118 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53119"
+
+# CVE-2026-53120 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53121"
+
+# CVE-2026-53122 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53123"
+
+# fixed-version: only affects 6.14.6 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53124"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53125"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53126"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53127"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53128"
+
+# CVE-2026-53129 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53130"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53131"
+
+# CVE-2026-53132 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53133"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53134"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53135"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53136"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53137"
+
+# CVE-2026-53138 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53139 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53140"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53141"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53142"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53143"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53144"
+
+# fixed-version: only affects 6.18.32 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53145"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53146"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53147"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53148"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53149"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53150"
+
+# CVE-2026-53151 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.12.78 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53152"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53153"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53154"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53155"
+
+# CVE-2026-53156 needs backporting (fixed from 7.1)
+
+# CVE-2026-53157 may need backporting (fixed from 6.6.144)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53158"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53159"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53160"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53161"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53162"
+
+# CVE-2026-53163 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53164"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53165"
+
+# CVE-2026-53167 may need backporting (fixed from 6.6.144)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53168"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53169"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53170"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53171"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53172"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53173"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53174"
+
+# fixed-version: only affects 6.12.93 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53175"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53176"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53177"
+
+# CVE-2026-53178 needs backporting (fixed from 7.1)
+
+# CVE-2026-53179 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53180"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53181"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53182"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53183"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53184"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53185"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53186"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53187"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53188"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53189"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53190"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53191"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53192"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53193"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53194"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53195"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53196"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53197"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53198"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53199"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53200"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53201"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53202"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53203"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53204"
+
+# fixed-version: only affects 6.12.30 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53205"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53206"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53207"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53208"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53209"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53210"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53211"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53212"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53213"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53214"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53215"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53216"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53217"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53218"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53219"
+
+# CVE-2026-53220 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53221"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53222"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53223"
+
+# CVE-2026-53224 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53225"
+
+# CVE-2026-53226 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53227"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53228"
+
+# CVE-2026-53229 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53230"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53231"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53232"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53233"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53234"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53235"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53236"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53237"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53238"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53239"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53240"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53241"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53242"
+
+# fixed-version: only affects 7.0.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53243"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53244"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53245"
+
+# CVE-2026-53246 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53247"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53248"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53249"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53250"
+
+# fixed-version: only affects 6.12.2 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53251"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53252"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53253"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53254"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53255"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53256"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53257"
+
+# CVE-2026-53258 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53259"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53260"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53261"
+
+# CVE-2026-53262 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53263"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53264"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53265"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53266"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53267"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53268"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53269"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53270"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53271"
+
+# CVE-2026-53272 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53273"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53274"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53275"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53276"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53277"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53278"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53279"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53280"
+
+# fixed-version: only affects 6.12.57 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53281"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53282"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53283"
+
+# CVE-2026-53284 needs backporting (fixed from 7.1)
+
+# CVE-2026-53285 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53286"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53287"
+
+# fixed-version: only affects 6.12.54 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53288"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53289"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53290"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53291"
+
+# CVE-2026-53292 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53293"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53294"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53295"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53296"
+
+# CVE-2026-53297 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53298"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53299"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53300"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53301"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53302"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53303"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53304"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53305"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53306"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53307"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53308"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53309"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53310"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53311"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53312"
+
+# CVE-2026-53313 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53314"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53315"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53316"
+
+# CVE-2026-53317 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53318"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53319"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-53320"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53321"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53322"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53323"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53324"
+
+# CVE-2026-53325 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53326"
+
+# CVE-2026-53327 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53328"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53329"
+
+# CVE-2026-53330 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53331"
+
+# CVE-2026-53332 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53333"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53334"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53335"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53336"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53337"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53338"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53339"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53340"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53341"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53342"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53343"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53344"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53345"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53346"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53347"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53348"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53349"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53350"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53351"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53352"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53353"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53354"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53355"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53356"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-53357"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-53358"
+
+# CVE-2026-53359 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53360"
+
+# CVE-2026-53361 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53362 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53363"
+
+# fixed-version: only affects 6.16.4 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53364"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53365"
+
+# CVE-2026-53366 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.17.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53367"
+
+# CVE-2026-53368 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-53369"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53370"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53371"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53372"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53373"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-53374"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-53375"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-53376"
+
+# CVE-2026-53377 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53378"
+
+# cpe-stable-backport: Backported in 6.6.140
+CVE_CHECK_IGNORE += "CVE-2026-53379"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53380"
+
+# CVE-2026-53381 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53382 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53383 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53384 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53385 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53386"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53387"
+
+# CVE-2026-53388 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53389"
+
+# CVE-2026-53390 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53391 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53392 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-53393 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53394"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53395"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-53396"
+
+# CVE-2026-53397 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53398 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-53399 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-53400 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-53401 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-53402 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-53403 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63793"
+
+# CVE-2026-63794 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63795 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63796 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63797 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63798 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63799"
+
+# CVE-2026-63800 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63801 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63802 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63803 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63804 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63805 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63806 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63807 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63808 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63809 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63810 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63811 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63812 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63813"
+
+# CVE-2026-63814 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63815 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63816 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63817 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63818 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63819 needs backporting (fixed from 7.2rc1)
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63820"
+
+# CVE-2026-63821 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63822 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63823 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63824 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63825 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-63826 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63827 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63828 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63829 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-63830 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63831 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.12.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63832"
+
+# CVE-2026-63833 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63834 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63835 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-63836 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63837"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63838"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63839"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63840"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63841"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63842"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63843"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63844"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63845"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63846"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63847"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63848"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63849"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63850"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63851"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63852"
+
+# CVE-2026-63853 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63854"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63855"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63856"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63857"
+
+# CVE-2026-63858 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63859"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63860"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63861"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63862"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63863"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63864"
+
+# cpe-stable-backport: Backported in 6.6.141
+CVE_CHECK_IGNORE += "CVE-2026-63865"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63866"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63867"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63868"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63869"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63870"
+
+# CVE-2026-63871 needs backporting (fixed from 7.1)
+
+# CVE-2026-63872 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63873"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63874"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63875"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63876"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63877"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63878"
+
+# CVE-2026-63879 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63880"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63881"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63882"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63883"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63884"
+
+# fixed-version: only affects 6.18.32 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63885"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63886"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63887"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63888"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63889"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63890"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63891"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63892"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63893"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63894"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63895"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63896"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63897"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63898"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63899"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63900"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63901"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63902"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63903"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63904"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63905"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63906"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63907"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63908"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63909"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63910"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63911"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63912"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63913"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63914"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63915"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63916"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63917"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63918"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63919"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63920"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63921"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63922"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63923"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63924"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63925"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63926"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63927"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63928"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63929"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63930"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63931"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63932"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63933"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63934"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63935"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63936"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63937"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63938"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63939"
+
+# CVE-2026-63940 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63941"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63942"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63943"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63944"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63945"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63946"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63947"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63948"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63949"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63950"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63951"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63952"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63953"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63954"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63955"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63956"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63957"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63958"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63959"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63960"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63961"
+
+# CVE-2026-63962 needs backporting (fixed from 7.1)
+
+# CVE-2026-63963 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63964"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63965"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63966"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63967"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63968"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63969"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63970"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63971"
+
+# fixed-version: only affects 6.18.33 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63972"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63973"
+
+# CVE-2026-63974 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63975"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63976"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63977"
+
+# CVE-2026-63978 needs backporting (fixed from 7.1)
+
+# CVE-2026-63979 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63980"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63981"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63982"
+
+# CVE-2026-63983 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63984"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63985"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63986"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63987"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63988"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63989"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63990"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63991"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63992"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63993"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-63994"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63995"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63996"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63997"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-63998"
+
+# CVE-2026-63999 may need backporting (fixed from 6.7)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64000"
+
+# CVE-2026-64001 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64002"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64003"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64004"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64005"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64006"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64007"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64008"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64009"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64010"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64011"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64012"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64013"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64014"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64015"
+
+# fixed-version: only affects 6.18.33 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64016"
+
+# CVE-2026-64017 may need backporting (fixed from 6.7)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64018"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64019"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64020"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64021"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64022"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64023"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64024"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64025"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64026"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64027"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64028"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64029"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64030"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64031"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64032"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64033"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64034"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64035"
+
+# CVE-2026-64036 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64037"
+
+# CVE-2026-64038 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64039"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64040"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64041"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64042"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64043"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64044"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64045"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64046"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64047"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64048"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64049"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64050"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64051"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64052"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64053"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64054"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64055"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64056"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64057"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64058"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64059"
+
+# CVE-2026-64060 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64061"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64062"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64063"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64064"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64065"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64066"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64067"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64068"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64069"
+
+# CVE-2026-64070 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64071"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64072"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64073"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64074"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64075"
+
+# CVE-2026-64076 needs backporting (fixed from 7.1)
+
+# CVE-2026-64077 needs backporting (fixed from 7.1)
+
+# CVE-2026-64078 needs backporting (fixed from 7.1)
+
+# CVE-2026-64079 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64080"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64081"
+
+# CVE-2026-64082 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64083"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64084"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64085"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64086"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64087"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64088"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64089"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64090"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64091"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64092"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64093"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64094"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64095"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64096"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64097"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64098"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64099"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64100"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64101"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64102"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64103"
+
+# fixed-version: only affects 6.13.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64104"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64105"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64106"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64107"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64108"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64109"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64110"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64111"
+
+# CVE-2026-64112 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64113"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64114"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64115"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64116"
+
+# CVE-2026-64117 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64118"
+
+# fixed-version: only affects 6.11.3 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64119"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64120"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64121"
+
+# fixed-version: only affects 6.18.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64122"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64123"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64124"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64125"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64126"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64127"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64128"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64129"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64130"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64131"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64132"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64133"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64134"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64135"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64136"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64137"
+
+# CVE-2026-64138 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64139"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64140"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64141"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64142"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64143"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64144"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64145"
+
+# CVE-2026-64146 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64147"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64148"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64149"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64150"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64151"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64152"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64153"
+
+# CVE-2026-64154 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64155"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64156"
+
+# fixed-version: only affects 6.10.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64157"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64158"
+
+# fixed-version: only affects 6.10.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64159"
+
+# CVE-2026-64160 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64161"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64162"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64163"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64164"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64165"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64166"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64167"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64168"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64169"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64170"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64171"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64172"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64173"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64174"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64175"
+
+# fixed-version: only affects 6.17.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64176"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64177"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64178"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64179"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64180"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64181"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64182"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64183"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64184"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64185"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64186"
+
+# CVE-2026-64187 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64188 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64189 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64190 needs backporting (fixed from 7.1)
+
+# CVE-2026-64191 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64192 needs backporting (fixed from 7.2rc2)
+
+# CVE-2026-64205 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64206 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64207"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64208"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64209"
+
+# CVE-2026-64210 needs backporting (fixed from 7.1)
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64211"
+
+# CVE-2026-64212 needs backporting (fixed from 7.1)
+
+# CVE-2026-64213 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64214"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64215"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64216"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64217"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64218"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64219"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64220"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64221"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64222"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64223"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64224"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64225"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64226"
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64227"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64228"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64229"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64230"
+
+# cpe-stable-backport: Backported in 6.6.142
+CVE_CHECK_IGNORE += "CVE-2026-64231"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64232"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64233"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64234"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64235"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64236"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64237"
+
+# fixed-version: only affects 6.19.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64238"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64239"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64240"
+
+# CVE-2026-64241 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64242"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64243"
+
+# CVE-2026-64244 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64245 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64246 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64247 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64248 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64249 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64250 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64251"
+
+# CVE-2026-64252 may need backporting (fixed from 6.6.144)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64253"
+
+# CVE-2026-64254 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64255 needs backporting (fixed from 7.2rc1)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64256"
+
+# CVE-2026-64257 needs backporting (fixed from 7.2rc4)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64258"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64259"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64260"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64261"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64262"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64263"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64264"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64265"
+
+# CVE-2026-64266 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64267"
+
+# CVE-2026-64268 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64269 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64270 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64271 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64272 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64273 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64274 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64275 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64276 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64277 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64278"
+
+# CVE-2026-64279 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64280 needs backporting (fixed from 7.2rc1)
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64281"
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64282"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64283"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64284"
+
+# fixed-version: only affects 7.0 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64285"
+
+# CVE-2026-64286 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64287 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64288"
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64289"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64290"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64291"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64292"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64293"
+
+# CVE-2026-64294 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64295"
+
+# CVE-2026-64296 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64297 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64298 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64299 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64300"
+
+# CVE-2026-64301 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64302"
+
+# CVE-2026-64303 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64304 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64305 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64306 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64307"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64308"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64309"
+
+# fixed-version: only affects 6.12.75 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64310"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64311"
+
+# CVE-2026-64312 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64313 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64314"
+
+# CVE-2026-64315 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64316 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64317 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64318 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64319 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64320 needs backporting (fixed from 7.2rc1)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64321"
+
+# CVE-2026-64322 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64323 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64324 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64325"
+
+# CVE-2026-64326 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64327"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64328"
+
+# CVE-2026-64329 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64330 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64331 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64332 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64333 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64334 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64335 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64336 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64337 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64338 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64339"
+
+# CVE-2026-64340 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64341 needs backporting (fixed from 7.2rc3)
+
+# CVE-2026-64342 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64343 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64344 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64345 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64346 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64347 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64348 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18.32 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64349"
+
+# CVE-2026-64350 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64351 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64352 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64353"
+
+# fixed-version: only affects 6.11.6 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64354"
+
+# CVE-2026-64355 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64356"
+
+# fixed-version: only affects 6.10 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64357"
+
+# CVE-2026-64358 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64359 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64360 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64361 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64362 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64363 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64364 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64365 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64366"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64367"
+
+# CVE-2026-64368 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64369"
+
+# CVE-2026-64370 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64371 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64372 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64373 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64374 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64375 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64376 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64377 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64378 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64379 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64380 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64381 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64382 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64383 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64384 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64385 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64386 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64387 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64388 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64389 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64390 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64391 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64392 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64393 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64394 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64395 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64396 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64397 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64398 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64399 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64400 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64401 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64402 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64403 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.12.6 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64404"
+
+# CVE-2026-64405 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64406 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64407 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64408 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64409 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64410"
+
+# CVE-2026-64411 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64412 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64413 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64414"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64415"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64416"
+
+# CVE-2026-64417 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64418"
+
+# CVE-2026-64419 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64420 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64421 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64422 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64423 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64424 needs backporting (fixed from 7.2rc2)
+
+# CVE-2026-64425 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64426"
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64427"
+
+# CVE-2026-64428 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64429 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64430 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64431"
+
+# CVE-2026-64432 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64433 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64434 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64435 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64436 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64437 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64438 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64439"
+
+# CVE-2026-64440 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64441 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64442 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64443 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64444 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64445 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64446 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64447"
+
+# CVE-2026-64448 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64449 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64450 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64451"
+
+# CVE-2026-64452 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64453"
+
+# CVE-2026-64454 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64455 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64456 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64457"
+
+# CVE-2026-64458 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64459"
+
+# fixed-version: only affects 6.17 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64460"
+
+# CVE-2026-64461 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64462 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64463 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.16 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64464"
+
+# CVE-2026-64465 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64466"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64467"
+
+# CVE-2026-64468 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64469 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64470 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64471 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64472 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.8 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64473"
+
+# CVE-2026-64474 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64475 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64476 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64477"
+
+# CVE-2026-64478 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64479 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64480 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64481 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64482 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64483 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64484 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64485"
+
+# CVE-2026-64486 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64487 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64488 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64489 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64490"
+
+# fixed-version: only affects 6.18 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64491"
+
+# fixed-version: only affects 6.13 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64492"
+
+# CVE-2026-64493 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64494 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64495 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64496 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64497 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64498"
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64499"
+
+# CVE-2026-64500 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64501"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64502"
+
+# CVE-2026-64503 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64504 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64505 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 7.1 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64506"
+
+# CVE-2026-64507 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64508 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.11 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64509"
+
+# CVE-2026-64510 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64511 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64512 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64513 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64514 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64515"
+
+# fixed-version: only affects 6.19 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64516"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64517"
+
+# fixed-version: only affects 6.12.5 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64518"
+
+# fixed-version: only affects 6.9 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64519"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64520"
+
+# fixed-version: only affects 6.15 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64521"
+
+# fixed-version: only affects 6.17.4 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64522"
+
+# CVE-2026-64523 needs backporting (fixed from 7.1)
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64524"
+
+# fixed-version: only affects 6.12.83 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64525"
+
+# fixed-version: only affects 6.14 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64526"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64527"
+
+# cpe-stable-backport: Backported in 6.6.143
+CVE_CHECK_IGNORE += "CVE-2026-64528"
+
+# CVE-2026-64529 may need backporting (fixed from 6.6.144)
+
+# CVE-2026-64530 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64531 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64532 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64533 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64534 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64535 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64536 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64537 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64538 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64539 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64540 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64541 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64542 needs backporting (fixed from 7.2rc1)
+
+# CVE-2026-64543 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64544 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64545 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64546 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64547 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64548 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64549 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64550 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64551 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64552 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64553 may need backporting (fixed from 6.6.145)
+
+# CVE-2026-64554 may need backporting (fixed from 6.6.145)
+
+# fixed-version: only affects 6.7 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64555"
+
+# CVE-2026-64600 may need backporting (fixed from 6.6.145)
 

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-30 07:41:26.725075+00:00 for kernel version 6.6.146
-# From cvelistV5 cve_2026-07-30_0600Z-1-g8c5cb801566
+# Generated at 2026-07-31 07:50:53.960021+00:00 for kernel version 6.6.147
+# From cvelistV5 cve_2026-07-31_0700Z-1-g4586eab1cb7
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.146"
+    this_version = "6.6.147"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -6271,6 +6271,9 @@ CVE_CHECK_IGNORE += "CVE-2022-49998"
 
 # fixed-version: Fixed from version 6.0
 CVE_CHECK_IGNORE += "CVE-2022-49999"
+
+# fixed-version: Fixed from version 6.0
+CVE_CHECK_IGNORE += "CVE-2022-4994"
 
 # fixed-version: Fixed from version 6.0
 CVE_CHECK_IGNORE += "CVE-2022-50000"
@@ -39579,7 +39582,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64558"
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64559"
 
-# CVE-2026-64560 needs backporting (fixed from 7.2rc3)
+# cpe-stable-backport: Backported in 6.6.147
+CVE_CHECK_IGNORE += "CVE-2026-64560"
 
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64600"

--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-28 12:34:49.179092+00:00 for kernel version 6.6.145
-# From cvelistV5 cve_2026-07-28_0600Z-1-gf38c5fdc2d5
+# Generated at 2026-07-30 07:41:26.725075+00:00 for kernel version 6.6.146
+# From cvelistV5 cve_2026-07-30_0600Z-1-g8c5cb801566
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.145"
+    this_version = "6.6.146"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -39566,6 +39566,20 @@ CVE_CHECK_IGNORE += "CVE-2026-64554"
 
 # fixed-version: only affects 6.7 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64555"
+
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64556"
+
+# cpe-stable-backport: Backported in 6.6.145
+CVE_CHECK_IGNORE += "CVE-2026-64557"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64558"
+
+# fixed-version: only affects 6.12 onwards
+CVE_CHECK_IGNORE += "CVE-2026-64559"
+
+# CVE-2026-64560 needs backporting (fixed from 7.2rc3)
 
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64600"

--- a/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/10-14-pci-pcie-xgs-iproc.patch
+++ b/recipes-kernel/linux/linux-yocto-onl-linux-6.6.y/bisdn-kmeta/bsp/armel-iproc/10-14-pci-pcie-xgs-iproc.patch
@@ -43,17 +43,17 @@ diff --git a/drivers/pci/controller/pcie-iproc.h b/drivers/pci/controller/pcie-i
 index 969ded03b8c2..c6eef4e61a19 100644
 --- a/drivers/pci/controller/pcie-iproc.h
 +++ b/drivers/pci/controller/pcie-iproc.h
-@@ -91,6 +91,9 @@ struct iproc_pcie {
+@@ -90,6 +90,9 @@ struct iproc_pcie {
  	phys_addr_t base_addr;
  	struct resource mem;
  	struct phy *phy;
 +#ifdef CONFIG_PCIE_XGS_IPROC
 +	struct phy_device *mdio_phy;
 +#endif
- 	int (*map_irq)(const struct pci_dev *, u8, u8);
  	bool ep_is_internal;
  	bool iproc_cfg_read;
-@@ -110,9 +113,11 @@ struct iproc_pcie {
+ 	bool rej_unconfig_pf;
+@@ -109,9 +112,11 @@ struct iproc_pcie {
  	struct iproc_msi *msi;
  };
  
@@ -70,7 +70,7 @@ new file mode 100644
 index 000000000000..0168f24fbb19
 --- /dev/null
 +++ b/drivers/pci/controller/pcie-xgs-iproc.c
-@@ -0,0 +1,501 @@
+@@ -0,0 +1,499 @@
 +/*
 + * Copyright (C) 2014 Hauke Mehrtens <hauke@hauke-m.de>
 + * Copyright (C) 2015 Broadcom Corporation
@@ -457,7 +457,7 @@ index 000000000000..0168f24fbb19
 +	host->dev.parent = dev;
 +	host->ops = &iproc_pcie_ops;
 +	host->sysdata = pcie;
-+	host->map_irq = pcie->map_irq;
++	host->map_irq = of_irq_parse_and_map_pci;
 +	host->swizzle_irq = pci_common_swizzle;
 +
 +	ret = pci_host_probe(host);
@@ -524,8 +524,6 @@ index 000000000000..0168f24fbb19
 +
 +	/* HX4/KT2/HR2 */
 +	pcie_sw_wa_func("pcie_wrong_gen2", pcie);
-+
-+	pcie->map_irq = of_irq_parse_and_map_pci;
 +
 +	ret = iproc_pcie_setup(pcie, &bridge->windows);
 +	if (ret)

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.146"
+LINUX_VERSION ?= "6.6.147"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "ae068b67619673618814059f96802314e08050d1"
+SRCREV_machine ?= "a1153c0deb44f75190f07677c0c6d61efd887246"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.144"
+LINUX_VERSION ?= "6.6.145"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "da47cbc254661aa66d61ef061485a7080305c4be"
+SRCREV_machine ?= "c5596480c50e081668ff170e80db6314a033be11"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.142"
+LINUX_VERSION ?= "6.6.143"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "924b4a879cbb75aef37c160b955b92f6894b11a4"
+SRCREV_machine ?= "d1cfde2d5d15be14123bdd1689162bd27f995a90"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.143"
+LINUX_VERSION ?= "6.6.144"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "d1cfde2d5d15be14123bdd1689162bd27f995a90"
+SRCREV_machine ?= "da47cbc254661aa66d61ef061485a7080305c4be"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.145"
+LINUX_VERSION ?= "6.6.146"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "c5596480c50e081668ff170e80db6314a033be11"
+SRCREV_machine ?= "ae068b67619673618814059f96802314e08050d1"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6


### PR DESCRIPTION
Update linux 6.6 to 6.6.146.

Changelogs:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.146
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.145
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.144
* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.143