### PR TITLE
linux-yocto-onl: update 6.6 to 6.6.148

### DIFF
--- a/recipes-kernel/linux/cve-exclusion_6.6.inc
+++ b/recipes-kernel/linux/cve-exclusion_6.6.inc
@@ -1,11 +1,11 @@
 
 # Auto-generated CVE metadata, DO NOT EDIT BY HAND.
-# Generated at 2026-07-31 07:50:53.960021+00:00 for kernel version 6.6.147
-# From cvelistV5 cve_2026-07-31_0700Z-1-g4586eab1cb7
+# Generated at 2026-08-03 12:30:30.601682+00:00 for kernel version 6.6.148
+# From cvelistV5 cve_2026-08-03_1100Z-1-g8491df4167c
 
 
 python check_kernel_cve_status_version() {
-    this_version = "6.6.147"
+    this_version = "6.6.148"
     kernel_version = d.getVar("LINUX_VERSION")
     if kernel_version != this_version:
         bb.warn("Kernel CVE status needs updating: generated for %s but kernel is %s" % (this_version, kernel_version))
@@ -26399,8 +26399,7 @@ CVE_CHECK_IGNORE += "CVE-2025-38523"
 # cpe-stable-backport: Backported in 6.6.100
 CVE_CHECK_IGNORE += "CVE-2025-38524"
 
-# fixed-version: only affects 6.14 onwards
-CVE_CHECK_IGNORE += "CVE-2025-38525"
+# CVE-2025-38525 may need backporting (fixed from 6.7)
 
 # cpe-stable-backport: Backported in 6.6.100
 CVE_CHECK_IGNORE += "CVE-2025-38526"
@@ -27672,7 +27671,8 @@ CVE_CHECK_IGNORE += "CVE-2025-39899"
 # fixed-version: only affects 6.12 onwards
 CVE_CHECK_IGNORE += "CVE-2025-39900"
 
-# CVE-2025-39901 needs backporting (fixed from 6.17)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2025-39901"
 
 # cpe-stable-backport: Backported in 6.6.105
 CVE_CHECK_IGNORE += "CVE-2025-39902"
@@ -28852,7 +28852,8 @@ CVE_CHECK_IGNORE += "CVE-2025-40305"
 # cpe-stable-backport: Backported in 6.6.117
 CVE_CHECK_IGNORE += "CVE-2025-40306"
 
-# CVE-2025-40307 needs backporting (fixed from 6.18)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2025-40307"
 
 # cpe-stable-backport: Backported in 6.6.117
 CVE_CHECK_IGNORE += "CVE-2025-40308"
@@ -31618,8 +31619,7 @@ CVE_CHECK_IGNORE += "CVE-2026-23382"
 # fixed-version: only affects 6.18 onwards
 CVE_CHECK_IGNORE += "CVE-2026-23384"
 
-# fixed-version: only affects 6.10 onwards
-CVE_CHECK_IGNORE += "CVE-2026-23385"
+# CVE-2026-23385 may need backporting (fixed from 6.7)
 
 # cpe-stable-backport: Backported in 6.6.130
 CVE_CHECK_IGNORE += "CVE-2026-23386"
@@ -36471,7 +36471,8 @@ CVE_CHECK_IGNORE += "CVE-2026-53088"
 
 # CVE-2026-53089 needs backporting (fixed from 7.1)
 
-# CVE-2026-53090 needs backporting (fixed from 7.1)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2026-53090"
 
 # CVE-2026-53091 needs backporting (fixed from 7.1)
 
@@ -38537,9 +38538,11 @@ CVE_CHECK_IGNORE += "CVE-2026-64189"
 # cpe-stable-backport: Backported in 6.6.144
 CVE_CHECK_IGNORE += "CVE-2026-64191"
 
-# CVE-2026-64192 needs backporting (fixed from 7.2rc2)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2026-64192"
 
-# CVE-2026-64205 needs backporting (fixed from 7.2rc1)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2026-64205"
 
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64206"
@@ -38757,7 +38760,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64278"
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64279"
 
-# CVE-2026-64280 needs backporting (fixed from 7.2rc1)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2026-64280"
 
 # fixed-version: only affects 7.1 onwards
 CVE_CHECK_IGNORE += "CVE-2026-64281"
@@ -39529,7 +39533,8 @@ CVE_CHECK_IGNORE += "CVE-2026-64540"
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64541"
 
-# CVE-2026-64542 needs backporting (fixed from 7.2rc1)
+# cpe-stable-backport: Backported in 6.6.148
+CVE_CHECK_IGNORE += "CVE-2026-64542"
 
 # cpe-stable-backport: Backported in 6.6.145
 CVE_CHECK_IGNORE += "CVE-2026-64543"

--- a/recipes-kernel/linux/linux-yocto-onl_6.6.bb
+++ b/recipes-kernel/linux/linux-yocto-onl_6.6.bb
@@ -8,9 +8,9 @@ KCONF_BSP_AUDIT_LEVEL = "1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-LINUX_VERSION ?= "6.6.147"
+LINUX_VERSION ?= "6.6.148"
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/?h=linux-6.6.y
-SRCREV_machine ?= "a1153c0deb44f75190f07677c0c6d61efd887246"
+SRCREV_machine ?= "aa0e49877a2e61e9f4ca10e039727a34f59e9964"
 
 # Use commit for kver matching (or close to) LINUX_VERSION
 # https://git.yoctoproject.org/yocto-kernel-cache/log/kver?h=yocto-6.6


### PR DESCRIPTION
Update linux 6.6 to 6.6.148. This includes a fix for early boot hangs observed on multiple devices:

    serial: 8250_mid: Fix NULL function pointer dereference on DNV/ICX-D/SNR platforms

    commit 7fb13fd7e9a59a37cd911efff83abe19e3ee029d upstream.

    Commit b1b4efea05a5 ("serial: 8250_mid: Disable DMA for selected
    platforms") replaced the dnv_board setup and exit callbacks with
    PTR_IF(false, ...), which evaluates to NULL. However, the three call
    sites in mid8250_probe() and mid8250_remove() unconditionally
    dereference these function pointers without NULL checks, causing a NULL
    pointer dereference (kernel oops) on any Denverton (DNV), Ice Lake Xeon
    D (ICX-D/CDF), or Snowridge (SNR) platform.

    Fix this by adding the missing NULL checks before calling the setup and
    exit callbacks.

The referenced commit caused boot hangs on AS4630-54{T,P}E, AS5835-54X and Questone 2A.

Changelog:

* https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.148